### PR TITLE
fix: opencode cross-tool handoff and gemini native resume

### DIFF
--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -445,9 +445,9 @@ register({
   binaryName: 'gemini',
   parseSessions: parseGeminiSessions,
   extractContext: extractGeminiContext,
-  nativeResumeArgs: () => ['--continue'],
+  nativeResumeArgs: () => ['--resume'],
   crossToolArgs: (prompt) => [prompt],
-  resumeCommandDisplay: () => `gemini --continue`,
+  resumeCommandDisplay: () => `gemini --resume`,
   mapHandoffFlags: mapGeminiFlags,
 });
 
@@ -462,7 +462,7 @@ register({
   parseSessions: parseOpenCodeSessions,
   extractContext: extractOpenCodeContext,
   nativeResumeArgs: (s) => ['--session', s.id],
-  crossToolArgs: (prompt) => ['--prompt', prompt],
+  crossToolArgs: (prompt) => ['run', prompt],
   resumeCommandDisplay: (s) => `opencode --session ${s.id}`,
   mapHandoffFlags: mapOpenCodeFlags,
 });

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -12,7 +12,7 @@ import {
 } from './forward-flags.js';
 import { extractContext, saveContext } from './index.js';
 import { getSourceLabels, safePath } from './markdown.js';
-import { IS_WINDOWS, SHELL_OPTION, WHICH_CMD } from './platform.js';
+import { IS_WINDOWS, WHICH_CMD } from './platform.js';
 
 /**
  * Resolve mapped + passthrough forward args for cross-tool launches.
@@ -161,11 +161,16 @@ export async function resume(
  */
 function runCommand(command: string, args: string[], cwd: string, stdinData?: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      stdio: stdinData ? ['pipe', 'inherit', 'inherit'] : 'inherit',
-      ...SHELL_OPTION,
-    });
+    const stdio: import('node:child_process').StdioOptions = stdinData
+      ? ['pipe', 'inherit', 'inherit']
+      : 'inherit';
+
+    // On Windows, invoke cmd.exe explicitly to handle .cmd/.bat shims.
+    // Args stay in the array — no shell:true (avoids DEP0190), no string
+    // concatenation (avoids command-injection risk).
+    const child = IS_WINDOWS
+      ? spawn(process.env.ComSpec ?? 'cmd.exe', ['/c', command, ...args], { cwd, stdio })
+      : spawn(command, args, { cwd, stdio });
 
     if (stdinData && child.stdin) {
       child.stdin.write(stdinData);
@@ -191,7 +196,7 @@ function runCommand(command: string, args: string[], cwd: string, stdinData?: st
  */
 async function isBinaryAvailable(binaryName: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const child = spawn(WHICH_CMD, [binaryName], { stdio: 'ignore', ...SHELL_OPTION });
+    const child = spawn(WHICH_CMD, [binaryName], { stdio: 'ignore' });
     child.on('close', (code) => resolve(code === 0));
     child.on('error', () => resolve(false));
   });


### PR DESCRIPTION
fixes #22

hey @DaveW001 — tracked this down to three things:

1. **opencode handoff** was passing `--prompt` which doesn't exist on the `run` subcommand. opencode uses yargs strict mode so it just shows help and exits 1. switched to positional args: `opencode run <prompt>`

2. **gemini native resume** was using `--continue` but gemini cli actually uses `--resume`. simple flag name mismatch.

3. **windows spawn** was hitting node 22's DEP0190 deprecation — passing args array with `shell: true` doesn't quote them, so multi-word prompts get word-split. rewrote `runCommand()` to build a properly quoted command string on windows and use direct spawn (no shell) on unix.

all 688 tests pass, build is clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

Fixes three handoff bugs: opencode now uses `run <prompt>` (positional) instead of non-existent `--prompt` flag, gemini uses `--resume` instead of `--continue`, and Windows spawn avoids DEP0190 by building quoted command strings. Changes are minimal and targeted.

- Simple flag corrections in registry are correct
- Windows quoting logic properly escapes special chars with `""` and handles word-splitting
- Unix path uses direct spawn (no shell) — clean and efficient
- **Issue**: `isBinaryAvailable()` still uses deprecated args-with-shell pattern on Windows (inconsistent with `runCommand()` fix)

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with one minor inconsistency
- Fixes are correct and minimal, but isBinaryAvailable() still triggers DEP0190 on Windows — won't break anything but creates inconsistency
- Pay attention to src/utils/resume.ts:201-209 (isBinaryAvailable function)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/parsers/registry.ts | Simple flag corrections for gemini (--continue → --resume) and opencode (--prompt → positional run arg) |
| src/utils/resume.ts | Rewrote runCommand() to fix DEP0190, but isBinaryAvailable() still uses deprecated pattern |

</details>


</details>


<sub>Last reviewed commit: 2eae97b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->