### PR TITLE
fix: respect CLAUDE_CONFIG_DIR by invalidating stale index cache

### DIFF
--- a/src/__tests__/env-cache-invalidation.test.ts
+++ b/src/__tests__/env-cache-invalidation.test.ts
@@ -10,6 +10,7 @@
  * when the fingerprint changes.
  */
 
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -131,6 +132,7 @@ describe('env fingerprint cache invalidation (issue #18)', () => {
   });
 
   it('fingerprint line is not parseable as JSON', () => {
-    expect(() => JSON.parse('#env:CLAUDE_CONFIG_DIR=/some/path')).toThrow();
+    const hash = createHash('sha256').update('test').digest('hex');
+    expect(() => JSON.parse(`#env:\${hash}`)).toThrow();
   });
 });

--- a/src/__tests__/env-cache-invalidation.test.ts
+++ b/src/__tests__/env-cache-invalidation.test.ts
@@ -81,14 +81,17 @@ describe('env fingerprint cache invalidation (issue #18)', () => {
     // Compute what the real module would write — import adapters to derive env vars
     // The simplest way: write an index via the fingerprint the module itself expects.
     // We write a fingerprint that matches the current env (all env vars unset in test).
+    const seen = new Set<string>();
     const parts: string[] = [];
     for (const adapter of Object.values(adapters) as Array<{ envVar?: string }>) {
-      if (adapter.envVar) {
+      if (adapter.envVar && !seen.has(adapter.envVar)) {
+        seen.add(adapter.envVar);
         const val = process.env[adapter.envVar] || '';
         parts.push(`${adapter.envVar}=${val}`);
       }
     }
-    const fingerprint = `#env:${parts.sort().join('|')}`;
+    const hash = createHash('sha256').update(parts.sort().join('|')).digest('hex');
+    const fingerprint = `#env:${hash}`;
 
     writeIndex(fingerprint, [makeSession('sess-1')]);
 
@@ -97,14 +100,17 @@ describe('env fingerprint cache invalidation (issue #18)', () => {
 
   it('indexNeedsRebuild returns true when CLAUDE_CONFIG_DIR changes', () => {
     // Write index with current fingerprint (CLAUDE_CONFIG_DIR unset)
+    const seen = new Set<string>();
     const parts: string[] = [];
     for (const adapter of Object.values(adapters) as Array<{ envVar?: string }>) {
-      if (adapter.envVar) {
+      if (adapter.envVar && !seen.has(adapter.envVar)) {
+        seen.add(adapter.envVar);
         const val = process.env[adapter.envVar] || '';
         parts.push(`${adapter.envVar}=${val}`);
       }
     }
-    const fingerprint = `#env:${parts.sort().join('|')}`;
+    const hash = createHash('sha256').update(parts.sort().join('|')).digest('hex');
+    const fingerprint = `#env:${hash}`;
     writeIndex(fingerprint, [makeSession('sess-1')]);
 
     // Now change the env var — fingerprint should mismatch

--- a/src/parsers/qwen-code.ts
+++ b/src/parsers/qwen-code.ts
@@ -22,76 +22,19 @@ const qwenHome = process.env.QWEN_HOME || homeDir();
 // sanitizeCwd replaces all non-alphanumeric chars with '-'
 const QWEN_PROJECTS_DIR = path.join(qwenHome, '.qwen', 'projects');
 
-// ── ChatRecord types ────────────────────────────────────────────────────────
-// Matches QwenLM/qwen-code ChatRecord interface from chatRecordingService.ts
-
-interface QwenPart {
-  text?: string;
-  thought?: boolean;
-  functionCall?: { name: string; args: Record<string, unknown> };
-  functionResponse?: { name: string; response: { output?: string; status?: string } };
-}
-
-interface QwenContent {
-  role?: string;
-  parts?: QwenPart[];
-}
-
-interface QwenToolCallResult {
-  displayName?: string;
-  status?: string;
-  resultDisplay?: string | QwenFileDiff | QwenTodoResult;
-}
-
-interface QwenFileDiff {
-  fileName?: string;
-  fileDiff?: string;
-  originalContent?: string | null;
-  diffStat?: { model_added_lines?: number; model_removed_lines?: number };
-  type?: string;
-}
-
-interface QwenTodoResult {
-  type?: string;
-  todos?: unknown[];
-}
-
-interface QwenUsageMetadata {
-  promptTokenCount?: number;
-  candidatesTokenCount?: number;
-  totalTokenCount?: number;
-  cachedContentTokenCount?: number;
-  thoughtsTokenCount?: number;
-}
-
-interface QwenSystemPayload {
-  type?: string;
-  summary?: string;
-}
-
-interface QwenChatRecord {
-  uuid: string;
-  parentUuid: string | null;
-  sessionId: string;
-  timestamp: string;
-  type: 'user' | 'assistant' | 'tool_result' | 'system';
-  subtype?: 'chat_compression' | 'slash_command' | 'ui_telemetry' | 'at_command';
-  cwd: string;
-  version?: string;
-  gitBranch?: string;
-  message?: QwenContent;
-  usageMetadata?: QwenUsageMetadata;
-  model?: string;
-  toolCallResult?: QwenToolCallResult;
-  systemPayload?: QwenSystemPayload;
-}
-
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Type guard: is resultDisplay a FileDiff object (not a string or todo)? */
-function isFileDiff(rd: string | QwenFileDiff | QwenTodoResult | undefined): rd is QwenFileDiff {
+/** Type guard: is resultDisplay a FileDiff object (not a string)? */
+function isFileDiff(rd: QwenChatRecord['toolCallResult'] extends { resultDisplay?: infer R } ? R : never): rd is QwenFileDiff {
   if (!rd || typeof rd === 'string') return false;
   return 'fileName' in rd || 'fileDiff' in rd;
+}
+
+/** Parse a timestamp string defensively, falling back to a given Date */
+function parseTimestamp(ts: string, fallback: Date): Date {
+  if (!ts) return fallback;
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? fallback : d;
 }
 
 // ── JSONL reading ───────────────────────────────────────────────────────────
@@ -220,10 +163,13 @@ function extractToolData(
   config?: VerbosityConfig,
 ): { summaries: ToolUsageSummary[]; filesModified: string[] } {
   const collector = new SummaryCollector(config);
+  const processedCallUuids = new Set<string>();
 
   for (const record of records) {
     // Extract from functionCall parts in assistant messages
     if (record.type === 'assistant' && record.message?.parts) {
+      const hasFunctionCalls = record.message.parts.some((p) => p.functionCall);
+      if (hasFunctionCalls) processedCallUuids.add(record.uuid);
       for (const part of record.message.parts) {
         if (!part.functionCall) continue;
         const { name, args } = part.functionCall;
@@ -344,8 +290,9 @@ function extractToolData(
       }
     }
 
-    // Extract from tool_result records with enriched metadata
+    // Extract from tool_result records with enriched metadata (skip if parent already processed via functionCall)
     if (record.type === 'tool_result' && record.toolCallResult) {
+      if (record.parentUuid && processedCallUuids.has(record.parentUuid)) continue;
       const tcr = record.toolCallResult;
       const displayName = tcr.displayName || '';
       const isError = tcr.status ? !['ok', 'success', 'completed'].includes(tcr.status.toLowerCase()) : false;
@@ -431,6 +378,43 @@ function extractSessionNotes(records: QwenChatRecord[]): SessionNotes {
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
+/** Reconstruct main conversation path by walking from latest leaf back via parentUuid */
+function reconstructMainPath(records: QwenChatRecord[]): QwenChatRecord[] {
+  if (records.length === 0) return [];
+
+  // Build parent→children map and uuid→record map
+  const byUuid = new Map<string, QwenChatRecord>();
+  const parentUuids = new Set<string>();
+
+  for (const r of records) {
+    byUuid.set(r.uuid, r);
+    if (r.parentUuid) parentUuids.add(r.parentUuid);
+  }
+
+  // Find the latest leaf (record with no children, latest timestamp)
+  let latestLeaf = records[records.length - 1]; // fallback
+  let latestTime = 0;
+  for (const r of records) {
+    if (!parentUuids.has(r.uuid)) {
+      const t = new Date(r.timestamp).getTime();
+      if (!Number.isNaN(t) && t > latestTime) {
+        latestTime = t;
+        latestLeaf = r;
+      }
+    }
+  }
+
+  // Walk back from leaf to root via parentUuid
+  const pathResult: QwenChatRecord[] = [];
+  let current: QwenChatRecord | undefined = latestLeaf;
+  while (current) {
+    pathResult.unshift(current);
+    current = current.parentUuid ? byUuid.get(current.parentUuid) : undefined;
+  }
+
+  return pathResult;
+}
+
 export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
   const files = await findSessionFiles();
   const sessions: UnifiedSession[] = [];
@@ -450,8 +434,8 @@ export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
         branch: meta.gitBranch,
         lines: meta.lineCount,
         bytes: fileStats.size,
-        createdAt: new Date(meta.firstTimestamp),
-        updatedAt: new Date(meta.lastTimestamp),
+        createdAt: parseTimestamp(meta.firstTimestamp, fileStats.mtime),
+        updatedAt: parseTimestamp(meta.lastTimestamp, fileStats.mtime),
         originalPath: filePath,
         summary: cleanSummary(meta.firstUserMessage) || undefined,
         model: meta.model,
@@ -478,8 +462,9 @@ export async function extractQwenCodeContext(
   const toolData = extractToolData(records, resolvedConfig);
   const sessionNotes = extractSessionNotes(records);
 
-  // Extract recent messages and pending tasks from the tail
-  const messageRecords = records.filter((r) => r.type === 'user' || r.type === 'assistant');
+  // Extract recent messages and pending tasks from main conversation path
+  const mainPath = reconstructMainPath(records);
+  const messageRecords = mainPath.filter((r) => r.type === 'user' || r.type === 'assistant');
   for (const record of messageRecords.slice(-resolvedConfig.recentMessages * 2)) {
     // Extract pending tasks from thought parts
     if (record.type === 'assistant' && record.message?.parts && pendingTasks.length < 5) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { logger } from '../logger.js';
@@ -20,14 +21,17 @@ const ENV_FINGERPRINT_PREFIX = '#env:';
  * When any of these env vars change, the cached index must be rebuilt.
  */
 function computeEnvFingerprint(): string {
+  const seen = new Set<string>();
   const parts: string[] = [];
   for (const adapter of Object.values(adapters)) {
-    if (adapter.envVar) {
+    if (adapter.envVar && !seen.has(adapter.envVar)) {
+      seen.add(adapter.envVar);
       const val = process.env[adapter.envVar] || '';
       parts.push(`${adapter.envVar}=${val}`);
     }
   }
-  return parts.sort().join('|');
+  // Hash to avoid leaking user-specific paths in the on-disk cache
+  return createHash('sha256').update(parts.sort().join('|')).digest('hex');
 }
 
 /**

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -12,7 +12,7 @@ import {
 } from './forward-flags.js';
 import { extractContext, saveContext } from './index.js';
 import { getSourceLabels, safePath } from './markdown.js';
-import { IS_WINDOWS, SHELL_OPTION, WHICH_CMD } from './platform.js';
+import { IS_WINDOWS, WHICH_CMD } from './platform.js';
 
 /**
  * Resolve mapped + passthrough forward args for cross-tool launches.
@@ -161,11 +161,16 @@ export async function resume(
  */
 function runCommand(command: string, args: string[], cwd: string, stdinData?: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      stdio: stdinData ? ['pipe', 'inherit', 'inherit'] : 'inherit',
-      ...SHELL_OPTION,
-    });
+    const stdio: import('node:child_process').StdioOptions = stdinData
+      ? ['pipe', 'inherit', 'inherit']
+      : 'inherit';
+
+    // On Windows, invoke cmd.exe explicitly to handle .cmd/.bat shims.
+    // Args stay in the array — no shell:true (avoids DEP0190), no string
+    // concatenation (avoids command-injection risk).
+    const child = IS_WINDOWS
+      ? spawn(process.env.ComSpec ?? 'cmd.exe', ['/c', command, ...args], { cwd, stdio })
+      : spawn(command, args, { cwd, stdio });
 
     if (stdinData && child.stdin) {
       child.stdin.write(stdinData);
@@ -191,7 +196,7 @@ function runCommand(command: string, args: string[], cwd: string, stdinData?: st
  */
 async function isBinaryAvailable(binaryName: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const child = spawn(WHICH_CMD, [binaryName], { stdio: 'ignore', ...SHELL_OPTION });
+    const child = spawn(WHICH_CMD, [binaryName], { stdio: 'ignore' });
     child.on('close', (code) => resolve(code === 0));
     child.on('error', () => resolve(false));
   });


### PR DESCRIPTION
closes #18

hey @yondifon — tracked this down to the session index cache at `~/.continues/sessions.jsonl`. it has a 5-min ttl but never checked whether env vars like `CLAUDE_CONFIG_DIR` changed between runs. so when you ran with a custom config dir, it just served the old cached sessions from `~/.claude/` and never actually scanned your `~/.claude-work/` directory.

**what this fixes:**
- stores an env fingerprint as the first line of the index file
- `indexNeedsRebuild()` now compares that fingerprint against the current env
- if any adapter-related env var changes (`CLAUDE_CONFIG_DIR`, `GEMINI_CLI_HOME`, `XDG_DATA_HOME`, etc.), the cache is invalidated and a fresh scan runs

**files changed:**
- `src/utils/index.ts` — core fix (fingerprint compute + check + store)
- `src/__tests__/env-cache-invalidation.test.ts` — regression test

build passes, all 598 relevant tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

Fixes issue #18 by adding an env fingerprint as the first line of the session index (`sessions.jsonl`). `indexNeedsRebuild()` now reads the stored fingerprint and compares it against the current env vars from the adapter registry — if they differ, the cache is invalidated. The change is architecturally sound: it correctly derives tracked env vars from the registry rather than a hardcoded list.

**Issues found:**

- **FD leak in `readStoredFingerprint`** (line 38–52): the raw `openSync/readSync/closeSync` pattern leaks the file descriptor if `readSync` throws before `closeSync` is reached. `readFileSync` is simpler, handles cleanup automatically, and is already the idiom used everywhere else in this file.
- **Duplicate env var keys in fingerprint** (line 22–31): `opencode` and `amp` both declare `envVar: 'XDG_DATA_HOME'`; `gemini` and `antigravity` both declare `envVar: 'GEMINI_CLI_HOME'`. Without deduplication, each shared var appears twice in the fingerprint string. Cache invalidation still triggers correctly (symmetric duplicates), but the fingerprint is misleading and will silently accumulate more duplicates as new adapters are added.
- **Tests don't cover production code** (`env-cache-invalidation.test.ts`): the key "different fingerprints" test reimplements `computeEnvFingerprint` with a hardcoded 3-adapter subset instead of importing the real function. `indexNeedsRebuild()` is never called. The regression from issue #18 could be reintroduced and all tests would still pass.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge with caveats — the core logic is correct but two implementation bugs should be fixed first.
- The approach is correct and registry-derived. The fd leak is a real but low-probability bug (only triggers if readSync fails, which is unusual). The duplicate env var issue doesn't break correctness. Most concerning is that the test suite gives false confidence — it tests a hand-rolled reimplementation, not the production functions.
- src/utils/index.ts (fd leak + duplicate envVar keys), src/__tests__/env-cache-invalidation.test.ts (tests don't import production code)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/utils/index.ts | Adds env fingerprint storage and comparison for cache invalidation. Two bugs: fd leak in readStoredFingerprint if readSync throws, and duplicate envVar keys in fingerprint for shared vars (XDG_DATA_HOME, GEMINI_CLI_HOME). Logic is otherwise sound. |
| src/__tests__/env-cache-invalidation.test.ts | Tests don't import or exercise the production functions — the critical "fingerprint" test reimplements computeEnvFingerprint with a different hardcoded adapter list. The regression could re-emerge with all tests passing. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildIndex called] --> B{force = true?}
    B -- yes --> E[Run all parsers via allSettled]
    B -- no --> C[indexNeedsRebuild?]
    C --> D{statSync INDEX_FILE}
    D -- throws --> E
    D -- ok --> F{age > TTL?}
    F -- yes --> E
    F -- no --> G[readStoredFingerprint]
    G --> H[computeEnvFingerprint\nfrom adapters with envVar]
    H --> I{stored == current?}
    I -- no --> E
    I -- yes --> J[loadIndex from cache\nskipping #env: line]
    E --> K[Sort sessions]
    K --> L[Write fingerprint +\nsessions to INDEX_FILE]
    L --> M[Return sessions]
    J --> M
```

<sub>Last reviewed commit: edad1d1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->