### PR TITLE
fix(qwen-code): correct storage path, tool classification, and gemini feature parity

### DIFF
--- a/src/__tests__/env-cache-invalidation.test.ts
+++ b/src/__tests__/env-cache-invalidation.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression test for GitHub issue #18:
+ * CLAUDE_CONFIG_DIR environment variable is ignored when running continues resume.
+ *
+ * Root cause: the session index cache (~/.continues/sessions.jsonl) had a 5-min TTL
+ * but did not track which env vars were in effect when the cache was built. Changing
+ * CLAUDE_CONFIG_DIR (or any adapter envVar) would still serve the stale cache.
+ *
+ * Fix: store an env fingerprint as the first line of the index file and invalidate
+ * when the fingerprint changes.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// We test the index module's exported functions directly.
+// The module reads `adapters` from registry — we mock that to avoid loading all parsers.
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-env-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('env fingerprint cache invalidation (issue #18)', () => {
+  it('indexNeedsRebuild returns true when env fingerprint changes', async () => {
+    // We directly test the logic: write an index file with one fingerprint,
+    // then check that changing the env var triggers a rebuild.
+    const indexFile = path.join(tmpDir, 'sessions.jsonl');
+
+    // Simulate an index written with CLAUDE_CONFIG_DIR unset
+    const fingerprintNoEnv = '#env:CLAUDE_CONFIG_DIR=|GEMINI_CLI_HOME=|QWEN_HOME=|XDG_DATA_HOME=';
+    const sessionLine = JSON.stringify({
+      id: 'test-session',
+      source: 'claude',
+      cwd: '/tmp/project',
+      repo: 'test/repo',
+      branch: 'main',
+      lines: 10,
+      bytes: 500,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      originalPath: '/tmp/test.jsonl',
+    });
+    fs.writeFileSync(indexFile, `${fingerprintNoEnv}\n${sessionLine}\n`);
+
+    // Read the first line — should be the fingerprint
+    const content = fs.readFileSync(indexFile, 'utf8');
+    const firstLine = content.split('\n')[0];
+    expect(firstLine).toMatch(/^#env:/);
+
+    // Simulate "env changed" — a different fingerprint
+    const fingerprintWithEnv = '#env:CLAUDE_CONFIG_DIR=/home/user/.claude-work|GEMINI_CLI_HOME=|QWEN_HOME=|XDG_DATA_HOME=';
+    expect(fingerprintNoEnv).not.toBe(fingerprintWithEnv);
+  });
+
+  it('loadIndex skips the fingerprint line when loading sessions', async () => {
+    const indexFile = path.join(tmpDir, 'sessions.jsonl');
+
+    const fingerprint = '#env:CLAUDE_CONFIG_DIR=';
+    const session1 = JSON.stringify({
+      id: 'sess-1',
+      source: 'claude',
+      cwd: '/tmp/a',
+      repo: 'a/b',
+      branch: 'main',
+      lines: 5,
+      bytes: 300,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+      originalPath: '/tmp/a.jsonl',
+    });
+    const session2 = JSON.stringify({
+      id: 'sess-2',
+      source: 'codex',
+      cwd: '/tmp/b',
+      repo: 'c/d',
+      branch: 'dev',
+      lines: 10,
+      bytes: 600,
+      createdAt: '2025-01-02T00:00:00.000Z',
+      updatedAt: '2025-01-02T00:00:00.000Z',
+      originalPath: '/tmp/b.jsonl',
+    });
+
+    fs.writeFileSync(indexFile, `${fingerprint}\n${session1}\n${session2}\n`);
+
+    // Read and parse manually (same logic as loadIndex)
+    const content = fs.readFileSync(indexFile, 'utf8');
+    const lines = content.trim().split('\n').filter((l) => l && !l.startsWith('#env:'));
+
+    expect(lines).toHaveLength(2);
+
+    const parsed1 = JSON.parse(lines[0]);
+    expect(parsed1.id).toBe('sess-1');
+
+    const parsed2 = JSON.parse(lines[1]);
+    expect(parsed2.id).toBe('sess-2');
+  });
+
+  it('fingerprint line is not parsed as JSON session data', () => {
+    // Ensure that if the fingerprint line is accidentally fed to JSON.parse,
+    // it doesn't produce a valid session object
+    const fingerprint = '#env:CLAUDE_CONFIG_DIR=/some/path';
+    expect(() => JSON.parse(fingerprint)).toThrow();
+  });
+
+  it('different env var values produce different fingerprints', () => {
+    // Simulate fingerprint computation
+    const compute = (envVars: Record<string, string>) => {
+      const adaptersWithEnvVar = [
+        { envVar: 'CLAUDE_CONFIG_DIR' },
+        { envVar: 'GEMINI_CLI_HOME' },
+        { envVar: 'XDG_DATA_HOME' },
+      ];
+      const parts: string[] = [];
+      for (const adapter of adaptersWithEnvVar) {
+        const val = envVars[adapter.envVar] || '';
+        parts.push(`${adapter.envVar}=${val}`);
+      }
+      return parts.sort().join('|');
+    };
+
+    const fp1 = compute({});
+    const fp2 = compute({ CLAUDE_CONFIG_DIR: '/home/user/.claude-work' });
+    const fp3 = compute({ CLAUDE_CONFIG_DIR: '/home/user/.claude-work', GEMINI_CLI_HOME: '/opt/gemini' });
+
+    expect(fp1).not.toBe(fp2);
+    expect(fp2).not.toBe(fp3);
+    expect(fp1).not.toBe(fp3);
+  });
+});

--- a/src/__tests__/env-cache-invalidation.test.ts
+++ b/src/__tests__/env-cache-invalidation.test.ts
@@ -13,129 +13,124 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-// We test the index module's exported functions directly.
-// The module reads `adapters` from registry — we mock that to avoid loading all parsers.
+// Create the fake home eagerly so it's ready before any mock evaluates
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-env-test-'));
+
+afterAll(() => {
+  fs.rmSync(fakeHome, { recursive: true, force: true });
+});
+
+// Mock homeDir() BEFORE importing the index module — the module evaluates
+// CONTINUES_DIR = path.join(homeDir(), '.continues') at import time.
+vi.mock('../utils/parser-helpers.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../utils/parser-helpers.js')>();
+  return {
+    ...orig,
+    homeDir: () => fakeHome,
+  };
+});
+
+// Now import the module under test — it will resolve INDEX_FILE under fakeHome.
+const { indexNeedsRebuild, loadIndex, ensureDirectories } = await import('../utils/index.js');
+const { adapters } = await import('../parsers/registry.js');
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-let tmpDir: string;
+function indexFilePath(): string {
+  return path.join(fakeHome, '.continues', 'sessions.jsonl');
+}
 
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-env-test-'));
-});
+function writeIndex(fingerprint: string, sessions: Record<string, unknown>[]): void {
+  ensureDirectories();
+  const lines = sessions.map((s) => JSON.stringify(s));
+  fs.writeFileSync(indexFilePath(), fingerprint + '\n' + lines.join('\n') + '\n');
+}
+
+function makeSession(id: string, source = 'claude'): Record<string, unknown> {
+  return {
+    id,
+    source,
+    cwd: '/tmp/project',
+    repo: 'test/repo',
+    branch: 'main',
+    lines: 10,
+    bytes: 500,
+    createdAt: '2025-06-01T00:00:00.000Z',
+    updatedAt: '2025-06-01T00:00:00.000Z',
+    originalPath: `/tmp/${id}.jsonl`,
+  };
+}
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
-  vi.restoreAllMocks();
+  // Clean the index file between tests
+  try { fs.unlinkSync(indexFilePath()); } catch (_) { /* file may not exist */ }
+  vi.unstubAllEnvs();
 });
 
+// ── Tests ────────────────────────────────────────────────────────────────────
+
 describe('env fingerprint cache invalidation (issue #18)', () => {
-  it('indexNeedsRebuild returns true when env fingerprint changes', async () => {
-    // We directly test the logic: write an index file with one fingerprint,
-    // then check that changing the env var triggers a rebuild.
-    const indexFile = path.join(tmpDir, 'sessions.jsonl');
-
-    // Simulate an index written with CLAUDE_CONFIG_DIR unset
-    const fingerprintNoEnv = '#env:CLAUDE_CONFIG_DIR=|GEMINI_CLI_HOME=|QWEN_HOME=|XDG_DATA_HOME=';
-    const sessionLine = JSON.stringify({
-      id: 'test-session',
-      source: 'claude',
-      cwd: '/tmp/project',
-      repo: 'test/repo',
-      branch: 'main',
-      lines: 10,
-      bytes: 500,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      originalPath: '/tmp/test.jsonl',
-    });
-    fs.writeFileSync(indexFile, `${fingerprintNoEnv}\n${sessionLine}\n`);
-
-    // Read the first line — should be the fingerprint
-    const content = fs.readFileSync(indexFile, 'utf8');
-    const firstLine = content.split('\n')[0];
-    expect(firstLine).toMatch(/^#env:/);
-
-    // Simulate "env changed" — a different fingerprint
-    const fingerprintWithEnv = '#env:CLAUDE_CONFIG_DIR=/home/user/.claude-work|GEMINI_CLI_HOME=|QWEN_HOME=|XDG_DATA_HOME=';
-    expect(fingerprintNoEnv).not.toBe(fingerprintWithEnv);
+  it('indexNeedsRebuild returns true when no index file exists', () => {
+    expect(indexNeedsRebuild()).toBe(true);
   });
 
-  it('loadIndex skips the fingerprint line when loading sessions', async () => {
-    const indexFile = path.join(tmpDir, 'sessions.jsonl');
-
-    const fingerprint = '#env:CLAUDE_CONFIG_DIR=';
-    const session1 = JSON.stringify({
-      id: 'sess-1',
-      source: 'claude',
-      cwd: '/tmp/a',
-      repo: 'a/b',
-      branch: 'main',
-      lines: 5,
-      bytes: 300,
-      createdAt: '2025-01-01T00:00:00.000Z',
-      updatedAt: '2025-01-01T00:00:00.000Z',
-      originalPath: '/tmp/a.jsonl',
-    });
-    const session2 = JSON.stringify({
-      id: 'sess-2',
-      source: 'codex',
-      cwd: '/tmp/b',
-      repo: 'c/d',
-      branch: 'dev',
-      lines: 10,
-      bytes: 600,
-      createdAt: '2025-01-02T00:00:00.000Z',
-      updatedAt: '2025-01-02T00:00:00.000Z',
-      originalPath: '/tmp/b.jsonl',
-    });
-
-    fs.writeFileSync(indexFile, `${fingerprint}\n${session1}\n${session2}\n`);
-
-    // Read and parse manually (same logic as loadIndex)
-    const content = fs.readFileSync(indexFile, 'utf8');
-    const lines = content.trim().split('\n').filter((l) => l && !l.startsWith('#env:'));
-
-    expect(lines).toHaveLength(2);
-
-    const parsed1 = JSON.parse(lines[0]);
-    expect(parsed1.id).toBe('sess-1');
-
-    const parsed2 = JSON.parse(lines[1]);
-    expect(parsed2.id).toBe('sess-2');
-  });
-
-  it('fingerprint line is not parsed as JSON session data', () => {
-    // Ensure that if the fingerprint line is accidentally fed to JSON.parse,
-    // it doesn't produce a valid session object
-    const fingerprint = '#env:CLAUDE_CONFIG_DIR=/some/path';
-    expect(() => JSON.parse(fingerprint)).toThrow();
-  });
-
-  it('different env var values produce different fingerprints', () => {
-    // Simulate fingerprint computation
-    const compute = (envVars: Record<string, string>) => {
-      const adaptersWithEnvVar = [
-        { envVar: 'CLAUDE_CONFIG_DIR' },
-        { envVar: 'GEMINI_CLI_HOME' },
-        { envVar: 'XDG_DATA_HOME' },
-      ];
-      const parts: string[] = [];
-      for (const adapter of adaptersWithEnvVar) {
-        const val = envVars[adapter.envVar] || '';
+  it('indexNeedsRebuild returns false when index is fresh and fingerprint matches', () => {
+    // Compute what the real module would write — import adapters to derive env vars
+    // The simplest way: write an index via the fingerprint the module itself expects.
+    // We write a fingerprint that matches the current env (all env vars unset in test).
+    const parts: string[] = [];
+    for (const adapter of Object.values(adapters) as Array<{ envVar?: string }>) {
+      if (adapter.envVar) {
+        const val = process.env[adapter.envVar] || '';
         parts.push(`${adapter.envVar}=${val}`);
       }
-      return parts.sort().join('|');
-    };
+    }
+    const fingerprint = `#env:${parts.sort().join('|')}`;
 
-    const fp1 = compute({});
-    const fp2 = compute({ CLAUDE_CONFIG_DIR: '/home/user/.claude-work' });
-    const fp3 = compute({ CLAUDE_CONFIG_DIR: '/home/user/.claude-work', GEMINI_CLI_HOME: '/opt/gemini' });
+    writeIndex(fingerprint, [makeSession('sess-1')]);
 
-    expect(fp1).not.toBe(fp2);
-    expect(fp2).not.toBe(fp3);
-    expect(fp1).not.toBe(fp3);
+    expect(indexNeedsRebuild()).toBe(false);
+  });
+
+  it('indexNeedsRebuild returns true when CLAUDE_CONFIG_DIR changes', () => {
+    // Write index with current fingerprint (CLAUDE_CONFIG_DIR unset)
+    const parts: string[] = [];
+    for (const adapter of Object.values(adapters) as Array<{ envVar?: string }>) {
+      if (adapter.envVar) {
+        const val = process.env[adapter.envVar] || '';
+        parts.push(`${adapter.envVar}=${val}`);
+      }
+    }
+    const fingerprint = `#env:${parts.sort().join('|')}`;
+    writeIndex(fingerprint, [makeSession('sess-1')]);
+
+    // Now change the env var — fingerprint should mismatch
+    vi.stubEnv('CLAUDE_CONFIG_DIR', '/home/user/.claude-work');
+
+    expect(indexNeedsRebuild()).toBe(true);
+  });
+
+  it('loadIndex skips the fingerprint line and returns only sessions', () => {
+    writeIndex('#env:CLAUDE_CONFIG_DIR=', [
+      makeSession('sess-1', 'claude'),
+      makeSession('sess-2', 'codex'),
+    ]);
+
+    const sessions = loadIndex();
+
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].id).toBe('sess-1');
+    expect(sessions[1].id).toBe('sess-2');
+    expect(sessions[0].createdAt).toBeInstanceOf(Date);
+  });
+
+  it('loadIndex returns empty array for non-existent file', () => {
+    expect(loadIndex()).toEqual([]);
+  });
+
+  it('fingerprint line is not parseable as JSON', () => {
+    expect(() => JSON.parse('#env:CLAUDE_CONFIG_DIR=/some/path')).toThrow();
   });
 });

--- a/src/__tests__/fixtures/index.ts
+++ b/src/__tests__/fixtures/index.ts
@@ -996,12 +996,14 @@ export function createKimiFixture(): FixtureDir {
 
 /**
  * Create a temporary directory with Qwen Code session fixtures
- * Storage: ~/.qwen/tmp/<sha256-hash>/chats/<sessionId>.jsonl
+ * Storage: ~/.qwen/projects/<sanitized-cwd>/chats/<sessionId>.jsonl
+ * sanitizeCwd replaces [^a-zA-Z0-9] with '-'
  */
 export function createQwenCodeFixture(): FixtureDir {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'test-qwen-code-'));
-  const projectHash = createHash('sha256').update('/home/user/project').digest('hex');
-  const chatsDir = path.join(root, projectHash, 'chats');
+  // sanitizeCwd('/home/user/project') → '-home-user-project'
+  const sanitizedCwd = '/home/user/project'.replace(/[^a-zA-Z0-9]/g, '-');
+  const chatsDir = path.join(root, sanitizedCwd, 'chats');
   fs.mkdirSync(chatsDir, { recursive: true });
 
   const sessionId = 'test-qwen-code-session-1';
@@ -1029,15 +1031,35 @@ export function createQwenCodeFixture(): FixtureDir {
       message: {
         role: 'model',
         parts: [
+          { text: 'Let me think about this...', thought: true },
           { text: 'I found the issue in login.ts. The token validation was missing.' },
           { functionCall: { name: 'read_file', args: { file_path: 'login.ts' } } },
         ],
       },
-      usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 200 },
+      usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 200, thoughtsTokenCount: 50 },
+    }),
+    JSON.stringify({
+      uuid: '00000000-0000-0000-0000-000000000005',
+      parentUuid: '00000000-0000-0000-0000-000000000002',
+      sessionId,
+      timestamp: '2026-01-15T10:00:07.000Z',
+      type: 'tool_result',
+      cwd: '/home/user/project',
+      version: '1.0.0',
+      toolCallResult: {
+        displayName: 'Edit',
+        status: 'ok',
+        resultDisplay: {
+          fileName: 'login.ts',
+          fileDiff: '+  validateToken(token);\n-  // missing validation',
+          originalContent: '// missing validation',
+          diffStat: { model_added_lines: 1, model_removed_lines: 1 },
+        },
+      },
     }),
     JSON.stringify({
       uuid: '00000000-0000-0000-0000-000000000003',
-      parentUuid: '00000000-0000-0000-0000-000000000002',
+      parentUuid: '00000000-0000-0000-0000-000000000005',
       sessionId,
       timestamp: '2026-01-15T10:00:10.000Z',
       type: 'user',

--- a/src/__tests__/unit-conversions.test.ts
+++ b/src/__tests__/unit-conversions.test.ts
@@ -848,7 +848,7 @@ beforeAll(() => {
     cwd: '/home/user/project',
     repo: 'user/project',
     branch: 'main',
-    lines: 4,
+    lines: 5,
     bytes: fs.statSync(qwenCodeFile).size,
     createdAt: now,
     updatedAt: now,

--- a/src/parsers/qwen-code.ts
+++ b/src/parsers/qwen-code.ts
@@ -14,19 +14,22 @@ import type {
 import { classifyToolName } from '../types/tool-names.js';
 import { listSubdirectories } from '../utils/fs-helpers.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
-import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
+import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
 import { fileSummary, mcpSummary, SummaryCollector, shellSummary, truncate } from '../utils/tool-summarizer.js';
 
 const qwenHome = process.env.QWEN_HOME || homeDir();
-const QWEN_BASE_DIR = path.join(qwenHome, '.qwen', 'tmp');
+// Qwen Code stores chats under ~/.qwen/projects/<sanitized-cwd>/chats/
+// sanitizeCwd replaces all non-alphanumeric chars with '-'
+const QWEN_PROJECTS_DIR = path.join(qwenHome, '.qwen', 'projects');
 
 // ── ChatRecord types ────────────────────────────────────────────────────────
 // Matches QwenLM/qwen-code ChatRecord interface from chatRecordingService.ts
 
 interface QwenPart {
   text?: string;
+  thought?: boolean;
   functionCall?: { name: string; args: Record<string, unknown> };
-  functionResponse?: { name: string; response: { output?: string } };
+  functionResponse?: { name: string; response: { output?: string; status?: string } };
 }
 
 interface QwenContent {
@@ -37,20 +40,33 @@ interface QwenContent {
 interface QwenToolCallResult {
   displayName?: string;
   status?: string;
-  resultDisplay?: {
-    filePath?: string;
-    fileDiff?: string;
-    diffStat?: { model_added_lines?: number; model_removed_lines?: number };
-    isNewFile?: boolean;
-    type?: string;
-  };
+  resultDisplay?: string | QwenFileDiff | QwenTodoResult;
+}
+
+interface QwenFileDiff {
+  fileName?: string;
+  fileDiff?: string;
+  originalContent?: string | null;
+  diffStat?: { model_added_lines?: number; model_removed_lines?: number };
+  type?: string;
+}
+
+interface QwenTodoResult {
+  type?: string;
+  todos?: unknown[];
 }
 
 interface QwenUsageMetadata {
   promptTokenCount?: number;
   candidatesTokenCount?: number;
+  totalTokenCount?: number;
   cachedContentTokenCount?: number;
   thoughtsTokenCount?: number;
+}
+
+interface QwenSystemPayload {
+  type?: string;
+  summary?: string;
 }
 
 interface QwenChatRecord {
@@ -59,7 +75,7 @@ interface QwenChatRecord {
   sessionId: string;
   timestamp: string;
   type: 'user' | 'assistant' | 'tool_result' | 'system';
-  subtype?: string;
+  subtype?: 'chat_compression' | 'slash_command' | 'ui_telemetry' | 'at_command';
   cwd: string;
   version?: string;
   gitBranch?: string;
@@ -67,6 +83,15 @@ interface QwenChatRecord {
   usageMetadata?: QwenUsageMetadata;
   model?: string;
   toolCallResult?: QwenToolCallResult;
+  systemPayload?: QwenSystemPayload;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Type guard: is resultDisplay a FileDiff object (not a string or todo)? */
+function isFileDiff(rd: string | QwenFileDiff | QwenTodoResult | undefined): rd is QwenFileDiff {
+  if (!rd || typeof rd === 'string') return false;
+  return 'fileName' in rd || 'fileDiff' in rd;
 }
 
 // ── JSONL reading ───────────────────────────────────────────────────────────
@@ -90,12 +115,19 @@ async function readJsonlRecords(filePath: string): Promise<QwenChatRecord[]> {
 
 // ── Text extraction ─────────────────────────────────────────────────────────
 
+/** Extract non-thought text from parts */
 function extractTextFromParts(parts: QwenPart[] | undefined): string {
   if (!parts) return '';
   return parts
-    .filter((p) => p.text)
+    .filter((p) => p.text && !p.thought)
     .map((p) => p.text!)
     .join('\n');
+}
+
+/** Extract thought/reasoning text from parts */
+function extractThoughtsFromParts(parts: QwenPart[] | undefined): string[] {
+  if (!parts) return [];
+  return parts.filter((p) => p.text && p.thought).map((p) => p.text!);
 }
 
 function extractContentText(content: QwenContent | undefined): string {
@@ -108,10 +140,9 @@ function extractContentText(content: QwenContent | undefined): string {
 async function findSessionFiles(): Promise<string[]> {
   const results: string[] = [];
 
-  if (!fs.existsSync(QWEN_BASE_DIR)) return results;
+  if (!fs.existsSync(QWEN_PROJECTS_DIR)) return results;
 
-  for (const projectDir of listSubdirectories(QWEN_BASE_DIR)) {
-    if (path.basename(projectDir) === 'bin') continue;
+  for (const projectDir of listSubdirectories(QWEN_PROJECTS_DIR)) {
     const chatsDir = path.join(projectDir, 'chats');
     if (!fs.existsSync(chatsDir)) continue;
 
@@ -201,23 +232,41 @@ function extractToolData(
 
         const fp = (args?.file_path as string) || (args?.path as string) || '';
 
+        // Try to extract result from a matching functionResponse in the same parts array
+        let resultStr: string | undefined;
+        for (const rp of record.message.parts) {
+          if (rp.functionResponse?.name === name && rp.functionResponse.response?.output) {
+            resultStr = String(rp.functionResponse.response.output);
+            break;
+          }
+        }
+        const isResponseError = record.message.parts.some(
+          (rp) => rp.functionResponse?.name === name && rp.functionResponse.response?.status === 'error',
+        );
+
         switch (category) {
           case 'shell': {
             const cmd = (args?.command as string) || (args?.cmd as string) || '';
-            collector.add(name, shellSummary(cmd), { data: { category: 'shell', command: cmd } });
+            collector.add(name, shellSummary(cmd, resultStr), {
+              data: { category: 'shell', command: cmd, ...(resultStr ? { stdoutTail: resultStr.slice(-500) } : {}) },
+              isError: isResponseError,
+            });
             break;
           }
-          case 'write':
+          case 'write': {
             collector.add(name, fileSummary('write', fp), {
               data: { category: 'write', filePath: fp },
               filePath: fp,
               isWrite: true,
+              isError: isResponseError,
             });
             break;
+          }
           case 'read':
             collector.add(name, fileSummary('read', fp), {
               data: { category: 'read', filePath: fp },
               filePath: fp,
+              isError: isResponseError,
             });
             break;
           case 'edit':
@@ -225,41 +274,71 @@ function extractToolData(
               data: { category: 'edit', filePath: fp },
               filePath: fp,
               isWrite: true,
+              isError: isResponseError,
             });
             break;
           case 'grep': {
             const pattern = (args?.pattern as string) || (args?.query as string) || '';
-            collector.add(name, `grep "${truncate(pattern, 40)}"`, { data: { category: 'grep', pattern } });
+            collector.add(name, `grep "${truncate(pattern, 40)}"`, {
+              data: { category: 'grep', pattern, ...(fp ? { targetPath: fp } : {}) },
+              isError: isResponseError,
+            });
             break;
           }
           case 'glob': {
             const pattern = (args?.pattern as string) || fp;
-            collector.add(name, `glob ${truncate(pattern, 50)}`, { data: { category: 'glob', pattern } });
+            collector.add(name, `glob ${truncate(pattern, 50)}`, {
+              data: { category: 'glob', pattern },
+              isError: isResponseError,
+            });
             break;
           }
           case 'search':
             collector.add(name, `search "${truncate((args?.query as string) || '', 50)}"`, {
               data: { category: 'search', query: (args?.query as string) || '' },
+              isError: isResponseError,
             });
             break;
-          case 'fetch':
-            collector.add(name, `fetch ${truncate((args?.url as string) || '', 60)}`, {
-              data: { category: 'fetch', url: (args?.url as string) || '' },
+          case 'fetch': {
+            const url = (args?.url as string) || '';
+            collector.add(name, `fetch ${truncate(url, 60)}`, {
+              data: {
+                category: 'fetch',
+                url,
+                ...(resultStr ? { resultPreview: resultStr.slice(0, 100) } : {}),
+              },
+              isError: isResponseError,
             });
             break;
+          }
           case 'task': {
             const desc = (args?.description as string) || (args?.prompt as string) || '';
-            collector.add(name, `task "${truncate(desc, 60)}"`, { data: { category: 'task', description: desc } });
+            const agentType = (args?.subagent_type as string) || undefined;
+            collector.add(name, `task "${truncate(desc, 60)}"${agentType ? ` (${agentType})` : ''}`, {
+              data: { category: 'task', description: desc, ...(agentType ? { agentType } : {}) },
+              isError: isResponseError,
+            });
             break;
           }
           case 'ask': {
-            const question = truncate((args?.question as string) || '', 80);
-            collector.add(name, `ask: "${question}"`, { data: { category: 'ask', question } });
+            const question = truncate((args?.question as string) || (args?.prompt as string) || '', 80);
+            collector.add(name, `ask: "${question}"`, {
+              data: { category: 'ask', question },
+              isError: isResponseError,
+            });
             break;
           }
           default: {
             const argsStr = args ? JSON.stringify(args).slice(0, 100) : '';
-            collector.add(name, mcpSummary(name, argsStr), { data: { category: 'mcp', toolName: name } });
+            collector.add(name, mcpSummary(name, argsStr, resultStr), {
+              data: {
+                category: 'mcp',
+                toolName: name,
+                ...(argsStr ? { params: argsStr } : {}),
+                ...(resultStr ? { result: resultStr.slice(0, 100) } : {}),
+              },
+              isError: isResponseError,
+            });
           }
         }
       }
@@ -269,21 +348,41 @@ function extractToolData(
     if (record.type === 'tool_result' && record.toolCallResult) {
       const tcr = record.toolCallResult;
       const displayName = tcr.displayName || '';
-      const fp = tcr.resultDisplay?.filePath || '';
+      const isError = tcr.status ? !['ok', 'success', 'completed'].includes(tcr.status.toLowerCase()) : false;
 
-      if (displayName && fp && tcr.resultDisplay?.fileDiff) {
+      if (displayName && isFileDiff(tcr.resultDisplay)) {
+        const rd = tcr.resultDisplay;
+        const fp = rd.fileName || '';
+
         let diffStat: { added: number; removed: number } | undefined;
-        if (tcr.resultDisplay.diffStat) {
+        if (rd.diffStat) {
           diffStat = {
-            added: tcr.resultDisplay.diffStat.model_added_lines || 0,
-            removed: tcr.resultDisplay.diffStat.model_removed_lines || 0,
+            added: rd.diffStat.model_added_lines || 0,
+            removed: rd.diffStat.model_removed_lines || 0,
+          };
+        } else if (rd.fileDiff) {
+          // Fallback: count +/- lines from fileDiff
+          const lines = rd.fileDiff.split('\n');
+          diffStat = {
+            added: lines.filter((l: string) => l.startsWith('+')).length,
+            removed: lines.filter((l: string) => l.startsWith('-')).length,
           };
         }
-        const isNew = tcr.resultDisplay.isNewFile ?? false;
+
+        // isNewFile is determined by originalContent === null
+        const isNew = rd.originalContent === null;
+        const diff = rd.fileDiff || undefined;
         collector.add(displayName, fileSummary(isNew ? 'write' : 'edit', fp, diffStat, isNew), {
-          data: { category: isNew ? 'write' : 'edit', filePath: fp },
+          data: {
+            category: isNew ? 'write' : 'edit',
+            filePath: fp,
+            isNewFile: isNew,
+            ...(diff ? { diff } : {}),
+            ...(diffStat ? { diffStats: diffStat } : {}),
+          },
           filePath: fp,
           isWrite: true,
+          isError,
         });
       }
     }
@@ -296,11 +395,20 @@ function extractToolData(
 
 function extractSessionNotes(records: QwenChatRecord[]): SessionNotes {
   const notes: SessionNotes = {};
+  const reasoning: string[] = [];
 
   for (const record of records) {
     if (record.type !== 'assistant') continue;
 
     if (record.model && !notes.model) notes.model = record.model;
+
+    // Extract reasoning from thought parts
+    if (record.message?.parts && reasoning.length < 5) {
+      for (const thought of extractThoughtsFromParts(record.message.parts)) {
+        if (reasoning.length >= 5) break;
+        if (thought.length > 10) reasoning.push(truncate(thought, 200));
+      }
+    }
 
     if (record.usageMetadata) {
       if (!notes.tokenUsage) notes.tokenUsage = { input: 0, output: 0 };
@@ -317,6 +425,7 @@ function extractSessionNotes(records: QwenChatRecord[]): SessionNotes {
     }
   }
 
+  if (reasoning.length > 0) notes.reasoning = reasoning;
   return notes;
 }
 
@@ -337,7 +446,7 @@ export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
         id: meta.sessionId,
         source: 'qwen-code',
         cwd: meta.cwd,
-        repo: '',
+        repo: extractRepoFromCwd(meta.cwd),
         branch: meta.gitBranch,
         lines: meta.lineCount,
         bytes: fileStats.size,
@@ -369,9 +478,26 @@ export async function extractQwenCodeContext(
   const toolData = extractToolData(records, resolvedConfig);
   const sessionNotes = extractSessionNotes(records);
 
-  // Extract recent messages (last N user/assistant records)
+  // Extract recent messages and pending tasks from the tail
   const messageRecords = records.filter((r) => r.type === 'user' || r.type === 'assistant');
   for (const record of messageRecords.slice(-resolvedConfig.recentMessages * 2)) {
+    // Extract pending tasks from thought parts
+    if (record.type === 'assistant' && record.message?.parts && pendingTasks.length < 5) {
+      for (const thought of extractThoughtsFromParts(record.message.parts)) {
+        if (pendingTasks.length >= 5) break;
+        const lower = thought.toLowerCase();
+        if (
+          lower.includes('todo') ||
+          lower.includes('next') ||
+          lower.includes('remaining') ||
+          lower.includes('need to') ||
+          lower.includes('next step')
+        ) {
+          pendingTasks.push(truncate(thought, 200));
+        }
+      }
+    }
+
     const text = extractContentText(record.message);
     if (!text) continue;
 

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
-import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 import type { VerbosityConfig } from '../config/index.js';
+import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 import { TOOL_NAMES } from '../types/tool-names.js';
 import {
   type FlagOccurrence,
@@ -9,23 +9,26 @@ import {
   type ForwardMapResult,
   normalizeAgentSandbox,
 } from '../utils/forward-flags.js';
+import { extractAmpContext, parseAmpSessions } from './amp.js';
+import { extractAntigravityContext, parseAntigravitySessions } from './antigravity.js';
 import { extractClaudeContext, parseClaudeSessions } from './claude.js';
+import {
+  extractClineContext,
+  extractKiloCodeContext,
+  extractRooCodeContext,
+  parseClineSessions,
+  parseKiloCodeSessions,
+  parseRooCodeSessions,
+} from './cline.js';
 import { extractCodexContext, parseCodexSessions } from './codex.js';
 import { extractCopilotContext, parseCopilotSessions } from './copilot.js';
+import { extractCrushContext, parseCrushSessions } from './crush.js';
 import { extractCursorContext, parseCursorSessions } from './cursor.js';
 import { extractDroidContext, parseDroidSessions } from './droid.js';
 import { extractGeminiContext, parseGeminiSessions } from './gemini.js';
-import { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
-import { extractAmpContext, parseAmpSessions } from './amp.js';
-import { extractKiroContext, parseKiroSessions } from './kiro.js';
-import { extractCrushContext, parseCrushSessions } from './crush.js';
-import {
-  extractClineContext, parseClineSessions,
-  extractRooCodeContext, parseRooCodeSessions,
-  extractKiloCodeContext, parseKiloCodeSessions,
-} from './cline.js';
-import { extractAntigravityContext, parseAntigravitySessions } from './antigravity.js';
 import { extractKimiContext, parseKimiSessions } from './kimi.js';
+import { extractKiroContext, parseKiroSessions } from './kiro.js';
+import { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
 import { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
 
 /**
@@ -613,14 +616,14 @@ register({
   name: 'qwen-code',
   label: 'Qwen Code',
   color: chalk.hex('#6366F1'),
-  storagePath: '~/.qwen/tmp/*/chats/',
+  storagePath: '~/.qwen/projects/*/chats/',
   envVar: 'QWEN_HOME',
   binaryName: 'qwen',
   parseSessions: parseQwenCodeSessions,
   extractContext: extractQwenCodeContext,
-  nativeResumeArgs: () => ['--continue'],
+  nativeResumeArgs: (s) => ['--resume', s.id],
   crossToolArgs: (prompt) => [prompt],
-  resumeCommandDisplay: () => `qwen --continue`,
+  resumeCommandDisplay: (s) => `qwen --resume ${s.id}`,
   mapHandoffFlags: mapGeminiFlags,
 });
 

--- a/src/types/tool-names.ts
+++ b/src/types/tool-names.ts
@@ -36,6 +36,8 @@ export const SHELL_TOOLS: ReadonlySet<string> = new Set([
   'bash',
   'terminal',
   'run_terminal_command',
+  'run_shell_command',
+  'Shell',
   'exec_command',
   'shell_command',
   'Execute',
@@ -48,13 +50,38 @@ export const READ_TOOLS: ReadonlySet<string> = new Set(['Read', 'ReadFile', 'rea
 export const WRITE_TOOLS: ReadonlySet<string> = new Set(['Write', 'WriteFile', 'write_file', 'Create', 'create_file']);
 
 /** File edit/patch tools */
-export const EDIT_TOOLS: ReadonlySet<string> = new Set(['Edit', 'EditFile', 'edit_file', 'apply_diff', 'apply_patch', 'ApplyPatch']);
+export const EDIT_TOOLS: ReadonlySet<string> = new Set([
+  'Edit',
+  'EditFile',
+  'edit_file',
+  'edit',
+  'apply_diff',
+  'apply_patch',
+  'ApplyPatch',
+  'replace',
+]);
 
 /** Search/grep tools */
-export const GREP_TOOLS: ReadonlySet<string> = new Set(['Grep', 'grep', 'codebase_search']);
+export const GREP_TOOLS: ReadonlySet<string> = new Set([
+  'Grep',
+  'grep',
+  'grep_search',
+  'codebase_search',
+  'search_file_content',
+  'SearchFiles',
+]);
 
 /** Glob/directory listing tools */
-export const GLOB_TOOLS: ReadonlySet<string> = new Set(['Glob', 'glob', 'list_directory', 'file_search', 'LS']);
+export const GLOB_TOOLS: ReadonlySet<string> = new Set([
+  'Glob',
+  'glob',
+  'list_directory',
+  'ListFiles',
+  'file_search',
+  'LS',
+  'FindFiles',
+  'ReadFolder',
+]);
 
 /** Web search tools */
 export const SEARCH_TOOLS: ReadonlySet<string> = new Set(['WebSearch', 'web_search', 'web_search_call']);
@@ -72,7 +99,21 @@ export const TASK_OUTPUT_TOOLS: ReadonlySet<string> = new Set(['TaskOutput']);
 export const ASK_TOOLS: ReadonlySet<string> = new Set(['AskUserQuestion', 'request_user_input']);
 
 /** Tools to skip — internal bookkeeping, no useful handoff context */
-export const SKIP_TOOLS: ReadonlySet<string> = new Set(['TaskStop', 'ExitPlanMode', 'TodoWrite', 'update_plan', 'view_image']);
+export const SKIP_TOOLS: ReadonlySet<string> = new Set([
+  'TaskStop',
+  'ExitPlanMode',
+  'exit_plan_mode',
+  'TodoWrite',
+  'todo_write',
+  'SaveMemory',
+  'save_memory',
+  'Skill',
+  'skill',
+  'Lsp',
+  'lsp',
+  'update_plan',
+  'view_image',
+]);
 
 // ── Tool Sample Classification ──────────────────────────────────────────────
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,13 +35,8 @@ function computeEnvFingerprint(): string {
  */
 function readStoredFingerprint(): string | null {
   try {
-    const fd = fs.openSync(INDEX_FILE, 'r');
-    const buf = Buffer.alloc(1024);
-    const bytesRead = fs.readSync(fd, buf, 0, 1024, 0);
-    fs.closeSync(fd);
-    const head = buf.toString('utf8', 0, bytesRead);
-    const newlineIdx = head.indexOf('\n');
-    const firstLine = newlineIdx >= 0 ? head.slice(0, newlineIdx) : head;
+    const content = fs.readFileSync(INDEX_FILE, 'utf8');
+    const firstLine = content.slice(0, content.indexOf('\n'));
     if (firstLine.startsWith(ENV_FINGERPRINT_PREFIX)) {
       return firstLine.slice(ENV_FINGERPRINT_PREFIX.length);
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,46 @@ const CONTEXTS_DIR = path.join(CONTINUES_DIR, 'contexts');
 // Cache TTL in milliseconds (5 minutes)
 const INDEX_TTL = 5 * 60 * 1000;
 
+// Prefix for the env fingerprint line stored in the index file
+const ENV_FINGERPRINT_PREFIX = '#env:';
+
+/**
+ * Build a fingerprint of environment variables that affect parser storage paths.
+ * When any of these env vars change, the cached index must be rebuilt.
+ */
+function computeEnvFingerprint(): string {
+  const parts: string[] = [];
+  for (const adapter of Object.values(adapters)) {
+    if (adapter.envVar) {
+      const val = process.env[adapter.envVar] || '';
+      parts.push(`${adapter.envVar}=${val}`);
+    }
+  }
+  return parts.sort().join('|');
+}
+
+/**
+ * Read the env fingerprint stored in the first line of the index file.
+ */
+function readStoredFingerprint(): string | null {
+  try {
+    const fd = fs.openSync(INDEX_FILE, 'r');
+    const buf = Buffer.alloc(1024);
+    const bytesRead = fs.readSync(fd, buf, 0, 1024, 0);
+    fs.closeSync(fd);
+    const head = buf.toString('utf8', 0, bytesRead);
+    const newlineIdx = head.indexOf('\n');
+    const firstLine = newlineIdx >= 0 ? head.slice(0, newlineIdx) : head;
+    if (firstLine.startsWith(ENV_FINGERPRINT_PREFIX)) {
+      return firstLine.slice(ENV_FINGERPRINT_PREFIX.length);
+    }
+    return null;
+  } catch (err) {
+    logger.debug('index: failed to read stored fingerprint', err);
+    return null;
+  }
+}
+
 /**
  * Ensure continues directories exist
  */
@@ -35,7 +75,16 @@ export function indexNeedsRebuild(): boolean {
   try {
     const stats = fs.statSync(INDEX_FILE);
     const age = Date.now() - stats.mtime.getTime();
-    return age > INDEX_TTL;
+    if (age > INDEX_TTL) return true;
+
+    // Rebuild if env vars affecting storage paths have changed
+    const stored = readStoredFingerprint();
+    if (stored !== computeEnvFingerprint()) {
+      logger.debug('index: env fingerprint changed, rebuilding');
+      return true;
+    }
+
+    return false;
   } catch (err) {
     logger.debug('index: cache stale check failed', err);
     return true; // File doesn't exist or can't be read
@@ -64,7 +113,7 @@ export async function buildIndex(force = false): Promise<UnifiedSession[]> {
   // Sort by updated time (newest first)
   allSessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 
-  // Write to index file
+  // Write to index file — first line is the env fingerprint
   const lines = allSessions.map((s) =>
     JSON.stringify({
       ...s,
@@ -73,7 +122,8 @@ export async function buildIndex(force = false): Promise<UnifiedSession[]> {
     }),
   );
 
-  fs.writeFileSync(INDEX_FILE, lines.join('\n') + '\n');
+  const fingerprint = `${ENV_FINGERPRINT_PREFIX}${computeEnvFingerprint()}`;
+  fs.writeFileSync(INDEX_FILE, fingerprint + '\n' + lines.join('\n') + '\n');
 
   return allSessions;
 }
@@ -87,7 +137,7 @@ export function loadIndex(): UnifiedSession[] {
     const lines = content
       .trim()
       .split('\n')
-      .filter((l) => l);
+      .filter((l) => l && !l.startsWith(ENV_FINGERPRINT_PREFIX));
 
     return lines.flatMap((line) => {
       try {


### PR DESCRIPTION
fixes critical bugs found during source code audit against [QwenLM/qwen-code](https://github.com/QwenLM/qwen-code):

**critical fixes:**
- storage path was wrong (`~/.qwen/tmp/<sha256>` → `~/.qwen/projects/<sanitized-cwd>`) — parser would never find real sessions
- `nativeResumeArgs` now uses `--resume <sessionId>` for specific session resume (not just `--continue`)
- `toolCallResult.resultDisplay` field names corrected (`fileName` not `filePath`, union type discrimination)

**feature parity with gemini parser:**
- thought/reasoning extraction (separate `thought: true` parts from output text)
- pending tasks extraction from thought parts
- `isError` tracking from `toolCallResult.status` and `functionResponse`
- `diffStat` fallback: count +/- lines from `fileDiff` when `diffStat` absent
- `extractRepoFromCwd` for repo field (was hardcoded to `''`)
- `resultStr` extraction for shell/fetch/mcp categories
- `agentType` extraction for task category

**tool name classification:**
- added all qwen-code tool names: `run_shell_command`, `grep_search`, `edit`, `Shell`, `ListFiles`
- added skip tools: `todo_write`, `exit_plan_mode`, `save_memory`, `skill`, `lsp`
- added legacy migrations: `search_file_content`, `replace`, `SearchFiles`, `FindFiles`, `ReadFolder`

**fixture:**
- storage structure updated to match real format
- added `tool_result` record with `toolCallResult` metadata
- added thought parts and `thoughtsTokenCount`

all 694 tests pass ✅

ref #12 cc @karatechopping
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

Fixes critical bugs in qwen-code parser: corrected storage path from `~/.qwen/tmp/<sha256>` to `~/.qwen/projects/<sanitized-cwd>`, fixed `nativeResumeArgs` to use `--resume <sessionId>`, and corrected `toolCallResult.resultDisplay` field names (`fileName` not `filePath`). Achieves full feature parity with gemini parser by adding thought/reasoning extraction, pending task detection, `isError` tracking, `diffStat` fallback counting, `extractRepoFromCwd`, `resultStr` extraction, and `agentType` extraction. Tool name classification correctly expanded with all qwen-code tool names and legacy migrations.

- **Critical fixes verified**: storage path now matches actual qwen-code structure, parser will find real sessions
- **Registry**: complete registration with all required `ToolAdapter` fields, uses `mapGeminiFlags` for consistency
- **Tool classification**: comprehensive coverage of qwen-code tool names across all canonical sets (SHELL_TOOLS, READ_TOOLS, EDIT_TOOLS, GREP_TOOLS, GLOB_TOOLS, SKIP_TOOLS)
- **Fixture**: realistic test data with correct storage structure, thought parts, `toolCallResult` metadata
- **Env cache invalidation**: properly invalidates index when `QWEN_HOME` changes

Minor style deviations from stated rules (consistent with existing JSONL parsers): raw JSON casts instead of Zod validation, direct slice instead of `trimMessages()` helper, naive diff line counting. None introduce bugs.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor style improvements recommended
- All critical bugs fixed correctly (storage path, resume args, field names). Feature parity implementation matches gemini parser patterns. Tool classification complete. Tests pass (694). Three minor style deviations from rules but consistent with existing codebase patterns (no Zod validation for JSONL, no trimMessages helper, naive diff counting). No logic errors or correctness issues found.
- No files require special attention — all changes follow established patterns
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/parsers/qwen-code.ts | Fixed critical storage path, added thought extraction, pending tasks, diffStat fallback, and full gemini feature parity |
| src/parsers/registry.ts | Registered qwen-code adapter with correct nativeResumeArgs and mapGeminiFlags |
| src/types/tool-names.ts | Added qwen-code to TOOL_NAMES and all qwen-code tool name mappings to canonical sets |
| src/utils/index.ts | Added env fingerprint tracking to invalidate cache when QWEN_HOME or other env vars change |
| src/__tests__/fixtures/index.ts | Added qwen-code fixture with correct storage structure, thought parts, and toolCallResult metadata |

</details>


</details>


<sub>Last reviewed commit: 4ea76c6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->