### PR TITLE
fix: respect tool-specific env vars for session storage paths

### DIFF
--- a/src/parsers/claude.ts
+++ b/src/parsers/claude.ts
@@ -15,7 +15,9 @@ import {
 } from '../utils/tool-extraction.js';
 import { truncate } from '../utils/tool-summarizer.js';
 
-const CLAUDE_PROJECTS_DIR = path.join(homeDir(), '.claude', 'projects');
+const CLAUDE_PROJECTS_DIR = process.env.CLAUDE_CONFIG_DIR
+  ? path.join(process.env.CLAUDE_CONFIG_DIR, 'projects')
+  : path.join(homeDir(), '.claude', 'projects');
 
 /**
  * Find all Claude session files recursively

--- a/src/parsers/codex.ts
+++ b/src/parsers/codex.ts
@@ -24,7 +24,9 @@ import {
   withResult,
 } from '../utils/tool-summarizer.js';
 
-const CODEX_SESSIONS_DIR = path.join(homeDir(), '.codex', 'sessions');
+const CODEX_SESSIONS_DIR = process.env.CODEX_HOME
+  ? path.join(process.env.CODEX_HOME, 'sessions')
+  : path.join(homeDir(), '.codex', 'sessions');
 
 /**
  * Find all Codex session files recursively

--- a/src/parsers/gemini.ts
+++ b/src/parsers/gemini.ts
@@ -17,7 +17,9 @@ import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
 import { classifyToolName } from '../types/tool-names.js';
 import { fileSummary, mcpSummary, shellSummary, SummaryCollector, truncate } from '../utils/tool-summarizer.js';
 
-const GEMINI_BASE_DIR = path.join(homeDir(), '.gemini', 'tmp');
+const GEMINI_BASE_DIR = process.env.GEMINI_CLI_HOME
+  ? path.join(process.env.GEMINI_CLI_HOME, '.gemini', 'tmp')
+  : path.join(homeDir(), '.gemini', 'tmp');
 
 /**
  * Find all Gemini session files

--- a/src/parsers/opencode.ts
+++ b/src/parsers/opencode.ts
@@ -22,7 +22,9 @@ import { findFiles, listSubdirectories } from '../utils/fs-helpers.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
 
-const OPENCODE_BASE_DIR = path.join(homeDir(), '.local', 'share', 'opencode');
+const OPENCODE_BASE_DIR = process.env.XDG_DATA_HOME
+  ? path.join(process.env.XDG_DATA_HOME, 'opencode')
+  : path.join(homeDir(), '.local', 'share', 'opencode');
 const OPENCODE_STORAGE_DIR = path.join(OPENCODE_BASE_DIR, 'storage');
 const OPENCODE_DB_PATH = path.join(OPENCODE_BASE_DIR, 'opencode.db');
 


### PR DESCRIPTION
## Summary

Parsers now check each tool's official environment variable override before falling back to the default `os.homedir()`-based paths. Without this, users who customize their config directories via env vars will have their sessions silently missed by `continues`.

- **Claude Code**: check `CLAUDE_CONFIG_DIR` → `$CLAUDE_CONFIG_DIR/projects/`
- **Codex CLI**: check `CODEX_HOME` → `$CODEX_HOME/sessions/`
- **Gemini CLI**: check `GEMINI_CLI_HOME` → `$GEMINI_CLI_HOME/.gemini/tmp/`
- **OpenCode**: check `XDG_DATA_HOME` → `$XDG_DATA_HOME/opencode/`

The remaining 3 tools (Copilot, Factory Droid, Cursor) have no env var override mechanism, so they are unchanged.

## References

Each env var matches the tool's own config resolution:

| Tool | Env Var | Source |
|------|---------|--------|
| Claude Code | `CLAUDE_CONFIG_DIR` | [docs: Settings — Environment variables](https://code.claude.com/docs/en/settings) |
| Codex CLI | `CODEX_HOME` | [`codex-rs/utils/home-dir/src/lib.rs#L11-L15`](https://github.com/openai/codex/blob/ddfa032eb8506eeb21b4f00f12f0836f06e8a6b0/codex-rs/utils/home-dir/src/lib.rs#L11-L15) — `find_codex_home()` reads `CODEX_HOME` env var |
| Gemini CLI | `GEMINI_CLI_HOME` | [`packages/core/src/utils/paths.ts#L20-L26`](https://github.com/google-gemini/gemini-cli/blob/29e8f2abf41f6db15efb11e94c839b90d09bdb51/packages/core/src/utils/paths.ts#L20-L26), [docs: Configuration](https://github.com/google-gemini/gemini-cli/blob/29e8f2abf41f6db15efb11e94c839b90d09bdb51/docs/reference/configuration.md) |
| OpenCode | `XDG_DATA_HOME` | [`packages/opencode/src/global/index.ts#L2-L9`](https://github.com/sst/opencode/blob/dev/packages/opencode/src/global/index.ts#L2-L9) — `xdgData` from `xdg-basedir` resolves `$XDG_DATA_HOME/opencode` |

## Test plan

- [x] `tsc` compiles clean
- [x] All 278 unit tests pass (`vitest run`)
- [ ] Manual: set `CLAUDE_CONFIG_DIR=/tmp/test-claude` and verify `continues list --source claude` reads from the custom path
- [ ] Manual: set `CODEX_HOME=/tmp/test-codex` and verify `continues list --source codex` reads from the custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)