### PR TITLE
fix windows cross-tool handoff breaking on cmd.exe

### DIFF
--- a/src/__tests__/windows-safe-prompt.test.ts
+++ b/src/__tests__/windows-safe-prompt.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { UnifiedSession } from '../types/index.js';
+import { TOOL_NAMES } from '../types/tool-names.js';
 import { buildWindowsSafePrompt } from '../utils/resume.js';
 
 // Minimal session stub for testing
-function stubSession(source: string): UnifiedSession {
+function stubSession(source: UnifiedSession['source']): UnifiedSession {
   return {
     id: 'test-id',
-    source: source as UnifiedSession['source'],
+    source,
     summary: 'Test session',
     cwd: '/test/dir',
     updatedAt: new Date(),
@@ -48,7 +49,7 @@ describe('buildWindowsSafePrompt', () => {
   });
 
   it('should be safe for all supported tools', () => {
-    const tools = ['claude', 'codex', 'copilot', 'gemini', 'opencode', 'droid', 'cursor'];
+    const tools = TOOL_NAMES;
     for (const tool of tools) {
       const prompt = buildWindowsSafePrompt(stubSession(tool));
       expect(CMD_METACHARACTERS.test(prompt)).toBe(false);

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -49,14 +49,23 @@ export async function crossToolResume(
 
   // Always save handoff file to project directory (for sandboxed tools like Gemini)
   const localPath = path.join(cwd, '.continues-handoff.md');
+  let handoffWritten = false;
   try {
     fs.writeFileSync(localPath, context.markdown);
+    handoffWritten = true;
   } catch (err) {
     logger.debug('resume: failed to write handoff file', localPath, err);
   }
 
   // Also save to global directory as backup
   saveContext(context);
+
+  // On Windows the prompt references .continues-handoff.md — the write must succeed
+  if (IS_WINDOWS && !handoffWritten) {
+    throw new Error(
+      `Failed to write handoff file to ${localPath}. Cross-tool resume on Windows requires this file. Check directory permissions.`,
+    );
+  }
 
   // Build prompt based on mode
   const prompt = IS_WINDOWS


### PR DESCRIPTION
fixes cross-tool resume on windows — cmd.exe splits the multi-line prompt at newlines, so codex/claude/etc see broken args. now uses a short single-line prompt pointing to the handoff file instead.

fixes #17

cc @NeverBeLazyG @GhalebAldoboni @ThunderCls — would appreciate if you could test this when it lands
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

Fixes cross-tool handoff on Windows by bypassing cmd.exe's multi-line prompt issues. Uses a short single-line prompt referencing `.continues-handoff.md` instead of embedding full context. Solid fix with one test issue:

- Core logic is sound — detects Windows and short-circuits to safe prompt
- Preserves file-based handoff mechanism (already working)
- Test coverage validates single-line, no metacharacters, length constraints
- **Issue**: Test hardcodes 7 tools instead of importing `TOOL_NAMES` (misses 9 tools, violates registry-single-source-of-truth rule)

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after fixing test's hardcoded tool list
- Core fix is correct and well-tested. The hardcoded tool list in tests doesn't affect runtime behavior but should be fixed to maintain test coverage for all 16 supported tools
- Fix the hardcoded tool list in `src/__tests__/windows-safe-prompt.test.ts:51` before merging
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/__tests__/windows-safe-prompt.test.ts | New test suite for Windows-safe prompt generation with good coverage, but hardcodes tool list instead of deriving from TOOL_NAMES |
| src/utils/resume.ts | Clean Windows fix that bypasses multi-line prompts on cmd.exe by using single-line file reference |

</details>


</details>


<sub>Last reviewed commit: 804354d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->