### PR TITLE
fix: show clear error when only one CLI tool is installed

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -294,6 +294,13 @@ async function interactivePick(options: { source?: string; noTui?: boolean; rebu
           label: `${sourceColors[t](t.charAt(0).toUpperCase() + t.slice(1))}`,
         }));
 
+    if (targetOptions.length === 0) {
+      const allTools: SessionSource[] = ['claude', 'codex', 'copilot', 'gemini', 'opencode', 'droid'];
+      const missing = allTools.filter(t => !availableTools.includes(t)).map(t => t.charAt(0).toUpperCase() + t.slice(1));
+      clack.log.warn(`Only ${sourceColors[session.source](session.source)} is installed. Install at least one more (${missing.join(', ')}) to enable cross-tool handoff.`);
+      return;
+    }
+
     const targetTool = await clack.select({
       message: `Continue ${sourceColors[session.source](session.source)} session in:`,
       options: targetOptions,
@@ -505,6 +512,13 @@ program
             value: t,
             label: `${sourceColors[t](t.charAt(0).toUpperCase() + t.slice(1))}`,
           }));
+
+        if (targetOptions.length === 0) {
+          const allTools: SessionSource[] = ['claude', 'codex', 'copilot', 'gemini', 'opencode', 'droid'];
+          const missing = allTools.filter(t => !availableTools.includes(t)).map(t => t.charAt(0).toUpperCase() + t.slice(1));
+          clack.log.warn(`Only ${sourceColors[session.source](session.source)} is installed. Install at least one more (${missing.join(', ')}) to enable cross-tool handoff.`);
+          return;
+        }
 
         const selectedTarget = await clack.select({
           message: `Continue ${sourceColors[session.source](session.source)} session in:`,


### PR DESCRIPTION
When only one CLI tool is installed, `clack.select()` receives an empty options array and crashes with:
<img width="427" height="32" alt="Crash" src="https://github.com/user-attachments/assets/687e86b5-6444-4354-8a32-c755dd85dc42" />

This adds a guard in both places where target tool selection happens. Instead of crashing, it now tells the user which tool was detected and lists the ones they could install:
<img width="519" height="34" alt="CleanShot 2026-02-20 at 02 26 48" src="https://github.com/user-attachments/assets/bc47dcb5-23fb-48d7-948a-25be28c468c1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cross-tool handoff scenarios when no alternative tools are available, with clearer warning messages informing users about missing tools and session constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->