### PR TITLE
improve handoff parsing, chaining, and banner quality

### DIFF
--- a/src/__tests__/claude-task-reconciliation.test.ts
+++ b/src/__tests__/claude-task-reconciliation.test.ts
@@ -1,0 +1,144 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getPreset } from '../config/index.js';
+import { extractClaudeContext } from '../parsers/claude.js';
+import type { UnifiedSession } from '../types/index.js';
+
+function makeSession(originalPath: string): UnifiedSession {
+  const now = new Date('2026-03-03T00:00:00.000Z');
+  return {
+    id: 'test-session',
+    source: 'claude',
+    cwd: '/tmp',
+    lines: 0,
+    bytes: 0,
+    createdAt: now,
+    updatedAt: now,
+    originalPath,
+  };
+}
+
+function writeJsonl(filePath: string, records: Array<Record<string, unknown>>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, records.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf8');
+}
+
+describe('Claude task reconciliation', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not mark local_bash queue tasks as pending subagents', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-claude-bash-'));
+    tempDirs.push(tmp);
+    const filePath = path.join(tmp, 'session.jsonl');
+
+    writeJsonl(filePath, [
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        content: '{"task_id":"b57b3c5","description":"Watch CI run until completion","task_type":"local_bash"}',
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-03-03T00:00:01.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
+      },
+    ]);
+
+    const ctx = await extractClaudeContext(makeSession(filePath), getPreset('standard'));
+    expect(ctx.pendingTasks).not.toContain('Incomplete subagent: Watch CI run until completion');
+  });
+
+  it('keeps local_agent without terminal evidence as pending when transcript is missing', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-claude-agent-'));
+    tempDirs.push(tmp);
+    const filePath = path.join(tmp, 'session.jsonl');
+
+    writeJsonl(filePath, [
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        content: '{"task_id":"a111111","description":"Explore formatting","task_type":"local_agent"}',
+      },
+    ]);
+
+    const ctx = await extractClaudeContext(makeSession(filePath), getPreset('standard'));
+    expect(ctx.pendingTasks).toContain('Incomplete subagent: Explore formatting');
+  });
+
+  it('uses TaskOutput completion status as terminal evidence', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-claude-taskoutput-'));
+    tempDirs.push(tmp);
+    const filePath = path.join(tmp, 'session.jsonl');
+
+    writeJsonl(filePath, [
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        content: '{"task_id":"a222222","description":"Create docs","task_type":"local_agent"}',
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-03-03T00:00:01.000Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tu-taskoutput', name: 'TaskOutput', input: { task_id: 'a222222' } }],
+        },
+      },
+      {
+        type: 'user',
+        timestamp: '2026-03-03T00:00:02.000Z',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu-taskoutput',
+              content: '<retrieval_status>success</retrieval_status><task_id>a222222</task_id><status>completed</status>',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const ctx = await extractClaudeContext(makeSession(filePath), getPreset('standard'));
+    expect(ctx.pendingTasks).not.toContain('Incomplete subagent: Create docs');
+  });
+
+  it('uses XML task-notification status as terminal evidence', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-claude-tasknotif-'));
+    tempDirs.push(tmp);
+    const filePath = path.join(tmp, 'session.jsonl');
+
+    writeJsonl(filePath, [
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        content: '{"task_id":"a333333","description":"Create architecture docs","task_type":"local_agent"}',
+      },
+      {
+        type: 'user',
+        timestamp: '2026-03-03T00:00:03.000Z',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: '<task-notification><task-id>a333333</task-id><status>completed</status><summary>done</summary></task-notification>',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const ctx = await extractClaudeContext(makeSession(filePath), getPreset('standard'));
+    expect(ctx.pendingTasks).not.toContain('Incomplete subagent: Create architecture docs');
+  });
+});

--- a/src/__tests__/forward-flags.test.ts
+++ b/src/__tests__/forward-flags.test.ts
@@ -62,6 +62,15 @@ describe('cross-tool forwarding', () => {
     expect(resolved.passthroughArgs).toEqual([]);
   });
 
+  it('maps droid approval-mode yolo into skip-permissions-unsafe', () => {
+    const resolved = resolveCrossToolForwarding('droid', {
+      rawArgs: ['--approval-mode', 'yolo'],
+    });
+
+    expect(resolved.mappedArgs).toEqual(['--skip-permissions-unsafe']);
+    expect(resolved.passthroughArgs).toEqual([]);
+  });
+
   it('maps kimi allow-all forwarding into --yolo and preserves mapped args', () => {
     const resolved = resolveCrossToolForwarding('kimi', {
       rawArgs: ['--allow-all', '--add-dir', '/tmp/workspace', '--model', 'kimi-k2.5'],
@@ -74,6 +83,15 @@ describe('cross-tool forwarding', () => {
   it('maps amp yolo-like forwarding into --dangerously-allow-all', () => {
     const resolved = resolveCrossToolForwarding('amp', {
       rawArgs: ['--yolo'],
+    });
+
+    expect(resolved.mappedArgs).toEqual(['--dangerously-allow-all']);
+    expect(resolved.passthroughArgs).toEqual([]);
+  });
+
+  it('maps amp approval-mode yolo into --dangerously-allow-all', () => {
+    const resolved = resolveCrossToolForwarding('amp', {
+      rawArgs: ['--approval-mode', 'yolo'],
     });
 
     expect(resolved.mappedArgs).toEqual(['--dangerously-allow-all']);
@@ -107,25 +125,33 @@ describe('cross-tool forwarding', () => {
     expect(resolved.passthroughArgs).toEqual([]);
   });
 
-  it('applies required default init flags for handoff targets', () => {
-    expect(getDefaultHandoffInitArgs('claude')).toEqual(['--dangerously-skip-permissions']);
-    expect(getDefaultHandoffInitArgs('copilot')).toEqual(['--allow-all']);
-    expect(getDefaultHandoffInitArgs('gemini')).toEqual(['--yolo']);
-    expect(getDefaultHandoffInitArgs('cursor')).toEqual(['--yolo']);
-    expect(getDefaultHandoffInitArgs('droid')).toEqual(['--skip-permissions-unsafe']);
-    expect(getDefaultHandoffInitArgs('kimi')).toEqual(['--yolo']);
-    expect(getDefaultHandoffInitArgs('amp')).toEqual(['--dangerously-allow-all']);
-    expect(getDefaultHandoffInitArgs('kiro')).toEqual(['--trust-all-tools']);
-    expect(getDefaultHandoffInitArgs('crush')).toEqual(['--yolo']);
-    expect(getDefaultHandoffInitArgs('qwen-code')).toEqual(['--yolo']);
+  it('consumes unsupported approval and permission forwarding for opencode', () => {
+    const resolved = resolveCrossToolForwarding('opencode', {
+      rawArgs: ['--approval-mode', 'plan', '--permission-mode', 'plan'],
+    });
+
+    expect(resolved.mappedArgs).toEqual([]);
+    expect(resolved.passthroughArgs).toEqual([]);
+    expect(resolved.warnings).toContain(
+      'OpenCode: auto-approval, permission, and sandbox forwarding flags are not supported and were ignored.',
+    );
+  });
+
+  it('does not apply dangerous default init flags for handoff targets', () => {
+    expect(getDefaultHandoffInitArgs('claude')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('copilot')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('gemini')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('cursor')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('droid')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('kimi')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('amp')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('kiro')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('crush')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('qwen-code')).toEqual([]);
 
     expect(getDefaultHandoffInitArgs('codex')).toEqual([
       '-c',
       'model_reasoning_effort="high"',
-      '--ask-for-approval',
-      'never',
-      '--sandbox',
-      'danger-full-access',
       '-c',
       'model_reasoning_summary="detailed"',
       '-c',
@@ -133,8 +159,25 @@ describe('cross-tool forwarding', () => {
     ]);
   });
 
-  it('keeps codex init configs but drops ask/sandbox defaults when yolo-equivalent is already set', () => {
-    const args = getDefaultHandoffInitArgs('codex', ['--dangerously-bypass-approvals-and-sandbox']);
+  it('keeps codex reasoning defaults when explicit forwarding args are present', () => {
+    const args = getDefaultHandoffInitArgs('codex', [
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--sandbox',
+      'workspace-write',
+    ]);
+
+    expect(args).toEqual([
+      '-c',
+      'model_reasoning_effort="high"',
+      '-c',
+      'model_reasoning_summary="detailed"',
+      '-c',
+      'model_supports_reasoning_summaries=true',
+    ]);
+  });
+
+  it('keeps codex reasoning defaults when approval-mode is explicitly set', () => {
+    const args = getDefaultHandoffInitArgs('codex', ['--approval-mode', 'yolo']);
 
     expect(args).toEqual([
       '-c',
@@ -167,7 +210,7 @@ describe('cross-tool forwarding', () => {
     expect(command).toContain('--search');
   });
 
-  it('includes default yolo flag in gemini command preview when no forwarding args are provided', () => {
+  it('does not add default approval flags to gemini command preview', () => {
     const session: UnifiedSession = {
       id: 'abc123456789',
       source: 'claude',
@@ -182,10 +225,11 @@ describe('cross-tool forwarding', () => {
     const command = getResumeCommand(session, 'gemini');
 
     expect(command).toContain('continues resume abc123456789 --in gemini');
-    expect(command).toContain('--yolo');
+    expect(command).not.toContain('--yolo');
+    expect(command).not.toContain('--approval-mode yolo');
   });
 
-  it('includes default skip-permissions flag in droid command preview when no forwarding args are provided', () => {
+  it('does not add default approval flags to droid command preview', () => {
     const session: UnifiedSession = {
       id: 'abc123456789',
       source: 'claude',
@@ -200,10 +244,10 @@ describe('cross-tool forwarding', () => {
     const command = getResumeCommand(session, 'droid');
 
     expect(command).toContain('continues resume abc123456789 --in droid');
-    expect(command).toContain('--skip-permissions-unsafe');
+    expect(command).not.toContain('--skip-permissions-unsafe');
   });
 
-  it('includes default yolo flag in qwen command preview when no forwarding args are provided', () => {
+  it('does not add default approval flags to qwen command preview', () => {
     const session: UnifiedSession = {
       id: 'abc123456789',
       source: 'claude',
@@ -218,6 +262,7 @@ describe('cross-tool forwarding', () => {
     const command = getResumeCommand(session, 'qwen-code');
 
     expect(command).toContain('continues resume abc123456789 --in qwen-code');
-    expect(command).toContain('--yolo');
+    expect(command).not.toContain('--yolo');
+    expect(command).not.toContain('--approval-mode yolo');
   });
 });

--- a/src/__tests__/shared-utils.test.ts
+++ b/src/__tests__/shared-utils.test.ts
@@ -346,6 +346,25 @@ describe('extractAnthropicToolData', () => {
     expect(summaries[0].name).toBe('mcp__github-server___list-issues');
   });
 
+  it('tracks files modified by mcp__morph__edit_file', () => {
+    const messages: AnthropicMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu1',
+            name: 'mcp__morph__edit_file',
+            input: { path: '/tmp/edited-by-morph.ts', instruction: 'edit file', code_edit: '...' },
+          },
+        ],
+      },
+    ];
+
+    const { filesModified } = extractAnthropicToolData(messages);
+    expect(filesModified).toContain('/tmp/edited-by-morph.ts');
+  });
+
   it('handles empty messages', () => {
     const { summaries, filesModified } = extractAnthropicToolData([]);
     expect(summaries).toEqual([]);
@@ -492,10 +511,10 @@ describe('classifyToolName', () => {
 
   it('returns undefined for skip tools', () => {
     expect(classifyToolName('TodoWrite')).toBeUndefined();
-    expect(classifyToolName('ExitPlanMode')).toBeUndefined();
   });
 
   it('returns mcp for unknown tools', () => {
+    expect(classifyToolName('ExitPlanMode')).toBe('mcp');
     expect(classifyToolName('mcp__github__list_issues')).toBe('mcp');
     expect(classifyToolName('some-custom-tool')).toBe('mcp');
     expect(classifyToolName('unknown_tool')).toBe('mcp');

--- a/src/__tests__/unit-conversions.test.ts
+++ b/src/__tests__/unit-conversions.test.ts
@@ -1427,6 +1427,35 @@ describe('cache/thinking token breakdown rendering', () => {
   });
 });
 
+describe('subagent status rendering', () => {
+  const baseSession: UnifiedSession = {
+    id: 'test-subagent-status',
+    source: 'claude',
+    cwd: '/tmp/test',
+    lines: 10,
+    bytes: 500,
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+    originalPath: '/tmp/test.jsonl',
+  };
+
+  it('renders completed-without-result as success (not warning)', () => {
+    const md = generateHandoffMarkdown(baseSession, [], [], [], [], {
+      subagentResults: [
+        {
+          taskId: 'a1',
+          description: 'Watch CI run until completion',
+          status: 'completed',
+          toolCallCount: 0,
+        },
+      ],
+    });
+
+    expect(md).toContain('✅ Completed');
+    expect(md).not.toContain('⚠️ Completed');
+  });
+});
+
 describe('MCP namespace grouping', () => {
   const baseSession: UnifiedSession = {
     id: 'test-mcp-ns',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,7 @@ program
   .option('--debug', 'Show debug-level logs')
   .option('--config <path>', 'Path to .continues.yml config file')
   .option('--preset <name>', 'Verbosity preset for inspect/dump output: minimal, standard, verbose, full', 'standard')
+  .option('--no-chain', 'Disable compacted-session chaining in handoff extraction')
   .helpOption('-h, --help', 'Display help for command')
   .hook('preAction', () => {
     const opts = program.opts();
@@ -127,7 +128,17 @@ Aliases:
 
 // Default command - Interactive TUI
 program.option('-a, --all', 'Show all sessions globally (skip directory filtering)').action(async (options) => {
-  await interactivePick({ all: options.all, forwardArgs: tailArgs }, cliContext);
+  const globalOptions = program.opts();
+  await interactivePick(
+    {
+      all: options.all,
+      forwardArgs: tailArgs,
+      preset: globalOptions.preset as string | undefined,
+      configPath: globalOptions.config as string | undefined,
+      chain: globalOptions.chain as boolean | undefined,
+    },
+    cliContext,
+  );
 });
 
 // Pick command (explicit TUI)
@@ -142,7 +153,17 @@ program
   .allowExcessArguments(true)
   .action(async (options, command: Command) => {
     const rawForwardArgs = getExtraCommandArgs(command, 0);
-    await interactivePick({ ...options, forwardArgs: [...rawForwardArgs, ...tailArgs] }, cliContext);
+    const globalOptions = program.opts();
+    await interactivePick(
+      {
+        ...options,
+        forwardArgs: [...rawForwardArgs, ...tailArgs],
+        preset: globalOptions.preset as string | undefined,
+        configPath: globalOptions.config as string | undefined,
+        chain: globalOptions.chain as boolean | undefined,
+      },
+      cliContext,
+    );
   });
 
 // List sessions command
@@ -171,7 +192,18 @@ program
   .allowExcessArguments(true)
   .action(async (sessionId, options, command: Command) => {
     const rawForwardArgs = getExtraCommandArgs(command, 1);
-    await resumeCommand(sessionId, options, cliContext, { rawArgs: rawForwardArgs, tailArgs });
+    const globalOptions = program.opts();
+    await resumeCommand(
+      sessionId,
+      {
+        ...options,
+        preset: globalOptions.preset as string | undefined,
+        configPath: globalOptions.config as string | undefined,
+        chain: globalOptions.chain as boolean | undefined,
+      },
+      cliContext,
+      { rawArgs: rawForwardArgs, tailArgs },
+    );
   });
 
 // Scan command
@@ -200,7 +232,17 @@ program
   .option('--limit <number>', 'Limit number of sessions')
   .option('--rebuild', 'Force rebuild session index')
   .action(async (sourceOrAll, directory, options) => {
-    await dumpCommand(sourceOrAll, directory, options, cliContext);
+    const globalOptions = program.opts();
+    await dumpCommand(
+      sourceOrAll,
+      directory,
+      {
+        ...options,
+        configPath: globalOptions.config as string | undefined,
+        chain: globalOptions.chain as boolean | undefined,
+      },
+      cliContext,
+    );
   });
 
 // Inspect a session — parsing diagnostics
@@ -211,8 +253,10 @@ program
   .option('--write-md [path]', 'Write markdown output to file')
   .action(async (sessionId: string, opts: { truncate?: number; writeMd?: string | boolean }) => {
     // Inherit --preset from global options (subcommand duplication causes Commander scoping bug)
-    const globalPreset = program.opts().preset as string | undefined;
-    await inspectSession(sessionId, { ...opts, preset: globalPreset });
+    const globalOptions = program.opts();
+    const globalPreset = globalOptions.preset as string | undefined;
+    const globalChain = globalOptions.chain as boolean | undefined;
+    await inspectSession(sessionId, { ...opts, preset: globalPreset, chain: globalChain });
   });
 
 // Quick resume commands for each tool — generated from the adapter registry

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,15 +12,14 @@ import { createRequire } from 'node:module';
 import * as clack from '@clack/prompts';
 import { Command } from 'commander';
 import { getExtraCommandArgs } from './commands/_shared.js';
+import { dumpCommand } from './commands/dump.js';
+import { inspectSession } from './commands/inspect.js';
 import { listCommand } from './commands/list.js';
 import { interactivePick } from './commands/pick.js';
 import { resumeBySource } from './commands/quick-resume.js';
 import { rebuildCommand } from './commands/rebuild.js';
 import { resumeCommand } from './commands/resume-cmd.js';
-import { inspectSession } from './commands/inspect.js';
 import { scanCommand } from './commands/scan.js';
-import { dumpCommand } from './commands/dump.js';
-import { loadConfig, getPreset, mergeConfig } from './config/index.js';
 import { setLogLevel } from './logger.js';
 import { ALL_TOOLS, adapters, SOURCE_HELP } from './parsers/registry.js';
 
@@ -79,7 +78,7 @@ program
   .option('--verbose', 'Show info-level logs')
   .option('--debug', 'Show debug-level logs')
   .option('--config <path>', 'Path to .continues.yml config file')
-  .option('--preset <name>', 'Verbosity preset: minimal, standard, verbose, full', 'standard')
+  .option('--preset <name>', 'Verbosity preset for inspect/dump output: minimal, standard, verbose, full', 'standard')
   .helpOption('-h, --help', 'Display help for command')
   .hook('preAction', () => {
     const opts = program.opts();
@@ -89,17 +88,38 @@ program
   .addHelpText(
     'after',
     `
-Examples:
-  $ continues                      # Interactive TUI picker
-  $ continues list                 # List all sessions
-  $ continues list --source claude # Filter by source
-  $ continues list --json          # JSON output for scripting
-  $ continues resume abc123        # Resume by ID
-  $ continues resume abc123 --in gemini  # Cross-tool handoff
-  $ continues scan                 # Show session discovery stats
+Quick start:
+  $ continues
+  $ npx continues --preset full
+  $ continues claude 1
 
-Short aliases:
-  cont (binary alias)
+Core workflows:
+  $ continues list
+  $ continues list --source claude --limit 25
+  $ continues list --jsonl | jq '.source'
+  $ continues resume abc123
+  $ continues resume abc123 --in gemini
+  $ continues scan --rebuild
+
+Inspect & export:
+  $ continues inspect abc123 --preset full
+  $ continues inspect abc123 --preset verbose --write-md handoff.md
+  $ continues dump all ./out --preset verbose
+  $ continues dump claude ./out --json --limit 50
+
+Preset guide:
+  minimal  -> shortest output (token-saving / quick skim)
+  standard -> balanced default for daily usage
+  verbose  -> extra context + richer tool activity detail
+  full     -> maximum detail for handoff, debugging, and audits
+
+Power tips:
+  - Use --all to bypass current-directory filtering in pick mode
+  - Forward raw args to target tools after -- (example: continues claude 1 -- --help)
+  - Combine --config .continues.yml with --preset for project defaults + per-run overrides
+
+Aliases:
+  cont -> continues
   ls   -> list
   r    -> resume
 `,
@@ -175,7 +195,7 @@ program
 program
   .command('dump <source|all> <directory>')
   .description('Bulk export sessions to markdown or JSON files')
-  .option('--preset <name>', 'Verbosity preset: minimal, standard, verbose, full', 'standard')
+  .option('--preset <name>', 'Verbosity preset for export detail: minimal, standard, verbose, full', 'standard')
   .option('--json', 'Output as JSON instead of markdown')
   .option('--limit <number>', 'Limit number of sessions')
   .option('--rebuild', 'Force rebuild session index')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,9 @@ process.on('SIGINT', () => {
     } else {
       console.log('\nCancelled.');
     }
-    process.exitCode = 1;
+    if (process.exitCode == null) {
+      process.exitCode = 130;
+    }
   }
 });
 

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -22,6 +22,8 @@ export async function dumpCommand(
     json?: boolean;
     limit?: string;
     rebuild?: boolean;
+    configPath?: string;
+    chain?: boolean;
   },
   context: { isTTY: boolean },
 ): Promise<void> {
@@ -81,7 +83,20 @@ export async function dumpCommand(
     try {
       config = getPreset(presetName);
     } catch {
-      config = loadConfig();
+      config = loadConfig(options.configPath);
+    }
+
+    if (options.chain === false) {
+      config = {
+        ...config,
+        agents: {
+          ...config.agents,
+          claude: {
+            ...config.agents.claude,
+            chainCompactedHistory: false,
+          },
+        },
+      };
     }
 
     // Export sessions

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -626,7 +626,7 @@ function renderTruncated(
  */
 export async function inspectSession(
   sessionIdOrShort: string,
-  opts: { preset?: string; truncate?: number; writeMd?: string | boolean },
+  opts: { preset?: string; truncate?: number; writeMd?: string | boolean; chain?: boolean },
 ): Promise<void> {
   // 1. Find session
   const session = await findSession(sessionIdOrShort);
@@ -643,6 +643,19 @@ export async function inspectSession(
   } catch {
     // Fall back to loaded config if preset name is invalid
     config = loadConfig();
+  }
+
+  if (opts.chain === false) {
+    config = {
+      ...config,
+      agents: {
+        ...config.agents,
+        claude: {
+          ...config.agents.claude,
+          chainCompactedHistory: false,
+        },
+      },
+    };
   }
 
   // 2. Read raw events (format-aware)

--- a/src/commands/pick.ts
+++ b/src/commands/pick.ts
@@ -15,7 +15,16 @@ import { checkSingleToolAutoResume, selectTargetTool, showForwardingWarnings } f
  * Main interactive TUI command
  */
 export async function interactivePick(
-  options: { source?: string; noTui?: boolean; rebuild?: boolean; all?: boolean; forwardArgs?: string[] },
+  options: {
+    source?: string;
+    noTui?: boolean;
+    rebuild?: boolean;
+    all?: boolean;
+    forwardArgs?: string[];
+    preset?: string;
+    configPath?: string;
+    chain?: boolean;
+  },
   context: { isTTY: boolean; supportsColor: boolean; version: string },
 ): Promise<void> {
   try {
@@ -87,7 +96,13 @@ export async function interactivePick(
       clack.outro(`Launching ${targetTool}`);
 
       if (session.cwd) process.chdir(session.cwd);
-      await resume(session, targetTool, 'inline', forwarding);
+      await resume(
+        session,
+        targetTool,
+        'inline',
+        forwarding,
+        { preset: options.preset, configPath: options.configPath, chain: options.chain },
+      );
       return;
     }
 
@@ -233,7 +248,13 @@ export async function interactivePick(
 
     // Change to session's working directory and resume
     if (session.cwd) process.chdir(session.cwd);
-    await resume(session, targetTool, 'inline', forwarding);
+    await resume(
+      session,
+      targetTool,
+      'inline',
+      forwarding,
+      { preset: options.preset, configPath: options.configPath, chain: options.chain },
+    );
   } catch (error) {
     if (clack.isCancel(error)) {
       clack.cancel('Cancelled');

--- a/src/commands/pick.ts
+++ b/src/commands/pick.ts
@@ -2,8 +2,8 @@ import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import { showBanner } from '../display/banner.js';
 import { formatSessionForSelect, sourceColors } from '../display/format.js';
-import { maybePromptGithubStar } from '../display/star-prompt.js';
 import { showNoSessionsHelp } from '../display/help.js';
+import { maybePromptGithubStar } from '../display/star-prompt.js';
 import type { SessionSource, UnifiedSession } from '../types/index.js';
 import type { HandoffForwardingOptions } from '../utils/forward-flags.js';
 import { getAllSessions, getSessionsBySource } from '../utils/index.js';
@@ -26,7 +26,7 @@ export async function interactivePick(
       return;
     }
 
-    showBanner(context.version, context.supportsColor);
+    await showBanner(context.version, context.supportsColor);
     await maybePromptGithubStar();
     clack.intro(chalk.bold('continue') + chalk.cyan.bold('s') + chalk.gray(' — session picker'));
 

--- a/src/commands/pick.ts
+++ b/src/commands/pick.ts
@@ -35,7 +35,8 @@ export async function interactivePick(
       return;
     }
 
-    await showBanner(context.version, context.supportsColor);
+    const bannerCancelled = await showBanner(context.version, context.supportsColor);
+    if (bannerCancelled) return;
     await maybePromptGithubStar();
     clack.intro(chalk.bold('continue') + chalk.cyan.bold('s') + chalk.gray(' — session picker'));
 
@@ -96,13 +97,11 @@ export async function interactivePick(
       clack.outro(`Launching ${targetTool}`);
 
       if (session.cwd) process.chdir(session.cwd);
-      await resume(
-        session,
-        targetTool,
-        'inline',
-        forwarding,
-        { preset: options.preset, configPath: options.configPath, chain: options.chain },
-      );
+      await resume(session, targetTool, 'inline', forwarding, {
+        preset: options.preset,
+        configPath: options.configPath,
+        chain: options.chain,
+      });
       return;
     }
 
@@ -248,13 +247,11 @@ export async function interactivePick(
 
     // Change to session's working directory and resume
     if (session.cwd) process.chdir(session.cwd);
-    await resume(
-      session,
-      targetTool,
-      'inline',
-      forwarding,
-      { preset: options.preset, configPath: options.configPath, chain: options.chain },
-    );
+    await resume(session, targetTool, 'inline', forwarding, {
+      preset: options.preset,
+      configPath: options.configPath,
+      chain: options.chain,
+    });
   } catch (error) {
     if (clack.isCancel(error)) {
       clack.cancel('Cancelled');

--- a/src/commands/resume-cmd.ts
+++ b/src/commands/resume-cmd.ts
@@ -13,7 +13,7 @@ import { selectTargetTool, showForwardingWarnings } from './_shared.js';
  */
 export async function resumeCommand(
   sessionId: string,
-  options: { in?: string; reference?: boolean; noTui?: boolean },
+  options: { in?: string; reference?: boolean; noTui?: boolean; preset?: string; configPath?: string; chain?: boolean },
   context: { isTTY: boolean },
   forwarding?: HandoffForwardingOptions,
 ): Promise<void> {
@@ -48,6 +48,7 @@ export async function resumeCommand(
 
     const target = options.in as SessionSource | undefined;
     const mode = options.reference ? ('reference' as const) : ('inline' as const);
+    const contextOptions = { preset: options.preset, configPath: options.configPath, chain: options.chain };
 
     const forwardingFor = (candidateTarget: SessionSource | undefined): HandoffForwardingOptions | undefined => {
       if (!candidateTarget || candidateTarget === session.source) return undefined;
@@ -67,7 +68,7 @@ export async function resumeCommand(
       console.log();
 
       if (session.cwd) process.chdir(session.cwd);
-      await resume(session, target, mode, effectiveForwarding);
+      await resume(session, target, mode, effectiveForwarding, contextOptions);
       return;
     }
 
@@ -91,7 +92,7 @@ export async function resumeCommand(
       clack.outro(`Launching ${selectedTarget}`);
 
       if (session.cwd) process.chdir(session.cwd);
-      await resume(session, selectedTarget, mode, effectiveForwarding);
+      await resume(session, selectedTarget, mode, effectiveForwarding, contextOptions);
     } else {
       // Target specified, just resume
       const effectiveForwarding = forwardingFor(target);
@@ -105,7 +106,7 @@ export async function resumeCommand(
       console.log();
 
       if (session.cwd) process.chdir(session.cwd);
-      await resume(session, target, mode, effectiveForwarding);
+      await resume(session, target, mode, effectiveForwarding, contextOptions);
     }
   } catch (error) {
     if (clack.isCancel(error)) {

--- a/src/config/verbosity.ts
+++ b/src/config/verbosity.ts
@@ -97,6 +97,9 @@ const ClaudeAgentConfigSchema = z.object({
   parseSubagents: z.boolean().default(true),
   parseToolResultsDir: z.boolean().default(true),
   separateHumanFromToolResults: z.boolean().default(true),
+  chainCompactedHistory: z.boolean().default(true),
+  chainMaxDepth: z.number().int().min(0).default(2),
+  chainSummaryChars: z.number().int().min(0).default(800),
 });
 
 const AgentFlagsSchema = z.record(z.string(), z.union([z.boolean(), z.number(), z.string()]));
@@ -201,6 +204,9 @@ const MINIMAL_PRESET: VerbosityConfig = {
       parseSubagents: false,
       parseToolResultsDir: false,
       separateHumanFromToolResults: false,
+      chainCompactedHistory: true,
+      chainMaxDepth: 1,
+      chainSummaryChars: 300,
     },
   },
 };
@@ -273,6 +279,9 @@ const STANDARD_PRESET: VerbosityConfig = {
       parseSubagents: true,
       parseToolResultsDir: true,
       separateHumanFromToolResults: true,
+      chainCompactedHistory: true,
+      chainMaxDepth: 2,
+      chainSummaryChars: 800,
     },
   },
 };
@@ -345,6 +354,9 @@ const VERBOSE_PRESET: VerbosityConfig = {
       parseSubagents: true,
       parseToolResultsDir: true,
       separateHumanFromToolResults: true,
+      chainCompactedHistory: true,
+      chainMaxDepth: 4,
+      chainSummaryChars: 2000,
     },
   },
 };
@@ -417,6 +429,9 @@ const FULL_PRESET: VerbosityConfig = {
       parseSubagents: true,
       parseToolResultsDir: true,
       separateHumanFromToolResults: true,
+      chainCompactedHistory: true,
+      chainMaxDepth: 8,
+      chainSummaryChars: 5000,
     },
   },
 };

--- a/src/display/banner.ts
+++ b/src/display/banner.ts
@@ -1,10 +1,216 @@
+import { emitKeypressEvents } from 'node:readline';
 import chalk from 'chalk';
+
+type RotatingBannerLine = () => string;
+type KeyPress = { name?: string; ctrl?: boolean };
+
+const TAB_CYCLE_TIMEOUT_MS = 1400;
+const TAB_CYCLE_HINT = chalk.gray('[Tab to cycle]');
+
+const FALLBACK_BANNER_LINE: RotatingBannerLine = () =>
+  `${chalk.gray('💡 Tip:')} ${chalk.gray('Run')} ${chalk.cyan('continues --help')} ${chalk.gray(
+    'for examples and preset recipes.',
+  )}`;
+
+const PRESET_PROMO_LINES: RotatingBannerLine[] = [
+  () =>
+    `${chalk.gray('🎛️ Preset:')} ${chalk.cyan('full')} ${chalk.gray(
+      'is ideal for rich handoff context (npx continues --preset full).',
+    )}`,
+  () =>
+    `${chalk.gray('🎛️ Preset:')} ${chalk.cyan('minimal')} ${chalk.gray(
+      'keeps output compact when you only need the essentials.',
+    )}`,
+  () =>
+    `${chalk.gray('🎛️ Preset:')} ${chalk.cyan('verbose')} ${chalk.gray(
+      'adds deeper tool activity while staying shorter than full.',
+    )}`,
+  () =>
+    `${chalk.gray('🎛️ Preset:')} ${chalk.cyan('standard')} ${chalk.gray(
+      'is balanced for daily resume + inspect flows.',
+    )}`,
+];
+
+const STAR_PROMO_LINES: RotatingBannerLine[] = [
+  () =>
+    `${chalk.bgHex('#FFD93D').black.bold(' ⭐ LOVE CONTINUES? ')} ${chalk
+      .hex('#FFD93D')
+      .bold('Star:')} ${chalk.hex('#00FFC8').bold('github.com/yigitkonur/cli-continues')}`,
+];
+
+const GENERAL_BANNER_LINES: RotatingBannerLine[] = [
+  () =>
+    `${chalk.gray('💡 Tip:')} ${chalk.gray('Use')} ${chalk.cyan('continues inspect <id> --preset full')} ${chalk.gray(
+      'for maximum handoff detail.',
+    )}`,
+  () =>
+    `${chalk.gray('💡 Tip:')} ${chalk.gray('Run')} ${chalk.cyan('continues dump all ./handoffs --preset verbose')} ${chalk.gray(
+      'to export readable archives.',
+    )}`,
+  () =>
+    `${chalk.gray('🧠 Fact:')} ${chalk.gray(
+      'Presets cascade into inspect/dump output, so one flag can tune your whole workflow.',
+    )}`,
+  () =>
+    `${chalk.gray('🧠 Fact:')} ${chalk.gray(
+      'The',
+    )} ${chalk.cyan('cont')} ${chalk.gray('alias is built in — use')} ${chalk.cyan('cont claude')} ${chalk.gray(
+      'for fast quick-resume.',
+    )}`,
+  () =>
+    `${chalk.gray('💡 Tip:')} ${chalk.gray('Pair')} ${chalk.cyan('--config .continues.yml')} ${chalk.gray(
+      'with',
+    )} ${chalk.cyan('--preset')} ${chalk.gray('for per-project defaults + one-off overrides.')}`,
+  () =>
+    `${chalk.gray('💡 Tip:')} ${chalk.gray('Run')} ${chalk.cyan('continues resume <id> --in gemini')} ${chalk.gray(
+      'to hand off a Codex/Claude session cross-tool.',
+    )}`,
+  () =>
+    `${chalk.gray('💡 Tip:')} ${chalk.gray('Use')} ${chalk.cyan('continues list --jsonl | jq')} ${chalk.gray(
+      'when scripting filters around session metadata.',
+    )}`,
+  () =>
+    `${chalk.gray('💡 Tip:')} ${chalk.gray('Try')} ${chalk.cyan('continues scan --rebuild')} ${chalk.gray(
+      'if a freshly-created session is missing from the index.',
+    )}`,
+  () =>
+    `${chalk.gray('💡 Tip:')} ${chalk.gray('Use')} ${chalk.cyan('continues inspect <id> --write-md handoff.md')} ${chalk.gray(
+      'to save a portable handoff file.',
+    )}`,
+  () =>
+    `${chalk.gray('🧠 Fact:')} ${chalk.gray('Use')} ${chalk.cyan('--all')} ${chalk.gray(
+      'to skip CWD filtering and browse every discovered session.',
+    )}`,
+  () =>
+    `${chalk.gray('🧠 Fact:')} ${chalk.gray('You can forward args to target CLIs after')} ${chalk.cyan('--')} ${chalk.gray(
+      '(e.g. continues claude 1 -- --dangerously-skip-permissions).',
+    )}`,
+  () =>
+    `${chalk.gray('🧠 Fact:')} ${chalk.gray('Inspect + dump both honor')} ${chalk.cyan('--preset')} ${chalk.gray(
+      'so detail level stays consistent across tools.',
+    )}`,
+  () =>
+    `${chalk.gray('🧠 Fact:')} ${chalk.gray('Need quick routing?')} ${chalk.cyan('cont claude')} ${chalk.gray(
+      'and',
+    )} ${chalk.cyan('cont codex')} ${chalk.gray('jump straight into recent sessions.')}`,
+];
+
+const ALL_ROTATING_BANNER_LINES: RotatingBannerLine[] = [
+  ...PRESET_PROMO_LINES,
+  ...STAR_PROMO_LINES,
+  ...GENERAL_BANNER_LINES,
+];
+
+function pickRandomLine(lines: RotatingBannerLine[]): RotatingBannerLine {
+  if (lines.length === 0) return FALLBACK_BANNER_LINE;
+  const index = Math.floor(Math.random() * lines.length);
+  return lines[index] ?? lines[0] ?? FALLBACK_BANNER_LINE;
+}
+
+function pickWeightedInitialLine(): RotatingBannerLine {
+  const roll = Math.random();
+  if (roll < 0.5) return pickRandomLine(PRESET_PROMO_LINES); // 50%
+  if (roll < 0.6) return pickRandomLine(STAR_PROMO_LINES); // 10%
+  return pickRandomLine(GENERAL_BANNER_LINES); // 40%
+}
+
+function shuffleLines(lines: RotatingBannerLine[]): RotatingBannerLine[] {
+  const shuffled = [...lines];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const current = shuffled[i];
+    const target = shuffled[j];
+    if (!current || !target) continue;
+    shuffled[i] = target;
+    shuffled[j] = current;
+  }
+  return shuffled;
+}
+
+function createCycleDeck(): RotatingBannerLine[] {
+  const initial = pickWeightedInitialLine();
+  const rest = shuffleLines(ALL_ROTATING_BANNER_LINES.filter((line) => line !== initial));
+  return [initial, ...rest];
+}
+
+function renderLineFromDeck(cycleDeck: RotatingBannerLine[], index: number): string {
+  const lineFactory = cycleDeck[index] ?? cycleDeck[0] ?? FALLBACK_BANNER_LINE;
+  return lineFactory();
+}
+
+async function showRotatingBannerLine(): Promise<void> {
+  const cycleDeck = createCycleDeck();
+  const stdin = process.stdin;
+  const stdout = process.stdout;
+  const canCycle = stdin.isTTY && stdout.isTTY && !process.env.CI && typeof stdin.setRawMode === 'function';
+
+  if (!canCycle) {
+    console.log(`  ${renderLineFromDeck(cycleDeck, 0)}`);
+    console.log();
+    return;
+  }
+
+  let index = 0;
+  let timeout: NodeJS.Timeout | undefined;
+
+  await new Promise<void>((resolve) => {
+    let finished = false;
+
+    const render = (): void => {
+      const line = renderLineFromDeck(cycleDeck, index);
+      stdout.write(`\r\x1B[2K  ${line} ${TAB_CYCLE_HINT}`);
+    };
+
+    const finish = (): void => {
+      if (finished) return;
+      finished = true;
+
+      if (timeout) clearTimeout(timeout);
+      stdin.off('keypress', onKeyPress);
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdout.write('\n\n');
+      resolve();
+    };
+
+    const armTimeout = (): void => {
+      if (timeout) clearTimeout(timeout);
+      timeout = setTimeout(finish, TAB_CYCLE_TIMEOUT_MS);
+    };
+
+    const onKeyPress = (_input: string, key: KeyPress): void => {
+      if (key.ctrl && key.name === 'c') {
+        finish();
+        process.kill(process.pid, 'SIGINT');
+        return;
+      }
+
+      if (key.name === 'tab') {
+        index = (index + 1) % cycleDeck.length;
+        render();
+        armTimeout();
+        return;
+      }
+
+      if (key.name === 'return' || key.name === 'enter' || key.name === 'escape' || key.name === 'space') {
+        finish();
+      }
+    };
+
+    emitKeypressEvents(stdin);
+    stdin.resume();
+    stdin.setRawMode(true);
+    stdin.on('keypress', onKeyPress);
+    render();
+    armTimeout();
+  });
+}
 
 /**
  * ASCII art banner with warm-to-cool gradient and highlighted 's' brand mark.
  * All letters are exactly 4 chars wide, 1-space separated, 3 rows.
  */
-export function showBanner(version: string, supportsColor: boolean): void {
+export async function showBanner(version: string, supportsColor: boolean): Promise<void> {
   if (!supportsColor) return;
 
   // Letter glyphs: [top, mid, bot], each 4 chars wide
@@ -22,15 +228,15 @@ export function showBanner(version: string, supportsColor: boolean): void {
 
   // Gradient: coral -> orange -> gold -> emerald -> blue -> sky -> purple -> mint
   const colors = [
-    chalk.hex('#FF6B6B'),        // c — coral
-    chalk.hex('#FF8E53'),        // o — orange
-    chalk.hex('#FFA940'),        // n — amber
-    chalk.hex('#FFD93D'),        // t — gold
-    chalk.hex('#6BCB77'),        // i — emerald
-    chalk.hex('#4D96FF'),        // n — blue
-    chalk.hex('#38B6FF'),        // u — sky
-    chalk.hex('#6C5CE7'),        // e — purple
-    chalk.hex('#00FFC8').bold,   // s — mint
+    chalk.hex('#FF6B6B'), // c — coral
+    chalk.hex('#FF8E53'), // o — orange
+    chalk.hex('#FFA940'), // n — amber
+    chalk.hex('#FFD93D'), // t — gold
+    chalk.hex('#6BCB77'), // i — emerald
+    chalk.hex('#4D96FF'), // n — blue
+    chalk.hex('#38B6FF'), // u — sky
+    chalk.hex('#6C5CE7'), // e — purple
+    chalk.hex('#00FFC8').bold, // s — mint
   ];
 
   console.log();
@@ -43,9 +249,36 @@ export function showBanner(version: string, supportsColor: boolean): void {
     console.log(line);
   }
   console.log();
-  console.log('  ' + chalk.bold.white('v' + version) + chalk.gray(' — never lose context across ') + chalk.cyan('14 AI coding agents'));
+  console.log(
+    '  ' +
+      chalk.bold.white(`v${version}`) +
+      chalk.gray(' — never lose context across ') +
+      chalk.cyan('14 AI coding agents'),
+  );
   console.log();
-  console.log('  ' + chalk.gray('🔄 Cross-tool handoff') + chalk.gray(' · ') + chalk.gray('🔎 Inspect mode') + chalk.gray(' · ') + chalk.gray('⚙️  YAML config') + chalk.gray(' · ') + chalk.gray('🌍 Env var overrides'));
-  console.log('  ' + chalk.gray('💡 cont <n> or continues <tool> to quick-resume'));
-  console.log();
+  console.log(
+    '  ' +
+      chalk.gray('🔄 Cross-tool handoff') +
+      chalk.gray(' · ') +
+      chalk.gray('🔎 Inspect mode') +
+      chalk.gray(' · ') +
+      chalk.gray('⚙️  YAML config') +
+      chalk.gray(' · ') +
+      chalk.gray('🌍 Env var overrides'),
+  );
+  console.log(
+    '  ' +
+      chalk.gray('🎛️ Try Presets:') +
+      chalk.gray(' · ') +
+      chalk.cyan('minimal') +
+      chalk.gray(' · ') +
+      chalk.cyan('standard') +
+      chalk.gray(' · ') +
+      chalk.cyan('verbose') +
+      chalk.gray(' · ') +
+      chalk.cyan('full') +
+      chalk.gray(' (eg: npx continues --preset full for better context handoff!)'),
+  );
+  console.log(`  ${chalk.gray('💡 cont <n> or continues <tool> to quick-resume')}`);
+  await showRotatingBannerLine();
 }

--- a/src/display/banner.ts
+++ b/src/display/banner.ts
@@ -138,7 +138,7 @@ function renderLineFromDeck(cycleDeck: RotatingBannerLine[], index: number): str
   return lineFactory();
 }
 
-async function showRotatingBannerLine(): Promise<void> {
+async function showRotatingBannerLine(): Promise<boolean> {
   const cycleDeck = createCycleDeck();
   const stdin = process.stdin;
   const stdout = process.stdout;
@@ -147,13 +147,13 @@ async function showRotatingBannerLine(): Promise<void> {
   if (!canCycle) {
     console.log(`  ${renderLineFromDeck(cycleDeck, 0)}`);
     console.log();
-    return;
+    return false;
   }
 
   let index = 0;
   let timeout: NodeJS.Timeout | undefined;
 
-  await new Promise<void>((resolve) => {
+  return await new Promise<boolean>((resolve) => {
     let finished = false;
     let rawModeEnabled = false;
 
@@ -177,7 +177,7 @@ async function showRotatingBannerLine(): Promise<void> {
       finished = true;
       teardownInput();
       stdout.write('\n\n');
-      resolve();
+      resolve(false);
     };
 
     const abortFromCtrlC = (): void => {
@@ -188,7 +188,7 @@ async function showRotatingBannerLine(): Promise<void> {
       if (process.exitCode === undefined) {
         process.exitCode = 130;
       }
-      process.kill(process.pid, 'SIGINT');
+      resolve(true);
     };
 
     const armTimeout = (): void => {
@@ -228,7 +228,7 @@ async function showRotatingBannerLine(): Promise<void> {
         teardownInput();
         console.log(`  ${renderLineFromDeck(cycleDeck, 0)}`);
         console.log();
-        resolve();
+        resolve(false);
       }
     }
   });
@@ -238,8 +238,8 @@ async function showRotatingBannerLine(): Promise<void> {
  * ASCII art banner with warm-to-cool gradient and highlighted 's' brand mark.
  * All letters are exactly 4 chars wide, 1-space separated, 3 rows.
  */
-export async function showBanner(version: string, supportsColor: boolean): Promise<void> {
-  if (!supportsColor) return;
+export async function showBanner(version: string, supportsColor: boolean): Promise<boolean> {
+  if (!supportsColor) return false;
 
   // Letter glyphs: [top, mid, bot], each 4 chars wide
   const glyphs: string[][] = [
@@ -308,5 +308,5 @@ export async function showBanner(version: string, supportsColor: boolean): Promi
       chalk.gray(' (eg: npx continues --preset full for better context handoff!)'),
   );
   console.log(`  ${chalk.gray('💡 cont <n> or continues <tool> to quick-resume')}`);
-  await showRotatingBannerLine();
+  return await showRotatingBannerLine();
 }

--- a/src/display/banner.ts
+++ b/src/display/banner.ts
@@ -155,22 +155,40 @@ async function showRotatingBannerLine(): Promise<void> {
 
   await new Promise<void>((resolve) => {
     let finished = false;
+    let rawModeEnabled = false;
 
     const render = (): void => {
       const line = renderLineFromDeck(cycleDeck, index);
       stdout.write(`\r\x1B[2K  ${line} ${TAB_CYCLE_HINT}`);
     };
 
+    const teardownInput = (): void => {
+      if (timeout) clearTimeout(timeout);
+      stdin.off('keypress', onKeyPress);
+      if (rawModeEnabled) {
+        stdin.setRawMode(false);
+        rawModeEnabled = false;
+      }
+      stdin.pause();
+    };
+
     const finish = (): void => {
       if (finished) return;
       finished = true;
-
-      if (timeout) clearTimeout(timeout);
-      stdin.off('keypress', onKeyPress);
-      stdin.setRawMode(false);
-      stdin.pause();
+      teardownInput();
       stdout.write('\n\n');
       resolve();
+    };
+
+    const abortFromCtrlC = (): void => {
+      if (finished) return;
+      finished = true;
+      teardownInput();
+      stdout.write('\n\n');
+      if (process.exitCode === undefined) {
+        process.exitCode = 130;
+      }
+      process.kill(process.pid, 'SIGINT');
     };
 
     const armTimeout = (): void => {
@@ -180,8 +198,7 @@ async function showRotatingBannerLine(): Promise<void> {
 
     const onKeyPress = (_input: string, key: KeyPress): void => {
       if (key.ctrl && key.name === 'c') {
-        finish();
-        process.kill(process.pid, 'SIGINT');
+        abortFromCtrlC();
         return;
       }
 
@@ -197,12 +214,23 @@ async function showRotatingBannerLine(): Promise<void> {
       }
     };
 
-    emitKeypressEvents(stdin);
-    stdin.resume();
-    stdin.setRawMode(true);
-    stdin.on('keypress', onKeyPress);
-    render();
-    armTimeout();
+    try {
+      emitKeypressEvents(stdin);
+      stdin.resume();
+      stdin.setRawMode(true);
+      rawModeEnabled = true;
+      stdin.on('keypress', onKeyPress);
+      render();
+      armTimeout();
+    } catch {
+      if (!finished) {
+        finished = true;
+        teardownInput();
+        console.log(`  ${renderLineFromDeck(cycleDeck, 0)}`);
+        console.log();
+        resolve();
+      }
+    }
   });
 }
 

--- a/src/parsers/claude.ts
+++ b/src/parsers/claude.ts
@@ -6,7 +6,7 @@ import type { ClaudeMessage } from '../types/schemas.js';
 import { extractTextFromBlocks, isRealUserMessage } from '../utils/content.js';
 import { findFiles } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
-import { generateHandoffMarkdown } from '../utils/markdown.js';
+import { generateHandoffMarkdown, safePath } from '../utils/markdown.js';
 import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
 import {
   type AnthropicMessage,
@@ -127,6 +127,133 @@ interface QueueOperationEntry {
   description: string;
   taskType?: string;
   operation: string;
+  status?: string;
+}
+
+interface TaskStatusEntry {
+  taskId: string;
+  status?: string;
+  taskType?: string;
+  description?: string;
+  source: 'queue' | 'user_notification' | 'task_output';
+}
+
+function extractTagValue(text: string, tags: string[]): string | undefined {
+  for (const tag of tags) {
+    const m = text.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`, 'i'));
+    if (m?.[1]) return m[1].trim();
+  }
+  return undefined;
+}
+
+function extractTaskStatusesFromTaggedText(
+  text: string,
+  source: TaskStatusEntry['source'],
+): TaskStatusEntry[] {
+  const statuses: TaskStatusEntry[] = [];
+  const notificationBlocks = text.match(/<task-notification>[\s\S]*?<\/task-notification>/gi);
+
+  const parseBlock = (block: string): TaskStatusEntry | null => {
+    const taskId = extractTagValue(block, ['task-id', 'task_id']);
+    if (!taskId) return null;
+
+    return {
+      taskId,
+      status: extractTagValue(block, ['status']),
+      taskType: extractTagValue(block, ['task-type', 'task_type']),
+      description: extractTagValue(block, ['summary', 'description']),
+      source,
+    };
+  };
+
+  if (notificationBlocks && notificationBlocks.length > 0) {
+    for (const block of notificationBlocks) {
+      const parsed = parseBlock(block);
+      if (parsed) statuses.push(parsed);
+    }
+    return statuses;
+  }
+
+  const single = parseBlock(text);
+  if (single) statuses.push(single);
+  return statuses;
+}
+
+function extractToolResultText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((item) => {
+      const block = item as Record<string, unknown>;
+      return typeof block?.text === 'string' ? block.text : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function isTerminalTaskStatus(status?: string): boolean {
+  if (!status) return false;
+  const normalized = status.toLowerCase().trim();
+  return new Set(['completed', 'complete', 'success', 'succeeded', 'done', 'failed', 'error', 'killed', 'cancelled', 'canceled', 'timeout', 'timed_out']).has(normalized);
+}
+
+function isCompletedTaskStatus(status?: string): boolean {
+  if (!status) return false;
+  const normalized = status.toLowerCase().trim();
+  return new Set(['completed', 'complete', 'success', 'succeeded', 'done']).has(normalized);
+}
+
+function extractUserTaskNotifications(messages: ClaudeMessage[]): TaskStatusEntry[] {
+  const statuses: TaskStatusEntry[] = [];
+
+  for (const msg of messages) {
+    if (msg.type !== 'user') continue;
+    const content = msg.message?.content;
+    if (typeof content === 'string') {
+      statuses.push(...extractTaskStatusesFromTaggedText(content, 'user_notification'));
+      continue;
+    }
+    if (!Array.isArray(content)) continue;
+
+    for (const block of content) {
+      if (block.type !== 'text' || !block.text) continue;
+      statuses.push(...extractTaskStatusesFromTaggedText(block.text, 'user_notification'));
+    }
+  }
+
+  return statuses;
+}
+
+function extractTaskOutputStatuses(messages: ClaudeMessage[]): TaskStatusEntry[] {
+  const statuses: TaskStatusEntry[] = [];
+  const toolUseById = new Map<string, { name: string }>();
+
+  for (const msg of messages) {
+    const content = msg.message?.content;
+    if (!Array.isArray(content)) continue;
+
+    for (const block of content as Array<Record<string, unknown>>) {
+      if (block.type === 'tool_use') {
+        const id = block.id as string | undefined;
+        const name = block.name as string | undefined;
+        if (id && name) toolUseById.set(id, { name });
+        continue;
+      }
+
+      if (block.type !== 'tool_result') continue;
+      const toolUseId = block.tool_use_id as string | undefined;
+      if (!toolUseId) continue;
+
+      const toolUse = toolUseById.get(toolUseId);
+      if (!toolUse || toolUse.name !== 'TaskOutput') continue;
+
+      const text = extractToolResultText(block.content);
+      if (!text) continue;
+      statuses.push(...extractTaskStatusesFromTaggedText(text, 'task_output'));
+    }
+  }
+
+  return statuses;
 }
 
 /**
@@ -142,6 +269,21 @@ function parseQueueOperations(messages: ClaudeMessage[]): QueueOperationEntry[] 
     const contentStr = (raw.content as string) || '';
     if (!contentStr) continue;
 
+    // XML-style task notifications (or tagged task payloads) often appear here.
+    const taggedStatuses = extractTaskStatusesFromTaggedText(contentStr, 'queue');
+    if (taggedStatuses.length > 0) {
+      for (const status of taggedStatuses) {
+        entries.push({
+          taskId: status.taskId,
+          description: status.description || '',
+          taskType: status.taskType,
+          operation,
+          status: status.status,
+        });
+      }
+      continue;
+    }
+
     try {
       const parsed = JSON.parse(contentStr) as Record<string, unknown>;
       const taskId = (parsed.task_id as string) || '';
@@ -152,10 +294,21 @@ function parseQueueOperations(messages: ClaudeMessage[]): QueueOperationEntry[] 
           description,
           taskType: (parsed.task_type as string) || undefined,
           operation,
+          status: (parsed.status as string) || undefined,
         });
       }
     } catch {
-      logger.debug('claude: malformed queue-operation content', contentStr.slice(0, 100));
+      const taskId = contentStr.match(/"task_id"\s*:\s*"([^"]+)"/)?.[1];
+      if (taskId) {
+        entries.push({
+          taskId,
+          description: contentStr.match(/"description"\s*:\s*"([^"]+)"/)?.[1] || '',
+          taskType: contentStr.match(/"task_type"\s*:\s*"([^"]+)"/)?.[1],
+          operation,
+        });
+      } else {
+        logger.debug('claude: malformed queue-operation content', contentStr.slice(0, 100));
+      }
     }
   }
   return entries;
@@ -180,6 +333,10 @@ function isTerminationMessage(text: string): boolean {
  */
 async function extractSubagentResult(filePath: string): Promise<{ text: string | null; status: 'completed' | 'killed'; toolCallCount: number }> {
   try {
+    if (!fs.existsSync(filePath)) {
+      return { text: null, status: 'killed', toolCallCount: 0 };
+    }
+
     const subMsgs = await readJsonlFile<ClaudeMessage>(filePath);
     let toolCallCount = 0;
     let lastSubstantialText: string | null = null;
@@ -282,6 +439,92 @@ function readToolResultsDir(sessionDir: string): string[] {
   }
 
   return notes;
+}
+
+function hasCompactionCue(messages: ClaudeMessage[]): boolean {
+  if (messages.some((m) => m.isCompactSummary)) return true;
+
+  const continuationPattern = /(continued from a previous conversation|ran out of context|summary below covers|conversation compacted)/i;
+  for (const msg of messages) {
+    if (msg.type !== 'user' && msg.type !== 'assistant') continue;
+    const text = extractTextFromBlocks(msg.message?.content);
+    if (text && continuationPattern.test(text)) return true;
+  }
+
+  return false;
+}
+
+async function extractLatestCompactSummary(filePath: string, maxChars: number): Promise<string | undefined> {
+  const messages = await readJsonlFile<ClaudeMessage>(filePath);
+  let compact: string | undefined;
+  for (const msg of messages) {
+    if (!msg.isCompactSummary || !msg.message?.content) continue;
+    const text = extractTextFromBlocks(msg.message.content);
+    if (text) compact = truncate(text, maxChars);
+  }
+  return compact;
+}
+
+async function resolvePreviousClaudeSessions(session: UnifiedSession, maxDepth: number): Promise<UnifiedSession[]> {
+  if (maxDepth <= 0) return [];
+  const allSessions = await parseClaudeSessions();
+  const candidates = allSessions
+    .filter((s) => s.id !== session.id && s.cwd === session.cwd)
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+
+  const selected: UnifiedSession[] = [];
+  const visited = new Set([session.id]);
+  let cursorTime = session.createdAt.getTime() || session.updatedAt.getTime();
+
+  for (const candidate of candidates) {
+    if (selected.length >= maxDepth) break;
+    if (visited.has(candidate.id)) continue;
+    if (candidate.updatedAt.getTime() > cursorTime) continue;
+
+    selected.push(candidate);
+    visited.add(candidate.id);
+    cursorTime = candidate.createdAt.getTime() || candidate.updatedAt.getTime();
+  }
+
+  return selected;
+}
+
+async function buildChainedHistoryPrefix(
+  session: UnifiedSession,
+  messages: ClaudeMessage[],
+  cfg: VerbosityConfig,
+): Promise<string | undefined> {
+  if (!cfg.agents.claude.chainCompactedHistory) return undefined;
+  if (!hasCompactionCue(messages)) return undefined;
+
+  const previous = await resolvePreviousClaudeSessions(session, cfg.agents.claude.chainMaxDepth);
+  if (previous.length === 0) return undefined;
+
+  const lines: string[] = [
+    '# Previous Session Chain Context',
+    '',
+    'The current Claude session appears compacted; best-effort predecessor sessions are included below.',
+    '',
+    '## Chained Previous Sessions',
+    '',
+  ];
+
+  const ordered = [...previous].reverse(); // oldest → newest for readable timeline
+  for (const [index, prev] of ordered.entries()) {
+    lines.push(`### ${index + 1}. ${prev.id} (${prev.updatedAt.toISOString().slice(0, 16).replace('T', ' ')})`);
+    lines.push(`- **Session file**: \`${safePath(prev.originalPath)}\``);
+    if (prev.summary) {
+      lines.push(`- **Summary**: ${truncate(prev.summary, cfg.agents.claude.chainSummaryChars)}`);
+    }
+
+    const compact = await extractLatestCompactSummary(prev.originalPath, cfg.agents.claude.chainSummaryChars);
+    if (compact) {
+      lines.push(`- **Compact summary**: ${compact}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trim();
 }
 
 /**
@@ -447,11 +690,23 @@ export async function extractClaudeContext(
     // Session dir = {project_dir}/{session_id}/ (not just dirname of the .jsonl)
     const sessionDir = session.originalPath.replace(/\.jsonl$/, '');
     const queueOps = parseQueueOperations(messages);
+    const userTaskStatuses = extractUserTaskNotifications(messages);
+    const taskOutputStatuses = extractTaskOutputStatuses(messages);
 
-    // Track which task_ids completed (have a "dequeue" or "complete" operation)
-    const completedIds = new Set(
-      queueOps.filter((op) => op.operation !== 'enqueue').map((op) => op.taskId),
-    );
+    // Terminal states can come from queue ops, user task notifications, or TaskOutput payloads.
+    const terminalTaskIds = new Set<string>();
+    const completedTaskIds = new Set<string>();
+
+    for (const op of queueOps) {
+      if (op.operation !== 'enqueue') terminalTaskIds.add(op.taskId);
+      if (isTerminalTaskStatus(op.status)) terminalTaskIds.add(op.taskId);
+      if (isCompletedTaskStatus(op.status)) completedTaskIds.add(op.taskId);
+    }
+
+    for (const statusEntry of [...userTaskStatuses, ...taskOutputStatuses]) {
+      if (isTerminalTaskStatus(statusEntry.status)) terminalTaskIds.add(statusEntry.taskId);
+      if (isCompletedTaskStatus(statusEntry.status)) completedTaskIds.add(statusEntry.taskId);
+    }
 
     // Deduplicate: keep only unique task_ids (first enqueue wins for description)
     const seen = new Set<string>();
@@ -465,9 +720,14 @@ export async function extractClaudeContext(
     let subagentCount = 0;
     for (const task of uniqueTasks) {
       if (subagentCount >= cfg.task.maxSamples) break;
+      // Only local_agent tasks are backed by subagent transcript files.
+      if (task.taskType && task.taskType !== 'local_agent') continue;
 
       const subagentPath = path.join(sessionDir, 'subagents', `agent-${task.taskId}.jsonl`);
-      const { text, status, toolCallCount } = await extractSubagentResult(subagentPath);
+      const { text, status: extractedStatus, toolCallCount } = await extractSubagentResult(subagentPath);
+      const status = !text && completedTaskIds.has(task.taskId)
+        ? 'completed'
+        : extractedStatus;
 
       // Always populate structured subagentResults
       if (!sessionNotes.subagentResults) sessionNotes.subagentResults = [];
@@ -484,7 +744,7 @@ export async function extractClaudeContext(
         if (!sessionNotes.reasoning) sessionNotes.reasoning = [];
         sessionNotes.reasoning.push(`Subagent "${task.description}": ${truncate(text, cfg.task.subagentResultChars)}`);
         subagentCount++;
-      } else if (!completedIds.has(task.taskId)) {
+      } else if (!terminalTaskIds.has(task.taskId)) {
         // Incomplete/killed subagent — add to pending tasks
         if (cfg.pendingTasks.extractFromSubagents && pendingTasks.length < cfg.pendingTasks.maxTasks) {
           pendingTasks.push(`Incomplete subagent: ${task.description}`);
@@ -525,22 +785,25 @@ export async function extractClaudeContext(
   }
 
   const finalMessages = recentMessages.slice(-cfg.recentMessages);
+  const dedupedPendingTasks = Array.from(new Set(pendingTasks)).slice(0, cfg.pendingTasks.maxTasks);
 
-  const markdown = generateHandoffMarkdown(
+  const baseMarkdown = generateHandoffMarkdown(
     session,
     finalMessages,
     filesModified,
-    pendingTasks,
+    dedupedPendingTasks,
     toolSummaries,
     sessionNotes,
     cfg,
   );
+  const chainPrefix = await buildChainedHistoryPrefix(session, messages, cfg);
+  const markdown = chainPrefix ? `${chainPrefix}\n\n---\n\n${baseMarkdown}` : baseMarkdown;
 
   return {
     session,
     recentMessages: finalMessages,
     filesModified,
-    pendingTasks,
+    pendingTasks: dedupedPendingTasks,
     toolSummaries,
     sessionNotes,
     markdown,

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -274,18 +274,42 @@ function mapDroidFlags(context: ForwardFlagMapContext): ForwardMapResult {
   const fullAutoOccurrences = context.all('fullAuto');
   const askOccurrences = context.all('askForApproval');
   const sandboxOccurrences = context.all('sandbox');
+  const approvalModeOccurrences = context.all('approvalMode');
+  const approvalMode = context.latestString('approvalMode')?.toLowerCase();
   const askForApproval = context.latestString('askForApproval')?.toLowerCase();
 
-  if (autoOccurrences.length > 0 || fullAutoOccurrences.length > 0 || askForApproval === 'never') {
-    context.consume(...autoOccurrences, ...fullAutoOccurrences, ...askOccurrences, ...sandboxOccurrences);
+  if (
+    autoOccurrences.length > 0 ||
+    fullAutoOccurrences.length > 0 ||
+    askForApproval === 'never' ||
+    approvalMode === 'yolo'
+  ) {
+    context.consume(
+      ...autoOccurrences,
+      ...fullAutoOccurrences,
+      ...askOccurrences,
+      ...sandboxOccurrences,
+      ...approvalModeOccurrences,
+    );
     args.push('--skip-permissions-unsafe');
 
     if (askOccurrences.length > 0 && askForApproval && askForApproval !== 'never') {
       warnings.push('Droid precedence: auto-approve mapping overrides unsupported ask-for-approval values.');
     }
-  } else if (askOccurrences.length > 0 || sandboxOccurrences.length > 0) {
-    context.consume(...askOccurrences, ...sandboxOccurrences);
-    warnings.push('Droid: --ask-for-approval and --sandbox are not supported by droid exec and were ignored.');
+
+    if (approvalModeOccurrences.length > 0 && approvalMode && approvalMode !== 'yolo') {
+      warnings.push('Droid: --approval-mode is not supported by droid exec and was ignored.');
+    }
+  } else if (askOccurrences.length > 0 || sandboxOccurrences.length > 0 || approvalModeOccurrences.length > 0) {
+    context.consume(...askOccurrences, ...sandboxOccurrences, ...approvalModeOccurrences);
+
+    if (askOccurrences.length > 0 || sandboxOccurrences.length > 0) {
+      warnings.push('Droid: --ask-for-approval and --sandbox are not supported by droid exec and were ignored.');
+    }
+
+    if (approvalModeOccurrences.length > 0 && approvalMode !== 'yolo') {
+      warnings.push('Droid: --approval-mode is not supported by droid exec and was ignored.');
+    }
   }
 
   const model = context.latestString('model');
@@ -311,15 +335,28 @@ function mapOpenCodeFlags(context: ForwardFlagMapContext): ForwardMapResult {
   const fullAutoOccurrences = context.all('fullAuto');
   const askOccurrences = context.all('askForApproval');
   const sandboxOccurrences = context.all('sandbox');
+  const approvalModeOccurrences = context.all('approvalMode');
+  const permissionModeOccurrences = context.all('permissionMode');
 
   if (
     autoOccurrences.length > 0 ||
     fullAutoOccurrences.length > 0 ||
     askOccurrences.length > 0 ||
-    sandboxOccurrences.length > 0
+    sandboxOccurrences.length > 0 ||
+    approvalModeOccurrences.length > 0 ||
+    permissionModeOccurrences.length > 0
   ) {
-    context.consume(...autoOccurrences, ...fullAutoOccurrences, ...askOccurrences, ...sandboxOccurrences);
-    warnings.push('OpenCode: auto-approval and sandbox forwarding flags are not supported and were ignored.');
+    context.consume(
+      ...autoOccurrences,
+      ...fullAutoOccurrences,
+      ...askOccurrences,
+      ...sandboxOccurrences,
+      ...approvalModeOccurrences,
+      ...permissionModeOccurrences,
+    );
+    warnings.push(
+      'OpenCode: auto-approval, permission, and sandbox forwarding flags are not supported and were ignored.',
+    );
   }
 
   const model = context.latestString('model');
@@ -351,18 +388,42 @@ function mapAmpFlags(context: ForwardFlagMapContext): ForwardMapResult {
   const fullAutoOccurrences = context.all('fullAuto');
   const askOccurrences = context.all('askForApproval');
   const sandboxOccurrences = context.all('sandbox');
+  const approvalModeOccurrences = context.all('approvalMode');
+  const approvalMode = context.latestString('approvalMode')?.toLowerCase();
   const askForApproval = context.latestString('askForApproval')?.toLowerCase();
 
-  if (autoOccurrences.length > 0 || fullAutoOccurrences.length > 0 || askForApproval === 'never') {
-    context.consume(...autoOccurrences, ...fullAutoOccurrences, ...askOccurrences, ...sandboxOccurrences);
+  if (
+    autoOccurrences.length > 0 ||
+    fullAutoOccurrences.length > 0 ||
+    askForApproval === 'never' ||
+    approvalMode === 'yolo'
+  ) {
+    context.consume(
+      ...autoOccurrences,
+      ...fullAutoOccurrences,
+      ...askOccurrences,
+      ...sandboxOccurrences,
+      ...approvalModeOccurrences,
+    );
     args.push('--dangerously-allow-all');
 
     if (askOccurrences.length > 0 && askForApproval && askForApproval !== 'never') {
       warnings.push('Amp precedence: auto-approve mapping overrides unsupported ask-for-approval values.');
     }
-  } else if (askOccurrences.length > 0 || sandboxOccurrences.length > 0) {
-    context.consume(...askOccurrences, ...sandboxOccurrences);
-    warnings.push('Amp: --ask-for-approval and --sandbox are not supported and were ignored.');
+
+    if (approvalModeOccurrences.length > 0 && approvalMode && approvalMode !== 'yolo') {
+      warnings.push('Amp: --approval-mode is not supported and was ignored.');
+    }
+  } else if (askOccurrences.length > 0 || sandboxOccurrences.length > 0 || approvalModeOccurrences.length > 0) {
+    context.consume(...askOccurrences, ...sandboxOccurrences, ...approvalModeOccurrences);
+
+    if (askOccurrences.length > 0 || sandboxOccurrences.length > 0) {
+      warnings.push('Amp: --ask-for-approval and --sandbox are not supported and were ignored.');
+    }
+
+    if (approvalModeOccurrences.length > 0 && approvalMode) {
+      warnings.push('Amp: --approval-mode is not supported and was ignored.');
+    }
   }
 
   return { mappedArgs: args, warnings };

--- a/src/types/tool-names.ts
+++ b/src/types/tool-names.ts
@@ -101,8 +101,6 @@ export const ASK_TOOLS: ReadonlySet<string> = new Set(['AskUserQuestion', 'reque
 /** Tools to skip — internal bookkeeping, no useful handoff context */
 export const SKIP_TOOLS: ReadonlySet<string> = new Set([
   'TaskStop',
-  'ExitPlanMode',
-  'exit_plan_mode',
   'TodoWrite',
   'todo_write',
   'SaveMemory',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { logger } from '../logger.js';
 import { adapters } from '../parsers/registry.js';
+import type { VerbosityConfig } from '../config/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 import { homeDir } from './parser-helpers.js';
 
@@ -185,10 +186,10 @@ export async function findSession(id: string): Promise<UnifiedSession | null> {
 /**
  * Extract context from a session based on its source
  */
-export async function extractContext(session: UnifiedSession): Promise<SessionContext> {
+export async function extractContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const adapter = adapters[session.source];
   if (!adapter) throw new Error(`Unknown session source: ${session.source}`);
-  return adapter.extractContext(session);
+  return adapter.extractContext(session, config);
 }
 
 /**

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -722,6 +722,8 @@ function renderSubagentResults(results: SubagentResult[], config: VerbosityConfi
       for (const line of text.split('\n')) {
         lines.push(`> ${line}`);
       }
+    } else if (r.status === 'completed') {
+      lines.push('> ✅ Completed');
     } else {
       // Non-completed: show status
       lines.push(`> \u26a0\ufe0f ${capitalize(r.status)}`);

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -1,6 +1,8 @@
 import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset, loadConfig } from '../config/index.js';
 import { logger } from '../logger.js';
 import { ALL_TOOLS, adapters } from '../parsers/registry.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
@@ -14,6 +16,12 @@ import { extractContext, saveContext } from './index.js';
 import { getSourceLabels, safePath } from './markdown.js';
 import { IS_WINDOWS, WHICH_CMD } from './platform.js';
 
+export interface HandoffContextOptions {
+  preset?: string;
+  configPath?: string;
+  chain?: boolean;
+}
+
 /**
  * Resolve mapped + passthrough forward args for cross-tool launches.
  */
@@ -23,10 +31,6 @@ export function resolveCrossToolForwarding(
 ): ForwardResolution {
   const adapter = adapters[target];
   return resolveTargetForwarding(target, adapter?.mapHandoffFlags, options);
-}
-
-function hasOption(args: string[], ...flags: string[]): boolean {
-  return args.some((token) => flags.some((flag) => token === flag || token.startsWith(`${flag}=`)));
 }
 
 function hasConfigOverride(args: string[], key: string): boolean {
@@ -55,67 +59,51 @@ function hasConfigOverride(args: string[], key: string): boolean {
 }
 
 export function getDefaultHandoffInitArgs(target: SessionSource, forwardedArgs: string[] = []): string[] {
-  switch (target) {
-    case 'claude': {
-      return hasOption(forwardedArgs, '--dangerously-skip-permissions') ? [] : ['--dangerously-skip-permissions'];
-    }
-    case 'codex': {
-      const defaults: string[] = [];
+  if (target !== 'codex') return [];
 
-      if (!hasConfigOverride(forwardedArgs, 'model_reasoning_effort')) {
-        defaults.push('-c', 'model_reasoning_effort="high"');
-      }
+  const defaults: string[] = [];
 
-      const hasUnsafeAuto = hasOption(forwardedArgs, '--dangerously-bypass-approvals-and-sandbox', '--full-auto');
-
-      if (!hasUnsafeAuto && !hasOption(forwardedArgs, '--ask-for-approval', '-a')) {
-        defaults.push('--ask-for-approval', 'never');
-      }
-
-      if (!hasUnsafeAuto && !hasOption(forwardedArgs, '--sandbox', '-s')) {
-        defaults.push('--sandbox', 'danger-full-access');
-      }
-
-      if (!hasConfigOverride(forwardedArgs, 'model_reasoning_summary')) {
-        defaults.push('-c', 'model_reasoning_summary="detailed"');
-      }
-
-      if (!hasConfigOverride(forwardedArgs, 'model_supports_reasoning_summaries')) {
-        defaults.push('-c', 'model_supports_reasoning_summaries=true');
-      }
-
-      return defaults;
-    }
-    case 'copilot': {
-      return hasOption(forwardedArgs, '--allow-all', '--yolo') ? [] : ['--allow-all'];
-    }
-    case 'gemini': {
-      return hasOption(forwardedArgs, '--yolo', '-y', '--approval-mode') ? [] : ['--yolo'];
-    }
-    case 'cursor': {
-      return hasOption(forwardedArgs, '--yolo', '--force', '-f') ? [] : ['--yolo'];
-    }
-    case 'droid': {
-      return hasOption(forwardedArgs, '--skip-permissions-unsafe', '--auto') ? [] : ['--skip-permissions-unsafe'];
-    }
-    case 'kimi': {
-      return hasOption(forwardedArgs, '--yolo', '-y', '--yes') ? [] : ['--yolo'];
-    }
-    case 'amp': {
-      return hasOption(forwardedArgs, '--dangerously-allow-all') ? [] : ['--dangerously-allow-all'];
-    }
-    case 'kiro': {
-      return hasOption(forwardedArgs, '--trust-all-tools') ? [] : ['--trust-all-tools'];
-    }
-    case 'crush': {
-      return hasOption(forwardedArgs, '--yolo', '-y') ? [] : ['--yolo'];
-    }
-    case 'qwen-code': {
-      return hasOption(forwardedArgs, '--yolo', '-y', '--approval-mode') ? [] : ['--yolo'];
-    }
-    default:
-      return [];
+  if (!hasConfigOverride(forwardedArgs, 'model_reasoning_effort')) {
+    defaults.push('-c', 'model_reasoning_effort="high"');
   }
+
+  if (!hasConfigOverride(forwardedArgs, 'model_reasoning_summary')) {
+    defaults.push('-c', 'model_reasoning_summary="detailed"');
+  }
+
+  if (!hasConfigOverride(forwardedArgs, 'model_supports_reasoning_summaries')) {
+    defaults.push('-c', 'model_supports_reasoning_summaries=true');
+  }
+
+  return defaults;
+}
+
+function resolveHandoffConfig(options?: HandoffContextOptions): VerbosityConfig {
+  const loaded = loadConfig(options?.configPath);
+
+  let config = loaded;
+  if (options?.preset) {
+    try {
+      config = getPreset(options.preset);
+    } catch {
+      // Keep loaded config when an invalid preset is provided.
+    }
+  }
+
+  if (options?.chain === false) {
+    config = {
+      ...config,
+      agents: {
+        ...config.agents,
+        claude: {
+          ...config.agents.claude,
+          chainCompactedHistory: false,
+        },
+      },
+    };
+  }
+
+  return config;
 }
 
 /**
@@ -136,8 +124,9 @@ export async function crossToolResume(
   target: SessionSource,
   mode: 'inline' | 'reference' = 'inline',
   forwarding?: HandoffForwardingOptions,
+  contextOptions?: HandoffContextOptions,
 ): Promise<void> {
-  const context = await extractContext(session);
+  const context = await extractContext(session, resolveHandoffConfig(contextOptions));
   const cwd = session.cwd || process.cwd();
 
   // Always save handoff file to project directory (for sandboxed tools like Gemini)
@@ -242,6 +231,7 @@ export async function resume(
   target?: SessionSource,
   mode: 'inline' | 'reference' = 'inline',
   forwarding?: HandoffForwardingOptions,
+  contextOptions?: HandoffContextOptions,
 ): Promise<void> {
   const actualTarget = target || session.source;
 
@@ -250,7 +240,7 @@ export async function resume(
     await nativeResume(session);
   } else {
     // Different tool - use cross-tool injection
-    await crossToolResume(session, actualTarget, mode, forwarding);
+    await crossToolResume(session, actualTarget, mode, forwarding, contextOptions);
   }
 }
 

--- a/src/utils/tool-extraction.ts
+++ b/src/utils/tool-extraction.ts
@@ -334,6 +334,15 @@ export function extractAnthropicToolData(
             ...(result ? { result: result.slice(0, config.mcp.resultChars) } : {}),
           };
           collector.add(name, mcpSummary(name, JSON.stringify(input).slice(0, config.mcp.paramChars), result?.slice(0, 80)), { data });
+
+          // Some MCP tools mutate local files (e.g. mcp__morph__edit_file).
+          // Track those paths in filesModified so handoff reflects all edits.
+          if (name === 'mcp__morph__edit_file') {
+            const mcpPath = (input.path as string) || (input.file_path as string) || '';
+            if (mcpPath) {
+              collector.trackFile(mcpPath);
+            }
+          }
         }
       } else {
         // Generic/unknown tool — treat as MCP-like


### PR DESCRIPTION
## what changed
- improved claude handoff parsing so important events are no longer dropped (including exitplanmode and richer task status reconciliation)
- fixed file tracking for `mcp__morph__edit_file` so modified-file reporting is complete
- improved subagent result rendering and pending-task filtering to remove false positives
- added compacted-session chaining by default, with `--no-chain` as an explicit opt-out
- threaded preset/config behavior through resume, pick, inspect, and dump flows
- added and updated tests for reconciliation, extraction, and rendering behavior

## why
the goal was to make claude -> codex handoff context much more reliable and higher-signal by fixing missing event coverage, reducing misleading status output, and making verbosity/chaining behavior predictable.

## verification
- `pnpm vitest` (9 files, 715 tests passed)
- `pnpm build`
- `node dist/cli.js inspect 1027312a-9493-49c8-83ba-a925afbf3ab4 --write-md /tmp/codex-output-chain-on.md`
- `node dist/cli.js --no-chain inspect 1027312a-9493-49c8-83ba-a925afbf3ab4 --write-md /tmp/codex-output-chain-off.md`
- verified expected inspection signals:
  - tool calls: `633`
  - files modified: `38`
  - includes `src/tools/send-message.ts`
  - no false pending `watch ci run until completion`
  - no false `⚠️ completed`
  - chain context present by default and absent with `--no-chain`
