### PR TITLE
fix: align ASCII logo

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ function showBanner(): void {
 
   console.log();
   console.log(t('                       ▄'));
-  console.log(t('  █▀▀▀ █▀▀█ █▀▀▄ ▀█▀▀  █   █▀▀▄ █  █ █▀▀█ ') + s('█▀▀▀'));
+  console.log(t('  █▀▀▀ █▀▀█ █▀▀▄ ▀█▀▀  █  █▀▀▄ █  █ █▀▀█ ') + s('█▀▀▀'));
   console.log(t('  █    █  █ █  █  █    █  █  █ █  █ █▀▀▀ ') + s('▀▀▀█'));
   console.log(t('  ▀▀▀▀ ▀▀▀▀ ▀  ▀  ▀    ▀  ▀  ▀ ▀▀▀▀ ▀▀▀▀ ') + s('▀▀▀▀'));
   console.log();


### PR DESCRIPTION
logo UI was misaligned. tested in ghostty and macOS terminal app.

<img width="1191" height="364" alt="terminal" src="https://github.com/user-attachments/assets/d773a1f2-5a89-412d-9ec9-75c1d64afb98" />
<img width="1430" height="398" alt="ghostty" src="https://github.com/user-attachments/assets/093e8b14-05af-4b1c-9740-3e6f118d1111" />
