### PR TITLE
feat: add qwen code support

### DIFF
--- a/src/__tests__/e2e-conversions.test.ts
+++ b/src/__tests__/e2e-conversions.test.ts
@@ -32,6 +32,7 @@ import {
   extractKiloCodeContext,
   extractAntigravityContext,
   extractKimiContext,
+  extractQwenCodeContext,
   parseClaudeSessions,
   parseCodexSessions,
   parseCopilotSessions,
@@ -47,10 +48,11 @@ import {
   parseKiloCodeSessions,
   parseAntigravitySessions,
   parseKimiSessions,
+  parseQwenCodeSessions,
 } from '../parsers/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 
-const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor', 'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi'];
+const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor', 'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi', 'qwen-code'];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   claude: parseClaudeSessions,
@@ -68,6 +70,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   'kilo-code': parseKiloCodeSessions,
   antigravity: parseAntigravitySessions,
   kimi: parseKimiSessions,
+  'qwen-code': parseQwenCodeSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -86,6 +89,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   'kilo-code': extractKiloCodeContext,
   antigravity: extractAntigravityContext,
   kimi: extractKimiContext,
+  'qwen-code': extractQwenCodeContext,
 };
 
 // Results directory
@@ -276,6 +280,7 @@ describe('E2E: 20 Cross-Tool Conversion Paths', () => {
           'kilo-code': 'Kilo Code',
           antigravity: 'Antigravity',
           kimi: 'Kimi CLI',
+          'qwen-code': 'Qwen Code',
         };
         const sourceLabel = sourceLabels[source];
 

--- a/src/__tests__/extract-handoffs.ts
+++ b/src/__tests__/extract-handoffs.ts
@@ -21,6 +21,7 @@ import {
   extractKiloCodeContext,
   extractAntigravityContext,
   extractKimiContext,
+  extractQwenCodeContext,
   parseClaudeSessions,
   parseCodexSessions,
   parseCopilotSessions,
@@ -36,13 +37,14 @@ import {
   parseKiloCodeSessions,
   parseAntigravitySessions,
   parseKimiSessions,
+  parseQwenCodeSessions,
 } from '../parsers/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 
 const RESULTS_DIR = path.join(process.env.HOME || '~', '.continues', 'e2e-test-results');
 fs.mkdirSync(RESULTS_DIR, { recursive: true });
 
-const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor', 'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi'];
+const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor', 'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi', 'qwen-code'];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   claude: parseClaudeSessions,
@@ -60,6 +62,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   'kilo-code': parseKiloCodeSessions,
   antigravity: parseAntigravitySessions,
   kimi: parseKimiSessions,
+  'qwen-code': parseQwenCodeSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -78,6 +81,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   'kilo-code': extractKiloCodeContext,
   antigravity: extractAntigravityContext,
   kimi: extractKimiContext,
+  'qwen-code': extractQwenCodeContext,
 };
 
 async function main() {

--- a/src/__tests__/fixtures/index.ts
+++ b/src/__tests__/fixtures/index.ts
@@ -851,25 +851,35 @@ export function createKiloCodeFixture(): FixtureDir {
 }
 
 /**
- * Create a temporary directory with Antigravity session fixtures (JSONL with role/parts)
+ * Create a temporary directory with Antigravity session fixtures (JSON with type/content/timestamp)
  */
 export function createAntigravityFixture(): FixtureDir {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'test-antigravity-'));
 
   const lines = [
-    JSON.stringify({ role: 'user', parts: [{ text: 'Fix the authentication bug in login.ts' }] }),
     JSON.stringify({
-      role: 'model',
-      parts: [{ text: 'I found the issue in login.ts. The token validation was missing.' }],
+      type: 'user',
+      content: 'Fix the authentication bug in login.ts',
+      timestamp: '2025-02-25T10:00:00Z',
     }),
-    JSON.stringify({ role: 'user', parts: [{ text: 'Great, please also add error handling' }] }),
     JSON.stringify({
-      role: 'model',
-      parts: [{ text: 'Done. I added try-catch blocks and proper error messages.' }],
+      type: 'assistant',
+      content: 'I found the issue in login.ts. The token validation was missing.',
+      timestamp: '2025-02-25T10:00:05Z',
+    }),
+    JSON.stringify({
+      type: 'user',
+      content: 'Great, please also add error handling',
+      timestamp: '2025-02-25T10:01:00Z',
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      content: 'Done. I added try-catch blocks and proper error messages.',
+      timestamp: '2025-02-25T10:01:10Z',
     }),
   ];
 
-  fs.writeFileSync(path.join(root, 'session.jsonl'), lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(root, 'session.json'), lines.join('\n') + '\n');
 
   return {
     root,
@@ -977,6 +987,81 @@ export function createKimiFixture(): FixtureDir {
       2,
     ),
   );
+
+  return {
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Create a temporary directory with Qwen Code session fixtures
+ * Storage: ~/.qwen/tmp/<sha256-hash>/chats/<sessionId>.jsonl
+ */
+export function createQwenCodeFixture(): FixtureDir {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'test-qwen-code-'));
+  const projectHash = createHash('sha256').update('/home/user/project').digest('hex');
+  const chatsDir = path.join(root, projectHash, 'chats');
+  fs.mkdirSync(chatsDir, { recursive: true });
+
+  const sessionId = 'test-qwen-code-session-1';
+  const lines = [
+    JSON.stringify({
+      uuid: '00000000-0000-0000-0000-000000000001',
+      parentUuid: null,
+      sessionId,
+      timestamp: '2026-01-15T10:00:01.000Z',
+      type: 'user',
+      cwd: '/home/user/project',
+      version: '1.0.0',
+      gitBranch: 'main',
+      message: { role: 'user', parts: [{ text: 'Fix the authentication bug in login.ts' }] },
+    }),
+    JSON.stringify({
+      uuid: '00000000-0000-0000-0000-000000000002',
+      parentUuid: '00000000-0000-0000-0000-000000000001',
+      sessionId,
+      timestamp: '2026-01-15T10:00:05.000Z',
+      type: 'assistant',
+      cwd: '/home/user/project',
+      version: '1.0.0',
+      model: 'qwen3-coder',
+      message: {
+        role: 'model',
+        parts: [
+          { text: 'I found the issue in login.ts. The token validation was missing.' },
+          { functionCall: { name: 'read_file', args: { file_path: 'login.ts' } } },
+        ],
+      },
+      usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 200 },
+    }),
+    JSON.stringify({
+      uuid: '00000000-0000-0000-0000-000000000003',
+      parentUuid: '00000000-0000-0000-0000-000000000002',
+      sessionId,
+      timestamp: '2026-01-15T10:00:10.000Z',
+      type: 'user',
+      cwd: '/home/user/project',
+      version: '1.0.0',
+      message: { role: 'user', parts: [{ text: 'Great, please also add error handling' }] },
+    }),
+    JSON.stringify({
+      uuid: '00000000-0000-0000-0000-000000000004',
+      parentUuid: '00000000-0000-0000-0000-000000000003',
+      sessionId,
+      timestamp: '2026-01-15T10:00:15.000Z',
+      type: 'assistant',
+      cwd: '/home/user/project',
+      version: '1.0.0',
+      model: 'qwen3-coder',
+      message: {
+        role: 'model',
+        parts: [{ text: 'Done. I added try-catch blocks and proper error messages.' }],
+      },
+    }),
+  ];
+
+  fs.writeFileSync(path.join(chatsDir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
 
   return {
     root,

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -41,14 +41,14 @@ import { EDIT_TOOLS, READ_TOOLS, SHELL_TOOLS, TOOL_NAMES, WRITE_TOOLS } from '..
 // ── tool-names.ts ────────────────────────────────────────────────────────────
 
 describe('TOOL_NAMES', () => {
-  it('contains exactly 15 tools', () => {
-    expect(TOOL_NAMES).toHaveLength(15);
+  it('contains exactly 16 tools', () => {
+    expect(TOOL_NAMES).toHaveLength(16);
   });
 
   it('includes all known tools', () => {
     const expected: SessionSource[] = [
       'claude', 'codex', 'copilot', 'gemini', 'opencode', 'droid', 'cursor',
-      'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi',
+      'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi', 'qwen-code',
     ];
     expect([...TOOL_NAMES]).toEqual(expected);
   });

--- a/src/__tests__/unit-conversions.test.ts
+++ b/src/__tests__/unit-conversions.test.ts
@@ -19,10 +19,11 @@ import {
   createCursorFixture,
   createDroidFixture,
   createGeminiFixture,
-  createKimiFixture,
   createKiloCodeFixture,
+  createKimiFixture,
   createKiroFixture,
   createOpenCodeSqliteFixture,
+  createQwenCodeFixture,
   createRooCodeFixture,
   type FixtureDir,
 } from './fixtures/index.js';
@@ -314,19 +315,15 @@ function parseAntigravityFixtureMessages(filePath: string): ConversationMessage[
   for (const line of lines) {
     try {
       const parsed = JSON.parse(line);
-      const text = (parsed.parts || [])
-        .filter((p: any) => p.text)
-        .map((p: any) => p.text)
-        .join('\n');
-      if (!text) continue;
+      if (typeof parsed.content !== 'string' || !parsed.content) continue;
 
-      if (parsed.role === 'user') {
-        messages.push({ role: 'user', content: text });
-      } else if (parsed.role === 'model') {
-        messages.push({ role: 'assistant', content: text });
+      if (parsed.type === 'user') {
+        messages.push({ role: 'user', content: parsed.content });
+      } else if (parsed.type === 'assistant') {
+        messages.push({ role: 'assistant', content: parsed.content });
       }
     } catch {
-      /* skip */
+      // skip malformed lines
     }
   }
   return messages;
@@ -364,6 +361,36 @@ function parseKimiFixtureMessages(filePath: string): ConversationMessage[] {
   return messages;
 }
 
+function parseQwenCodeFixtureMessages(filePath: string): ConversationMessage[] {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.trim().split('\n');
+  const messages: ConversationMessage[] = [];
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed.type !== 'user' && parsed.type !== 'assistant') continue;
+
+      const text = (parsed.message?.parts || [])
+        .filter((p: any) => p?.text)
+        .map((p: any) => p.text)
+        .join('\n');
+
+      if (!text) continue;
+
+      messages.push({
+        role: parsed.type === 'user' ? 'user' : 'assistant',
+        content: text,
+        timestamp: parsed.timestamp ? new Date(parsed.timestamp) : undefined,
+      });
+    } catch {
+      /* skip */
+    }
+  }
+
+  return messages;
+}
+
 // ─── Fixture Data ────────────────────────────────────────────────────────────
 
 // Derive from registry — automatically picks up new tools
@@ -390,6 +417,7 @@ beforeAll(() => {
   fixtures['roo-code'] = createRooCodeFixture();
   fixtures['kilo-code'] = createKiloCodeFixture();
   fixtures.antigravity = createAntigravityFixture();
+  fixtures['qwen-code'] = createQwenCodeFixture();
 
   // Build contexts from fixtures
   const now = new Date();
@@ -757,7 +785,7 @@ beforeAll(() => {
   const antigravityFile = fs
     .readdirSync(fixtures.antigravity.root)
     .map((f) => path.join(fixtures.antigravity.root, f as string))
-    .find((f) => f.endsWith('.jsonl'))!;
+    .find((f) => f.endsWith('.json') || f.endsWith('.jsonl'))!;
   const antigravitySession: UnifiedSession = {
     id: 'test-antigravity-session-1',
     source: 'antigravity',
@@ -807,6 +835,35 @@ beforeAll(() => {
     pendingTasks: [],
     toolSummaries: [],
     markdown: generateHandoffMarkdown(kimiSession, kimiMsgs, [], [], []),
+  };
+
+  // Qwen Code
+  const qwenCodeFile = fs
+    .readdirSync(fixtures['qwen-code'].root, { recursive: true })
+    .map((f) => path.join(fixtures['qwen-code'].root, f as string))
+    .find((f) => f.endsWith('.jsonl'))!;
+  const qwenCodeSession: UnifiedSession = {
+    id: 'test-qwen-code-session-1',
+    source: 'qwen-code',
+    cwd: '/home/user/project',
+    repo: 'user/project',
+    branch: 'main',
+    lines: 4,
+    bytes: fs.statSync(qwenCodeFile).size,
+    createdAt: now,
+    updatedAt: now,
+    originalPath: qwenCodeFile,
+    summary: 'Fix auth bug',
+    model: 'qwen3-coder',
+  };
+  const qwenCodeMsgs = parseQwenCodeFixtureMessages(qwenCodeFile);
+  contexts['qwen-code'] = {
+    session: qwenCodeSession,
+    recentMessages: qwenCodeMsgs,
+    filesModified: [],
+    pendingTasks: [],
+    toolSummaries: [],
+    markdown: generateHandoffMarkdown(qwenCodeSession, qwenCodeMsgs, [], [], []),
   };
 });
 
@@ -1083,7 +1140,13 @@ describe('Shared generateHandoffMarkdown', () => {
           },
           {
             summary: '$ npm build → exit 1',
-            data: { category: 'shell', command: 'npm build', exitCode: 1, errored: true, stdoutTail: 'Error: build failed' },
+            data: {
+              category: 'shell',
+              command: 'npm build',
+              exitCode: 1,
+              errored: true,
+              stdoutTail: 'Error: build failed',
+            },
           },
         ],
       },
@@ -1381,7 +1444,9 @@ describe('MCP namespace grouping', () => {
       {
         name: 'mcp__github__list_issues',
         count: 3,
-        samples: [{ summary: 'list_issues()', data: { category: 'mcp' as const, toolName: 'mcp__github__list_issues' } }],
+        samples: [
+          { summary: 'list_issues()', data: { category: 'mcp' as const, toolName: 'mcp__github__list_issues' } },
+        ],
       },
       {
         name: 'mcp__github__create_pr',

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -15,5 +15,6 @@ export {
 } from './cline.js';
 export { extractAntigravityContext, parseAntigravitySessions } from './antigravity.js';
 export { extractKimiContext, parseKimiSessions } from './kimi.js';
+export { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
 export type { ToolAdapter } from './registry.js';
 export { ALL_TOOLS, adapters, SOURCE_HELP } from './registry.js';

--- a/src/parsers/qwen-code.ts
+++ b/src/parsers/qwen-code.ts
@@ -1,0 +1,406 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as readline from 'node:readline';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
+import { logger } from '../logger.js';
+import type {
+  ConversationMessage,
+  SessionContext,
+  SessionNotes,
+  ToolUsageSummary,
+  UnifiedSession,
+} from '../types/index.js';
+import { classifyToolName } from '../types/tool-names.js';
+import { listSubdirectories } from '../utils/fs-helpers.js';
+import { generateHandoffMarkdown } from '../utils/markdown.js';
+import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
+import { fileSummary, mcpSummary, SummaryCollector, shellSummary, truncate } from '../utils/tool-summarizer.js';
+
+const qwenHome = process.env.QWEN_HOME || homeDir();
+const QWEN_BASE_DIR = path.join(qwenHome, '.qwen', 'tmp');
+
+// ── ChatRecord types ────────────────────────────────────────────────────────
+// Matches QwenLM/qwen-code ChatRecord interface from chatRecordingService.ts
+
+interface QwenPart {
+  text?: string;
+  functionCall?: { name: string; args: Record<string, unknown> };
+  functionResponse?: { name: string; response: { output?: string } };
+}
+
+interface QwenContent {
+  role?: string;
+  parts?: QwenPart[];
+}
+
+interface QwenToolCallResult {
+  displayName?: string;
+  status?: string;
+  resultDisplay?: {
+    filePath?: string;
+    fileDiff?: string;
+    diffStat?: { model_added_lines?: number; model_removed_lines?: number };
+    isNewFile?: boolean;
+    type?: string;
+  };
+}
+
+interface QwenUsageMetadata {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  cachedContentTokenCount?: number;
+  thoughtsTokenCount?: number;
+}
+
+interface QwenChatRecord {
+  uuid: string;
+  parentUuid: string | null;
+  sessionId: string;
+  timestamp: string;
+  type: 'user' | 'assistant' | 'tool_result' | 'system';
+  subtype?: string;
+  cwd: string;
+  version?: string;
+  gitBranch?: string;
+  message?: QwenContent;
+  usageMetadata?: QwenUsageMetadata;
+  model?: string;
+  toolCallResult?: QwenToolCallResult;
+}
+
+// ── JSONL reading ───────────────────────────────────────────────────────────
+
+async function readJsonlRecords(filePath: string): Promise<QwenChatRecord[]> {
+  const records: QwenChatRecord[] = [];
+  const input = fs.createReadStream(filePath, 'utf8');
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line) as QwenChatRecord);
+    } catch {
+      logger.debug('qwen-code: skipping malformed JSONL line in', filePath);
+    }
+  }
+
+  return records;
+}
+
+// ── Text extraction ─────────────────────────────────────────────────────────
+
+function extractTextFromParts(parts: QwenPart[] | undefined): string {
+  if (!parts) return '';
+  return parts
+    .filter((p) => p.text)
+    .map((p) => p.text!)
+    .join('\n');
+}
+
+function extractContentText(content: QwenContent | undefined): string {
+  if (!content?.parts) return '';
+  return extractTextFromParts(content.parts);
+}
+
+// ── Session file discovery ──────────────────────────────────────────────────
+
+async function findSessionFiles(): Promise<string[]> {
+  const results: string[] = [];
+
+  if (!fs.existsSync(QWEN_BASE_DIR)) return results;
+
+  for (const projectDir of listSubdirectories(QWEN_BASE_DIR)) {
+    if (path.basename(projectDir) === 'bin') continue;
+    const chatsDir = path.join(projectDir, 'chats');
+    if (!fs.existsSync(chatsDir)) continue;
+
+    try {
+      const entries = fs.readdirSync(chatsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+          results.push(path.join(chatsDir, entry.name));
+        }
+      }
+    } catch (err) {
+      logger.debug('qwen-code: error reading chats dir', chatsDir, err);
+    }
+  }
+
+  return results;
+}
+
+// ── Session metadata extraction ─────────────────────────────────────────────
+
+async function extractSessionMeta(filePath: string): Promise<{
+  sessionId: string;
+  cwd: string;
+  gitBranch?: string;
+  firstUserMessage: string;
+  firstTimestamp: string;
+  lastTimestamp: string;
+  model?: string;
+  lineCount: number;
+} | null> {
+  const input = fs.createReadStream(filePath, 'utf8');
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+
+  let sessionId = '';
+  let cwd = '';
+  let gitBranch: string | undefined;
+  let firstUserMessage = '';
+  let firstTimestamp = '';
+  let lastTimestamp = '';
+  let model: string | undefined;
+  let lineCount = 0;
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    lineCount++;
+
+    try {
+      const record = JSON.parse(line) as QwenChatRecord;
+
+      if (!sessionId && record.sessionId) sessionId = record.sessionId;
+      if (!cwd && record.cwd) cwd = record.cwd;
+      if (!gitBranch && record.gitBranch) gitBranch = record.gitBranch;
+      if (!model && record.model) model = record.model;
+
+      if (!firstTimestamp && record.timestamp) firstTimestamp = record.timestamp;
+      if (record.timestamp) lastTimestamp = record.timestamp;
+
+      if (!firstUserMessage && record.type === 'user') {
+        firstUserMessage = extractContentText(record.message);
+      }
+    } catch {
+      // skip malformed line
+    }
+  }
+
+  if (!sessionId) return null;
+
+  return { sessionId, cwd, gitBranch, firstUserMessage, firstTimestamp, lastTimestamp, model, lineCount };
+}
+
+// ── Tool data extraction ────────────────────────────────────────────────────
+
+function extractToolData(
+  records: QwenChatRecord[],
+  config?: VerbosityConfig,
+): { summaries: ToolUsageSummary[]; filesModified: string[] } {
+  const collector = new SummaryCollector(config);
+
+  for (const record of records) {
+    // Extract from functionCall parts in assistant messages
+    if (record.type === 'assistant' && record.message?.parts) {
+      for (const part of record.message.parts) {
+        if (!part.functionCall) continue;
+        const { name, args } = part.functionCall;
+        const category = classifyToolName(name);
+        if (!category) continue;
+
+        const fp = (args?.file_path as string) || (args?.path as string) || '';
+
+        switch (category) {
+          case 'shell': {
+            const cmd = (args?.command as string) || (args?.cmd as string) || '';
+            collector.add(name, shellSummary(cmd), { data: { category: 'shell', command: cmd } });
+            break;
+          }
+          case 'write':
+            collector.add(name, fileSummary('write', fp), {
+              data: { category: 'write', filePath: fp },
+              filePath: fp,
+              isWrite: true,
+            });
+            break;
+          case 'read':
+            collector.add(name, fileSummary('read', fp), {
+              data: { category: 'read', filePath: fp },
+              filePath: fp,
+            });
+            break;
+          case 'edit':
+            collector.add(name, fileSummary('edit', fp), {
+              data: { category: 'edit', filePath: fp },
+              filePath: fp,
+              isWrite: true,
+            });
+            break;
+          case 'grep': {
+            const pattern = (args?.pattern as string) || (args?.query as string) || '';
+            collector.add(name, `grep "${truncate(pattern, 40)}"`, { data: { category: 'grep', pattern } });
+            break;
+          }
+          case 'glob': {
+            const pattern = (args?.pattern as string) || fp;
+            collector.add(name, `glob ${truncate(pattern, 50)}`, { data: { category: 'glob', pattern } });
+            break;
+          }
+          case 'search':
+            collector.add(name, `search "${truncate((args?.query as string) || '', 50)}"`, {
+              data: { category: 'search', query: (args?.query as string) || '' },
+            });
+            break;
+          case 'fetch':
+            collector.add(name, `fetch ${truncate((args?.url as string) || '', 60)}`, {
+              data: { category: 'fetch', url: (args?.url as string) || '' },
+            });
+            break;
+          case 'task': {
+            const desc = (args?.description as string) || (args?.prompt as string) || '';
+            collector.add(name, `task "${truncate(desc, 60)}"`, { data: { category: 'task', description: desc } });
+            break;
+          }
+          case 'ask': {
+            const question = truncate((args?.question as string) || '', 80);
+            collector.add(name, `ask: "${question}"`, { data: { category: 'ask', question } });
+            break;
+          }
+          default: {
+            const argsStr = args ? JSON.stringify(args).slice(0, 100) : '';
+            collector.add(name, mcpSummary(name, argsStr), { data: { category: 'mcp', toolName: name } });
+          }
+        }
+      }
+    }
+
+    // Extract from tool_result records with enriched metadata
+    if (record.type === 'tool_result' && record.toolCallResult) {
+      const tcr = record.toolCallResult;
+      const displayName = tcr.displayName || '';
+      const fp = tcr.resultDisplay?.filePath || '';
+
+      if (displayName && fp && tcr.resultDisplay?.fileDiff) {
+        let diffStat: { added: number; removed: number } | undefined;
+        if (tcr.resultDisplay.diffStat) {
+          diffStat = {
+            added: tcr.resultDisplay.diffStat.model_added_lines || 0,
+            removed: tcr.resultDisplay.diffStat.model_removed_lines || 0,
+          };
+        }
+        const isNew = tcr.resultDisplay.isNewFile ?? false;
+        collector.add(displayName, fileSummary(isNew ? 'write' : 'edit', fp, diffStat, isNew), {
+          data: { category: isNew ? 'write' : 'edit', filePath: fp },
+          filePath: fp,
+          isWrite: true,
+        });
+      }
+    }
+  }
+
+  return { summaries: collector.getSummaries(), filesModified: collector.getFilesModified() };
+}
+
+// ── Session notes extraction ────────────────────────────────────────────────
+
+function extractSessionNotes(records: QwenChatRecord[]): SessionNotes {
+  const notes: SessionNotes = {};
+
+  for (const record of records) {
+    if (record.type !== 'assistant') continue;
+
+    if (record.model && !notes.model) notes.model = record.model;
+
+    if (record.usageMetadata) {
+      if (!notes.tokenUsage) notes.tokenUsage = { input: 0, output: 0 };
+      notes.tokenUsage.input += record.usageMetadata.promptTokenCount || 0;
+      notes.tokenUsage.output += record.usageMetadata.candidatesTokenCount || 0;
+
+      if (record.usageMetadata.cachedContentTokenCount) {
+        if (!notes.cacheTokens) notes.cacheTokens = { creation: 0, read: 0 };
+        notes.cacheTokens.read += record.usageMetadata.cachedContentTokenCount;
+      }
+      if (record.usageMetadata.thoughtsTokenCount) {
+        notes.thinkingTokens = (notes.thinkingTokens || 0) + record.usageMetadata.thoughtsTokenCount;
+      }
+    }
+  }
+
+  return notes;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
+  const files = await findSessionFiles();
+  const sessions: UnifiedSession[] = [];
+
+  for (const filePath of files) {
+    try {
+      const meta = await extractSessionMeta(filePath);
+      if (!meta) continue;
+
+      const fileStats = fs.statSync(filePath);
+
+      sessions.push({
+        id: meta.sessionId,
+        source: 'qwen-code',
+        cwd: meta.cwd,
+        repo: '',
+        branch: meta.gitBranch,
+        lines: meta.lineCount,
+        bytes: fileStats.size,
+        createdAt: new Date(meta.firstTimestamp),
+        updatedAt: new Date(meta.lastTimestamp),
+        originalPath: filePath,
+        summary: cleanSummary(meta.firstUserMessage) || undefined,
+        model: meta.model,
+      });
+    } catch (err) {
+      logger.debug('qwen-code: skipping unparseable session', filePath, err);
+    }
+  }
+
+  return sessions
+    .filter((s) => s.summary && s.summary.length > 0)
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}
+
+export async function extractQwenCodeContext(
+  session: UnifiedSession,
+  config?: VerbosityConfig,
+): Promise<SessionContext> {
+  const resolvedConfig = config ?? getPreset('standard');
+  const records = await readJsonlRecords(session.originalPath);
+  const recentMessages: ConversationMessage[] = [];
+  const pendingTasks: string[] = [];
+
+  const toolData = extractToolData(records, resolvedConfig);
+  const sessionNotes = extractSessionNotes(records);
+
+  // Extract recent messages (last N user/assistant records)
+  const messageRecords = records.filter((r) => r.type === 'user' || r.type === 'assistant');
+  for (const record of messageRecords.slice(-resolvedConfig.recentMessages * 2)) {
+    const text = extractContentText(record.message);
+    if (!text) continue;
+
+    recentMessages.push({
+      role: record.type === 'user' ? 'user' : 'assistant',
+      content: text,
+      timestamp: new Date(record.timestamp),
+    });
+  }
+
+  const trimmed = recentMessages.slice(-resolvedConfig.recentMessages);
+
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    toolData.filesModified,
+    pendingTasks,
+    toolData.summaries,
+    sessionNotes,
+    resolvedConfig,
+  );
+
+  return {
+    session: sessionNotes?.model ? { ...session, model: sessionNotes.model } : session,
+    recentMessages: trimmed,
+    filesModified: toolData.filesModified,
+    pendingTasks,
+    toolSummaries: toolData.summaries,
+    sessionNotes,
+    markdown,
+  };
+}

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -26,6 +26,7 @@ import {
 } from './cline.js';
 import { extractAntigravityContext, parseAntigravitySessions } from './antigravity.js';
 import { extractKimiContext, parseKimiSessions } from './kimi.js';
+import { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
 
 /**
  * Adapter interface — single contract for all supported CLI tools.
@@ -605,6 +606,22 @@ register({
   nativeResumeArgs: (s) => ['--session', s.id],
   crossToolArgs: (prompt) => ['--prompt', prompt],
   resumeCommandDisplay: (s) => `kimi --session ${s.id}`,
+});
+
+// ── Qwen Code ────────────────────────────────────────────────────────
+register({
+  name: 'qwen-code',
+  label: 'Qwen Code',
+  color: chalk.hex('#6366F1'),
+  storagePath: '~/.qwen/tmp/*/chats/',
+  envVar: 'QWEN_HOME',
+  binaryName: 'qwen',
+  parseSessions: parseQwenCodeSessions,
+  extractContext: extractQwenCodeContext,
+  nativeResumeArgs: () => ['--continue'],
+  crossToolArgs: (prompt) => [prompt],
+  resumeCommandDisplay: () => `qwen --continue`,
+  mapHandoffFlags: mapGeminiFlags,
 });
 
 // ── Completeness assertion ──────────────────────────────────────────

--- a/src/types/tool-names.ts
+++ b/src/types/tool-names.ts
@@ -20,6 +20,7 @@ export const TOOL_NAMES = Object.freeze([
   'kilo-code',
   'antigravity',
   'kimi',
+  'qwen-code',
 ] as const);
 
 /** Source CLI tool — derived from TOOL_NAMES, never defined manually */


### PR DESCRIPTION
adds qwen code (`qwen` cli from [QwenLM/qwen-code](https://github.com/QwenLM/qwen-code)) as the 16th supported tool.

**what changed:**
- new parser at `src/parsers/qwen-code.ts` — reads `~/.qwen/tmp/<hash>/chats/*.jsonl` (ChatRecord JSONL format, forked from gemini cli)
- registered in registry with binary `qwen`, resume via `--continue`, storage path `~/.qwen/tmp/*/chats/`
- fixture + all 30 new conversion test paths (240 total, up from 210)
- 692 tests passing, zero type errors

**technical notes:**
- qwen code stores sessions as append-only JSONL with tree-structured messages (uuid/parentUuid)
- message content uses google's Content format: `message.parts[].text`
- tool invocations extracted from `functionCall` parts + enriched `toolCallResult` metadata
- project dirs are sha256 hashes of the working directory path
- reuses gemini's flag mapper since qwen-code is forked from gemini cli

closes #12
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

Adds qwen-code (16th tool) - follows 4-step registration checklist, includes fixture and 30 new test paths. Parser correctly streams JSONL, uses SummaryCollector, and reuses gemini's flag mapper since qwen-code is forked from gemini CLI.

**Critical issue:**
- Lines 82 & 162 use unsafe `as` casts instead of Zod validation - violates `zod-schema-validation` rule. Must create `QwenChatRecordSchema` in `src/types/schemas.ts` and use `.safeParse()` like gemini.ts does.

**Minor issues:**
- Line 385 manually slices messages instead of using `trimMessages()` helper (though gemini.ts also does this)
- Line 17 imports unused `trimMessages`

Fix the Zod validation before merging - malformed session files will crash the CLI instead of being skipped.

<details><summary><h3>Confidence Score: 2/5</h3></summary>

- Not safe to merge - missing Zod validation will crash on malformed session files
- Score reflects critical correctness bug (unsafe casts) that violates explicit architectural rule and creates runtime crash risk. Otherwise clean implementation following gemini pattern.
- src/parsers/qwen-code.ts (add Zod schema validation), src/types/schemas.ts (create QwenChatRecordSchema)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/parsers/qwen-code.ts | New qwen-code parser added - follows gemini pattern well, but missing critical Zod validation on lines 82 & 162 |
| src/types/tool-names.ts | Added `qwen-code` to TOOL_NAMES array - clean, correct |
| src/parsers/registry.ts | Qwen Code registration complete - reuses gemini flag mapper appropriately, all ToolAdapter fields present |
| src/__tests__/fixtures/index.ts | Added createQwenCodeFixture with realistic JSONL data - follows established patterns |

</details>


</details>


<sub>Last reviewed commit: 0239af8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->