### PR TITLE
feat: add Cursor AI support

### DIFF
--- a/src/__tests__/conversions.test.ts
+++ b/src/__tests__/conversions.test.ts
@@ -17,9 +17,11 @@ import {
   extractOpenCodeContext,
   parseDroidSessions,
   extractDroidContext,
+  parseCursorSessions,
+  extractCursorContext,
 } from '../parsers/index.js';
 
-const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid'];
+const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor'];
 
 // Cache parsed sessions and contexts so we only parse once
 const sessionCache: Record<string, UnifiedSession[]> = {};
@@ -32,6 +34,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   codex: parseCodexSessions,
   opencode: parseOpenCodeSessions,
   droid: parseDroidSessions,
+  cursor: parseCursorSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -41,6 +44,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   codex: extractCodexContext,
   opencode: extractOpenCodeContext,
   droid: extractDroidContext,
+  cursor: extractCursorContext,
 };
 
 const friendlyNames: Record<SessionSource, string> = {
@@ -50,6 +54,7 @@ const friendlyNames: Record<SessionSource, string> = {
   codex: 'Codex CLI',
   opencode: 'OpenCode',
   droid: 'Factory Droid',
+  cursor: 'Cursor AI',
 };
 
 beforeAll(async () => {
@@ -177,6 +182,7 @@ describe('Conversion Content Quality', () => {
       codex: 'Codex CLI',
       opencode: 'OpenCode',
       droid: 'Factory Droid',
+      cursor: 'Cursor AI',
     };
 
     for (const source of ALL_SOURCES) {

--- a/src/__tests__/e2e-conversions.test.ts
+++ b/src/__tests__/e2e-conversions.test.ts
@@ -22,9 +22,10 @@ import {
   parseCodexSessions, extractCodexContext,
   parseOpenCodeSessions, extractOpenCodeContext,
   parseDroidSessions, extractDroidContext,
+  parseCursorSessions, extractCursorContext,
 } from '../parsers/index.js';
 
-const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid'];
+const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor'];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   claude: parseClaudeSessions,
@@ -33,6 +34,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   codex: parseCodexSessions,
   opencode: parseOpenCodeSessions,
   droid: parseDroidSessions,
+  cursor: parseCursorSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -42,6 +44,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   codex: extractCodexContext,
   opencode: extractOpenCodeContext,
   droid: extractDroidContext,
+  cursor: extractCursorContext,
 };
 
 // Results directory
@@ -210,11 +213,12 @@ describe('E2E: 20 Cross-Tool Conversion Paths', () => {
           return;
         }
 
-        const sourceLabel = {
+        const sourceLabels: Record<SessionSource, string> = {
           claude: 'Claude Code', copilot: 'GitHub Copilot CLI',
           gemini: 'Gemini CLI', codex: 'Codex CLI', opencode: 'OpenCode',
-          droid: 'Factory Droid',
-        }[source];
+          droid: 'Factory Droid', cursor: 'Cursor AI',
+        };
+        const sourceLabel = sourceLabels[source];
 
         const prompt = buildVerificationPrompt(contexts[source].markdown, sourceLabel);
         const cwd = contexts[source].session.cwd || process.cwd();

--- a/src/__tests__/extract-handoffs.ts
+++ b/src/__tests__/extract-handoffs.ts
@@ -9,6 +9,7 @@ import {
   parseCodexSessions, extractCodexContext,
   parseOpenCodeSessions, extractOpenCodeContext,
   parseDroidSessions, extractDroidContext,
+  parseCursorSessions, extractCursorContext,
 } from '../parsers/index.js';
 import type { UnifiedSession, SessionSource, SessionContext } from '../types/index.js';
 import * as fs from 'fs';
@@ -17,7 +18,7 @@ import * as path from 'path';
 const RESULTS_DIR = path.join(process.env.HOME || '~', '.continues', 'e2e-test-results');
 fs.mkdirSync(RESULTS_DIR, { recursive: true });
 
-const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid'];
+const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor'];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   claude: parseClaudeSessions,
@@ -26,6 +27,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   codex: parseCodexSessions,
   opencode: parseOpenCodeSessions,
   droid: parseDroidSessions,
+  cursor: parseCursorSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -35,6 +37,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   codex: extractCodexContext,
   opencode: extractOpenCodeContext,
   droid: extractDroidContext,
+  cursor: extractCursorContext,
 };
 
 async function main() {

--- a/src/__tests__/fixtures/index.ts
+++ b/src/__tests__/fixtures/index.ts
@@ -558,6 +558,86 @@ export function createDroidFixture(): FixtureDir {
 }
 
 /**
+ * Create a temporary directory with Cursor agent-transcript fixtures
+ */
+export function createCursorFixture(): FixtureDir {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'test-cursor-'));
+  const projectDir = path.join(root, '-test-project');
+  const transcriptsDir = path.join(projectDir, 'agent-transcripts');
+  const sessionId = 'cccccccc-1111-2222-3333-444444444444';
+  const sessionDir = path.join(transcriptsDir, sessionId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  const lines = [
+    JSON.stringify({
+      role: 'user',
+      message: {
+        content: [{ type: 'text', text: '<user_query>\nFix the authentication bug in login.ts\n</user_query>' }],
+      },
+    }),
+    JSON.stringify({
+      role: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'I\'ll look into the login.ts file to find the authentication bug.' }],
+      },
+    }),
+    JSON.stringify({
+      role: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'tc-001', name: 'read_file', input: { file_path: '/home/user/project/login.ts' } },
+        ],
+      },
+    }),
+    JSON.stringify({
+      role: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'tc-001', content: 'export function login() { ... }' }],
+      },
+    }),
+    JSON.stringify({
+      role: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'tc-002', name: 'edit_file', input: { file_path: '/home/user/project/login.ts', old_str: 'old code', new_str: 'new code' } },
+        ],
+      },
+    }),
+    JSON.stringify({
+      role: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'tc-002', content: 'File edited successfully' }],
+      },
+    }),
+    JSON.stringify({
+      role: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'I found the issue in login.ts. The token validation was missing.' }],
+      },
+    }),
+    JSON.stringify({
+      role: 'user',
+      message: {
+        content: [{ type: 'text', text: '<user_query>\nGreat, please also add error handling\n</user_query>' }],
+      },
+    }),
+    JSON.stringify({
+      role: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'Done. I added try-catch blocks and proper error messages.' }],
+      },
+    }),
+  ];
+
+  fs.writeFileSync(path.join(sessionDir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
+
+  return {
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+/**
  * Create OpenCode JSON-only fixture (legacy format)
  */
 export function createOpenCodeJsonFixture(): FixtureDir {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,6 +85,7 @@ const sourceColors: Record<SessionSource, (s: string) => string> = {
   codex: chalk.magenta,
   opencode: chalk.yellow,
   droid: chalk.red,
+  cursor: chalk.blueBright,
 };
 
 /**
@@ -160,6 +161,7 @@ function showNoSessionsHelp(): void {
   console.log(chalk.gray('  ~/.gemini/tmp/*/chats/'));
   console.log(chalk.gray('  ~/.local/share/opencode/storage/'));
   console.log(chalk.gray('  ~/.factory/sessions/'));
+  console.log(chalk.gray('  ~/.cursor/projects/*/agent-transcripts/'));
 }
 
 /**
@@ -336,7 +338,7 @@ async function interactivePick(options: { source?: string; noTui?: boolean; rebu
  */
 program
   .name('continues')
-  .description('Never lose context. Resume any AI coding session across Claude, Copilot, Gemini, Codex, OpenCode & Droid.')
+  .description('Never lose context. Resume any AI coding session across Claude, Copilot, Gemini, Codex, OpenCode, Droid & Cursor.')
   .version(VERSION)
   .helpOption('-h, --help', 'Display help for command')
   .addHelpText('after', `
@@ -369,7 +371,7 @@ program
 program
   .command('pick')
   .description('Interactive session picker (TUI mode)')
-  .option('-s, --source <source>', 'Filter by source (claude, copilot, gemini, codex, opencode, droid)')
+  .option('-s, --source <source>', 'Filter by source (claude, copilot, gemini, codex, opencode, droid, cursor)')
   .option('--no-tui', 'Disable TUI, use plain text')
   .option('--rebuild', 'Force rebuild session index')
   .action(async (options) => {
@@ -383,7 +385,7 @@ program
   .command('list')
   .alias('ls')
   .description('List all sessions in table format')
-  .option('-s, --source <source>', 'Filter by source (claude, copilot, gemini, codex, opencode, droid)')
+  .option('-s, --source <source>', 'Filter by source (claude, copilot, gemini, codex, opencode, droid, cursor)')
   .option('-n, --limit <number>', 'Limit number of sessions', '50')
   .option('--json', 'Output as JSON array')
   .option('--jsonl', 'Output as JSONL')
@@ -446,7 +448,7 @@ program
   .command('resume <session-id>')
   .alias('r')
   .description('Resume a session by ID or short ID')
-  .option('-i, --in <cli-tool>', 'Target CLI tool (claude, copilot, gemini, codex, opencode, droid)')
+  .option('-i, --in <cli-tool>', 'Target CLI tool (claude, copilot, gemini, codex, opencode, droid, cursor)')
   .option('--reference', 'Use file reference instead of inline context (for very large sessions)')
   .option('--no-tui', 'Disable interactive prompts')
   .action(async (sessionId, options) => {
@@ -668,6 +670,13 @@ program
   .description('Resume Nth newest Droid session (default: 1)')
   .action(async (n = '1') => {
     await resumeBySource('droid', parseInt(n, 10));
+  });
+
+program
+  .command('cursor [n]')
+  .description('Resume Nth newest Cursor session (default: 1)')
+  .action(async (n = '1') => {
+    await resumeBySource('cursor', parseInt(n, 10));
   });
 
 /**

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -1,0 +1,395 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import type { UnifiedSession, SessionContext, ConversationMessage, ToolUsageSummary, SessionNotes } from '../types/index.js';
+import { generateHandoffMarkdown } from '../utils/markdown.js';
+import { SummaryCollector, shellSummary, fileSummary, grepSummary, globSummary, searchSummary, fetchSummary, mcpSummary, subagentSummary, withResult, truncate } from '../utils/tool-summarizer.js';
+
+const CURSOR_PROJECTS_DIR = path.join(process.env.HOME || '~', '.cursor', 'projects');
+
+/** Content block inside a Cursor message */
+interface CursorContentBlock {
+  type: 'text' | 'thinking' | 'tool_use' | 'tool_result';
+  text?: string;
+  thinking?: string;
+  // tool_use fields
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  // tool_result fields
+  tool_use_id?: string;
+  content?: string | Array<{ type: string; text?: string }>;
+}
+
+/** A single JSONL line in Cursor agent-transcripts */
+interface CursorTranscriptLine {
+  role: 'user' | 'assistant';
+  message: {
+    content: CursorContentBlock[];
+  };
+}
+
+/**
+ * Derive cwd from the project slug directory name.
+ * Slug format: path separators replaced with dashes
+ * e.g. "Users-evolution-Sites-localhost-readybyte-test" → "/Users/evolution/Sites/localhost/readybyte-test"
+ *
+ * This is inherently ambiguous (directory names may contain dashes),
+ * so we use the file system to resolve: try replacing each dash
+ * from left to right and keep the longest prefix that exists on disk.
+ */
+function cwdFromSlug(slug: string): string {
+  // First try a simple reconstruction that checks the filesystem
+  const parts = slug.split('-');
+  let resolved = '';
+
+  for (let i = 0; i < parts.length; i++) {
+    const candidate = resolved ? resolved + '/' + parts[i] : '/' + parts[i];
+    if (fs.existsSync(candidate)) {
+      resolved = candidate;
+    } else {
+      // The rest belongs to the current path segment (directory name with dashes)
+      const remainder = parts.slice(i).join('-');
+      resolved = resolved + '/' + remainder;
+      if (fs.existsSync(resolved)) break;
+      // If that doesn't exist either, just use the simple dash→slash conversion
+      resolved = '/' + slug.replace(/-/g, '/');
+      break;
+    }
+  }
+
+  return resolved || '/' + slug.replace(/-/g, '/');
+}
+
+/**
+ * Find all Cursor agent-transcript JSONL files.
+ * Structure: ~/.cursor/projects/<project-slug>/agent-transcripts/<uuid>/<uuid>.jsonl
+ */
+async function findTranscriptFiles(): Promise<string[]> {
+  const files: string[] = [];
+
+  if (!fs.existsSync(CURSOR_PROJECTS_DIR)) {
+    return files;
+  }
+
+  try {
+    const projectDirs = fs.readdirSync(CURSOR_PROJECTS_DIR, { withFileTypes: true });
+    for (const projectDir of projectDirs) {
+      if (!projectDir.isDirectory()) continue;
+      const transcriptsDir = path.join(CURSOR_PROJECTS_DIR, projectDir.name, 'agent-transcripts');
+
+      if (!fs.existsSync(transcriptsDir)) continue;
+
+      try {
+        const sessionDirs = fs.readdirSync(transcriptsDir, { withFileTypes: true });
+        for (const sessionDir of sessionDirs) {
+          if (!sessionDir.isDirectory()) continue;
+          const jsonlPath = path.join(transcriptsDir, sessionDir.name, `${sessionDir.name}.jsonl`);
+          if (fs.existsSync(jsonlPath)) {
+            files.push(jsonlPath);
+          }
+        }
+      } catch {
+        // Skip directories we can't read
+      }
+    }
+  } catch {
+    // Skip if base dir can't be read
+  }
+
+  return files;
+}
+
+/**
+ * Extract the project slug from a transcript file path.
+ * Path: ~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl
+ */
+function getProjectSlug(filePath: string): string {
+  const parts = filePath.split(path.sep);
+  const projectsIdx = parts.indexOf('projects');
+  if (projectsIdx >= 0 && projectsIdx + 1 < parts.length) {
+    return parts[projectsIdx + 1];
+  }
+  return '';
+}
+
+/**
+ * Extract the session UUID from a transcript file path.
+ */
+function getSessionId(filePath: string): string {
+  return path.basename(filePath, '.jsonl');
+}
+
+/**
+ * Extract clean text from user_query tags if present
+ */
+function cleanUserQueryText(text: string): string {
+  const match = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
+  if (match) return match[1].trim();
+  return text;
+}
+
+/**
+ * Parse first few messages for summary
+ */
+async function parseSessionInfo(filePath: string): Promise<{
+  firstUserMessage: string;
+  lineCount: number;
+}> {
+  return new Promise((resolve) => {
+    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    let firstUserMessage = '';
+    let lineCount = 0;
+
+    rl.on('line', (line) => {
+      lineCount++;
+
+      if (!firstUserMessage && lineCount <= 50) {
+        try {
+          const parsed = JSON.parse(line) as CursorTranscriptLine;
+          if (parsed.role === 'user') {
+            for (const block of parsed.message.content) {
+              if (block.type === 'text' && block.text) {
+                const cleaned = cleanUserQueryText(block.text);
+                // Skip system-injected content
+                if (cleaned && !cleaned.startsWith('<') && !cleaned.startsWith('/') && !cleaned.includes('Session Handoff')) {
+                  firstUserMessage = cleaned;
+                  break;
+                }
+              }
+            }
+          }
+        } catch {
+          // Skip invalid lines
+        }
+      }
+    });
+
+    rl.on('close', () => resolve({ firstUserMessage, lineCount }));
+    rl.on('error', () => resolve({ firstUserMessage: '', lineCount: 0 }));
+  });
+}
+
+/**
+ * Extract repo name from cwd path
+ */
+function extractRepoFromCwd(cwd: string): string {
+  if (!cwd) return '';
+  const parts = cwd.split('/').filter(Boolean);
+  if (parts.length >= 2) {
+    return parts.slice(-2).join('/');
+  }
+  return parts[parts.length - 1] || '';
+}
+
+/**
+ * Parse all Cursor sessions
+ */
+export async function parseCursorSessions(): Promise<UnifiedSession[]> {
+  const files = await findTranscriptFiles();
+  const sessions: UnifiedSession[] = [];
+
+  for (const filePath of files) {
+    try {
+      const { firstUserMessage, lineCount } = await parseSessionInfo(filePath);
+      const fileStats = fs.statSync(filePath);
+      const slug = getProjectSlug(filePath);
+      const cwd = cwdFromSlug(slug);
+
+      const summary = firstUserMessage
+        .replace(/\n/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, 50);
+
+      sessions.push({
+        id: getSessionId(filePath),
+        source: 'cursor',
+        cwd,
+        repo: extractRepoFromCwd(cwd),
+        lines: lineCount,
+        bytes: fileStats.size,
+        createdAt: fileStats.birthtime,
+        updatedAt: fileStats.mtime,
+        originalPath: filePath,
+        summary: summary || undefined,
+      });
+    } catch {
+      // Skip files we can't parse
+    }
+  }
+
+  return sessions
+    .filter(s => s.bytes > 100)
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}
+
+/**
+ * Read all lines from a Cursor transcript
+ */
+async function readAllLines(filePath: string): Promise<CursorTranscriptLine[]> {
+  return new Promise((resolve) => {
+    const lines: CursorTranscriptLine[] = [];
+    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    rl.on('line', (line) => {
+      try {
+        lines.push(JSON.parse(line) as CursorTranscriptLine);
+      } catch {
+        // Skip invalid lines
+      }
+    });
+
+    rl.on('close', () => resolve(lines));
+    rl.on('error', () => resolve(lines));
+  });
+}
+
+/** Tools to skip — internal bookkeeping */
+const CURSOR_SKIP_TOOLS = new Set(['TodoWrite']);
+
+/**
+ * Extract tool usage summaries and files modified using shared SummaryCollector.
+ * Cursor uses Anthropic-style tool_use/tool_result content blocks.
+ */
+function extractToolData(lines: CursorTranscriptLine[]): { summaries: ToolUsageSummary[]; filesModified: string[] } {
+  const collector = new SummaryCollector();
+  const toolResultMap = new Map<string, string>();
+
+  // First pass: collect all tool_result blocks
+  for (const line of lines) {
+    for (const block of line.message.content) {
+      if (block.type !== 'tool_result' || !block.tool_use_id) continue;
+      let text = '';
+      if (typeof block.content === 'string') text = block.content;
+      else if (Array.isArray(block.content)) {
+        text = block.content.find(c => c.type === 'text')?.text || '';
+      }
+      if (text) toolResultMap.set(block.tool_use_id, text.slice(0, 100));
+    }
+  }
+
+  // Second pass: process tool_use blocks
+  for (const line of lines) {
+    if (line.role !== 'assistant') continue;
+    for (const block of line.message.content) {
+      if (block.type !== 'tool_use' || !block.name) continue;
+
+      const name = block.name;
+      if (CURSOR_SKIP_TOOLS.has(name)) continue;
+
+      const input = block.input || {};
+      const result = block.id ? toolResultMap.get(block.id) : undefined;
+      const fp = (input.file_path as string) || (input.path as string) || '';
+
+      if (name === 'Bash' || name === 'bash' || name === 'terminal' || name === 'run_terminal_command') {
+        collector.add('Bash', shellSummary((input.command as string) || '', result));
+      } else if (['Read', 'ReadFile', 'read_file'].includes(name)) {
+        collector.add(name, withResult(fileSummary('read', fp), result), fp);
+      } else if (['Write', 'WriteFile', 'write_file', 'Create', 'create_file'].includes(name)) {
+        collector.add(name, withResult(fileSummary('write', fp), result), fp, true);
+      } else if (['Edit', 'EditFile', 'edit_file', 'apply_diff'].includes(name)) {
+        collector.add(name, withResult(fileSummary('edit', fp), result), fp, true);
+      } else if (name === 'Grep' || name === 'grep' || name === 'codebase_search') {
+        collector.add('Grep', withResult(grepSummary((input.pattern as string) || (input.query as string) || '', (input.path as string) || ''), result));
+      } else if (name === 'Glob' || name === 'glob' || name === 'list_directory' || name === 'file_search') {
+        collector.add('Glob', withResult(globSummary((input.pattern as string) || (input.path as string) || ''), result));
+      } else if (name === 'WebFetch' || name === 'web_fetch') {
+        collector.add('WebFetch', fetchSummary((input.url as string) || ''));
+      } else if (name === 'WebSearch' || name === 'web_search') {
+        collector.add('WebSearch', searchSummary((input.query as string) || ''));
+      } else if (name === 'Task' || name === 'task') {
+        collector.add('Task', subagentSummary((input.description as string) || '', (input.subagent_type as string) || ''));
+      } else if (name.startsWith('mcp__') || name.includes('___') || name.includes('-')) {
+        collector.add(name, mcpSummary(name, JSON.stringify(input).slice(0, 100), result));
+      } else {
+        collector.add(name, withResult(`${name}(${JSON.stringify(input).slice(0, 100)})`, result));
+      }
+    }
+  }
+
+  return { summaries: collector.getSummaries(), filesModified: collector.getFilesModified() };
+}
+
+/**
+ * Extract session notes from thinking blocks
+ */
+function extractSessionNotes(lines: CursorTranscriptLine[]): SessionNotes {
+  const notes: SessionNotes = {};
+  const reasoning: string[] = [];
+
+  for (const line of lines) {
+    if (line.role !== 'assistant') continue;
+    for (const block of line.message.content) {
+      if (block.type === 'thinking' && reasoning.length < 5) {
+        const text = block.thinking || block.text || '';
+        if (text.length > 20) {
+          const firstLine = text.split(/[.\n]/)[0]?.trim();
+          if (firstLine) reasoning.push(truncate(firstLine, 200));
+        }
+      }
+    }
+  }
+
+  if (reasoning.length > 0) notes.reasoning = reasoning;
+  return notes;
+}
+
+/**
+ * Extract context from a Cursor session for cross-tool continuation
+ */
+export async function extractCursorContext(session: UnifiedSession): Promise<SessionContext> {
+  const lines = await readAllLines(session.originalPath);
+  const recentMessages: ConversationMessage[] = [];
+
+  const { summaries: toolSummaries, filesModified } = extractToolData(lines);
+  const sessionNotes = extractSessionNotes(lines);
+  const pendingTasks: string[] = [];
+
+  for (const line of lines) {
+    const textParts: string[] = [];
+    for (const block of line.message.content) {
+      if (block.type === 'text' && block.text) {
+        // Skip system-injected content
+        if (block.text.startsWith('<system-reminder>') || block.text.startsWith('<permissions')) continue;
+        if (block.text.startsWith('<external_links>')) continue;
+        if (block.text.startsWith('<image_files>')) continue;
+
+        const cleaned = line.role === 'user' ? cleanUserQueryText(block.text) : block.text;
+        if (cleaned) textParts.push(cleaned);
+      }
+    }
+
+    const text = textParts.join('\n').trim();
+    if (!text) continue;
+
+    recentMessages.push({
+      role: line.role === 'user' ? 'user' : 'assistant',
+      content: text,
+    });
+  }
+
+  const trimmed = recentMessages.slice(-10);
+
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    sessionNotes,
+  );
+
+  return {
+    session,
+    recentMessages: trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    sessionNotes,
+    markdown,
+  };
+}

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -4,3 +4,4 @@ export { parseCopilotSessions, extractCopilotContext } from './copilot.js';
 export { parseGeminiSessions, extractGeminiContext } from './gemini.js';
 export { parseOpenCodeSessions, extractOpenCodeContext } from './opencode.js';
 export { parseDroidSessions, extractDroidContext } from './droid.js';
+export { parseCursorSessions, extractCursorContext } from './cursor.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@
  */
 
 /** Source CLI tool */
-export type SessionSource = 'codex' | 'claude' | 'copilot' | 'gemini' | 'opencode' | 'droid';
+export type SessionSource = 'codex' | 'claude' | 'copilot' | 'gemini' | 'opencode' | 'droid' | 'cursor';
 
 /** Unified session metadata */
 export interface UnifiedSession {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ import { parseCopilotSessions, extractCopilotContext } from '../parsers/copilot.
 import { parseGeminiSessions, extractGeminiContext } from '../parsers/gemini.js';
 import { parseOpenCodeSessions, extractOpenCodeContext } from '../parsers/opencode.js';
 import { parseDroidSessions, extractDroidContext } from '../parsers/droid.js';
+import { parseCursorSessions, extractCursorContext } from '../parsers/cursor.js';
 
 const CONTINUES_DIR = path.join(process.env.HOME || '~', '.continues');
 const INDEX_FILE = path.join(CONTINUES_DIR, 'sessions.jsonl');
@@ -52,16 +53,17 @@ export async function buildIndex(force = false): Promise<UnifiedSession[]> {
   }
 
   // Parse all sessions from all sources in parallel
-  const [codexSessions, claudeSessions, copilotSessions, geminiSessions, opencodeSessions, droidSessions] = await Promise.all([
+  const [codexSessions, claudeSessions, copilotSessions, geminiSessions, opencodeSessions, droidSessions, cursorSessions] = await Promise.all([
     parseCodexSessions(),
     parseClaudeSessions(),
     parseCopilotSessions(),
     parseGeminiSessions(),
     parseOpenCodeSessions(),
     parseDroidSessions(),
+    parseCursorSessions(),
   ]);
 
-  const allSessions = [...codexSessions, ...claudeSessions, ...copilotSessions, ...geminiSessions, ...opencodeSessions, ...droidSessions];
+  const allSessions = [...codexSessions, ...claudeSessions, ...copilotSessions, ...geminiSessions, ...opencodeSessions, ...droidSessions, ...cursorSessions];
 
   // Sort by updated time (newest first)
   allSessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
@@ -139,6 +141,8 @@ export async function extractContext(session: UnifiedSession): Promise<SessionCo
       return extractOpenCodeContext(session);
     case 'droid':
       return extractDroidContext(session);
+    case 'cursor':
+      return extractCursorContext(session);
     default:
       throw new Error(`Unknown session source: ${session.source}`);
   }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -8,6 +8,7 @@ export const SOURCE_LABELS: Record<string, string> = {
   codex: 'Codex CLI',
   opencode: 'OpenCode',
   droid: 'Factory Droid',
+  cursor: 'Cursor AI',
 };
 
 /**

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -39,6 +39,11 @@ export async function nativeResume(session: UnifiedSession): Promise<void> {
       await runCommand('droid', ['-s', session.id], cwd);
       break;
 
+    case 'cursor':
+      // Cursor doesn't have native session resume via CLI; open the project
+      await runCommand('cursor', [cwd], cwd);
+      break;
+
     default:
       throw new Error(`Unknown session source: ${session.source}`);
   }
@@ -91,6 +96,11 @@ export async function crossToolResume(
 
     case 'droid':
       await runCommand('droid', ['exec', prompt], cwd);
+      break;
+
+    case 'cursor':
+      // Cursor CLI doesn't accept inline prompts; open the project with handoff file
+      await runCommand('cursor', [cwd], cwd);
       break;
 
     default:
@@ -196,13 +206,14 @@ export async function isToolAvailable(tool: SessionSource): Promise<boolean> {
 export async function getAvailableTools(): Promise<SessionSource[]> {
   const tools: SessionSource[] = [];
   
-  const [hasCodex, hasClaude, hasCopilot, hasGemini, hasOpencode, hasDroid] = await Promise.all([
+  const [hasCodex, hasClaude, hasCopilot, hasGemini, hasOpencode, hasDroid, hasCursor] = await Promise.all([
     isToolAvailable('codex'),
     isToolAvailable('claude'),
     isToolAvailable('copilot'),
     isToolAvailable('gemini'),
     isToolAvailable('opencode'),
     isToolAvailable('droid'),
+    isToolAvailable('cursor'),
   ]);
 
   if (hasCodex) tools.push('codex');
@@ -211,6 +222,7 @@ export async function getAvailableTools(): Promise<SessionSource[]> {
   if (hasGemini) tools.push('gemini');
   if (hasOpencode) tools.push('opencode');
   if (hasDroid) tools.push('droid');
+  if (hasCursor) tools.push('cursor');
 
   return tools;
 }
@@ -235,6 +247,8 @@ export function getResumeCommand(session: UnifiedSession, target?: SessionSource
         return `opencode --session ${session.id}`;
       case 'droid':
         return `droid -s ${session.id}`;
+      case 'cursor':
+        return `cursor ${session.cwd}`;
     }
   }
 


### PR DESCRIPTION
## Summary

- Add **Cursor AI** as the 7th supported platform
- New parser (`src/parsers/cursor.ts`) that discovers and parses agent-transcript JSONL files from `~/.cursor/projects/*/agent-transcripts/`
- Extracts conversation history, tool usage (Anthropic-style `tool_use`/`tool_result` blocks), and thinking/reasoning highlights
- Strips `<user_query>` wrapper tags from Cursor's user messages
- Derives working directory from project slug path
- Full integration across all modules: types, index, resume, CLI quick-command (`continues cursor`), source colors
- Test fixtures and **42 cross-tool conversion paths** (7×6) all passing (111 tests)

## Files Changed

| File | Change |
|------|--------|
| `src/parsers/cursor.ts` | **New** — Cursor session parser |
| `src/types/index.ts` | Add `'cursor'` to `SessionSource` union |
| `src/parsers/index.ts` | Barrel export |
| `src/utils/index.ts` | Wire into `buildIndex()` and `extractContext()` |
| `src/utils/markdown.ts` | Add `'Cursor AI'` to `SOURCE_LABELS` |
| `src/utils/resume.ts` | Native resume, cross-tool handoff, tool detection |
| `src/cli.ts` | Color (`blueBright`), quick-resume command, help texts |
| `src/__tests__/fixtures/index.ts` | `createCursorFixture()` |
| `src/__tests__/unit-conversions.test.ts` | Cursor parser tests + 42 conversion paths |
| `src/__tests__/conversions.test.ts` | Cursor integration |
| `src/__tests__/e2e-conversions.test.ts` | Cursor integration |
| `src/__tests__/extract-handoffs.ts` | Cursor integration |

## Test plan

- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] All 111 unit tests pass (`vitest run`)
- [x] Build succeeds (`tsc`)
- [ ] Manual test with real Cursor agent-transcripts on a machine with Cursor installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Cursor AI as a new session source. Parse and extract context from Cursor transcripts located at `~/.cursor/projects/*/agent-transcripts/`.
  * Introduced new `cursor [n]` CLI command to resume the Nth newest Cursor session.
  * Enabled cross-tool handoffs between Cursor and other supported tools.
  * Cursor sessions now appear in session listing and picking workflows.

* **Tests**
  * Extended test coverage to verify Cursor source support across all conversion and handoff scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->