### PR TITLE
fix: resolve Windows Cursor cwd slug path conversion

### DIFF
--- a/src/__tests__/cwd-from-slug.test.ts
+++ b/src/__tests__/cwd-from-slug.test.ts
@@ -1,0 +1,31 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+import { cwdFromSlug } from '../utils/slug.js';
+
+describe('cwdFromSlug', () => {
+  const itWindows = process.platform === 'win32' ? it : it.skip;
+
+  itWindows('resolves Windows drive-letter slugs using existing path', () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-slug-'));
+    const target = path.join(base, 'project-alpha');
+    fs.mkdirSync(target, { recursive: true });
+
+    const normalized = target.replace(/\\/g, '/');
+    const slug = normalized.replace(':', '').replace(/[/.]/g, '-');
+    const resolved = cwdFromSlug(slug).replace(/\\/g, '/');
+
+    expect(resolved.toLowerCase()).toBe(normalized.toLowerCase());
+
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+
+  it('falls back to drive-letter path format when no candidate exists', () => {
+    expect(cwdFromSlug('D-Workspace-project-alpha')).toBe('D:/Workspace/project/alpha');
+  });
+
+  it('keeps Unix fallback behavior for non-drive slugs', () => {
+    expect(cwdFromSlug('Users-alice-my-project')).toBe('/Users/alice/my/project');
+  });
+});

--- a/src/__tests__/cwd-from-slug.test.ts
+++ b/src/__tests__/cwd-from-slug.test.ts
@@ -21,8 +21,13 @@ describe('cwdFromSlug', () => {
     fs.rmSync(base, { recursive: true, force: true });
   });
 
-  it('falls back to drive-letter path format when no candidate exists', () => {
+  itWindows('falls back to drive-letter path format when no candidate exists', () => {
     expect(cwdFromSlug('D-Workspace-project-alpha')).toBe('D:/Workspace/project/alpha');
+  });
+
+  it('falls back to Unix path format for drive-letter-like slugs on non-Windows', () => {
+    if (process.platform === 'win32') return;
+    expect(cwdFromSlug('D-Workspace-project-alpha')).toBe('/D/Workspace/project/alpha');
   });
 
   it('keeps Unix fallback behavior for non-drive slugs', () => {

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { IS_WINDOWS } from './platform.js';
 
 /**
  * Derive cwd from a slug directory name using recursive backtracking.
@@ -11,13 +12,30 @@ import * as fs from 'fs';
 export function cwdFromSlug(slug: string): string {
   const parts = slug.split('-');
   let best: string | null = null;
+  const isDriveSlug = parts.length > 0 && /^[A-Za-z]$/.test(parts[0] || '');
+
+  function candidatePaths(segments: string[]): string[] {
+    const unixPath = '/' + segments.join('/');
+    if (segments.length > 0 && /^[A-Za-z]$/.test(segments[0] || '')) {
+      const drive = segments[0].toUpperCase();
+      const rest = segments.slice(1).join('/');
+      const winPath = rest ? `${drive}:/${rest}` : `${drive}:/`;
+      // On Windows prefer drive-letter paths; on Unix keep legacy order.
+      return IS_WINDOWS ? [winPath, unixPath] : [unixPath, winPath];
+    }
+    return [unixPath];
+  }
 
   function resolve(idx: number, segments: string[]): void {
     if (best) return; // already found a match
 
     if (idx >= parts.length) {
-      const p = '/' + segments.join('/');
-      if (fs.existsSync(p)) best = p;
+      for (const p of candidatePaths(segments)) {
+        if (fs.existsSync(p)) {
+          best = p;
+          break;
+        }
+      }
       return;
     }
 
@@ -41,7 +59,15 @@ export function cwdFromSlug(slug: string): string {
   }
 
   resolve(0, []);
-  return best || '/' + slug.replace(/-/g, '/');
+  if (best) return best;
+
+  if (isDriveSlug) {
+    const drive = parts[0].toUpperCase();
+    const rest = parts.slice(1).join('/');
+    return rest ? `${drive}:/${rest}` : `${drive}:/`;
+  }
+
+  return '/' + slug.replace(/-/g, '/');
 }
 
 /**

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -61,7 +61,7 @@ export function cwdFromSlug(slug: string): string {
   resolve(0, []);
   if (best) return best;
 
-  if (isDriveSlug) {
+  if (isDriveSlug && IS_WINDOWS) {
     const drive = parts[0].toUpperCase();
     const rest = parts.slice(1).join('/');
     return rest ? `${drive}:/${rest}` : `${drive}:/`;


### PR DESCRIPTION
## Summary
- fix Cursor slug-to-cwd resolution on Windows by supporting drive-letter candidates (e.g. `D:/...`) instead of falling back to invalid `/D/...`
- preserve existing Unix behavior while preferring Windows drive paths on Windows hosts
- add regression tests for Windows drive-path resolution and fallback behavior

## Test plan
- [x] `pnpm test -- cwd-from-slug cwd-matching`
- [x] `pnpm build`
- [x] `tsx src/cli.ts rebuild` and verify target Cursor session now resolves to `D:/...` instead of `/D/...`
- [x] `tsx src/cli.ts resume <session-id> --in cursor` no longer throws `ENOENT chdir ... -> '/D/...'`

Closes #35
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

This PR fixes `cwdFromSlug()` so that Cursor sessions on Windows resolve their working directory to the correct `D:/…` drive path instead of the erroneous `/D/…` Unix form. The approach — adding a `candidatePaths()` helper that generates both Unix and Windows path candidates and checking them in platform-preferred order — is clean and fits the existing utility. There is one logic regression: the final fallback (when no candidate path exists on disk) produces a Windows drive path unconditionally, even on Unix, because the `isDriveSlug` guard is missing an `IS_WINDOWS` check. The accompanying test for that fallback also asserts Windows-only behaviour without being gated to Windows, so it will mask the bug on Unix CI rather than catch it.

- **Bug**: `isDriveSlug` fallback on line 64 of `slug.ts` should be `if (isDriveSlug && IS_WINDOWS)` — without this, any Unix slug starting with a single letter silently resolves to a Windows-style path.
- **Test**: The unconditional `'falls back to drive-letter path format…'` test asserts `D:/…` on Unix; it should use `itWindows` (or split into two platform-aware cases) to avoid masking the above regression.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge on Windows-only environments; carries a Unix regression in the no-match fallback path.
- The Windows fix is correct and the search logic is sound, but the fallback branch is not platform-gated, silently breaking Unix users whose slugs start with a single letter. The test that was meant to document this behaviour actually hides the bug by asserting the wrong expectation unconditionally.
- Both `src/utils/slug.ts` (fallback guard) and `src/__tests__/cwd-from-slug.test.ts` (platform-aware assertion) need the one-line fix before merging.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/slug.ts | Windows drive-path support added via `candidatePaths()` and `isDriveSlug`; fallback for the no-match case is not gated by `IS_WINDOWS`, regressing Unix behaviour for single-letter-prefix slugs. |
| src/__tests__/cwd-from-slug.test.ts | New test file; Windows-specific path test is correctly gated, but the drive-letter fallback test runs unconditionally and asserts Windows-only behaviour on Unix. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["cwdFromSlug(slug)"] --> B["split slug on '-'"]
    B --> C["isDriveSlug = parts[0] is single letter"]
    C --> D["resolve(0, []) — recursive backtrack"]
    D -->|"idx >= parts.length"| E["candidatePaths(segments)"]
    E -->|"IS_WINDOWS"| F["[winPath, unixPath]"]
    E -->|"Unix"| G["[unixPath, winPath]"]
    F & G --> H{"fs.existsSync(p)?"}
    H -->|"yes"| I["best = p ✅"]
    H -->|"no — try next"| H
    D -->|"try dash as / , . , or -"| D
    I --> Z["return best"]
    D -->|"no match found"| J{"isDriveSlug?"}
    J -->|"yes ⚠️ (not gated by IS_WINDOWS)"| K["return D:/…  ← regression on Unix"]
    J -->|"no"| L["return /slug/with/slashes"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/utils/slug.ts
Line: 64-68

Comment:
**`isDriveSlug` fallback not gated by `IS_WINDOWS` — Unix regression**

The fallback converts single-letter-prefix slugs to `D:/…` even on Unix. Before this PR the fallback was always `'/' + slug.replace(/-/g, '/')`, so a Unix path like `/D/workspace/project` was produced correctly. Now any Unix slug whose first segment happens to be a single letter (e.g. a project literally at `/D/…`) silently returns a Windows-style path instead.

The `candidatePaths()` search already handles both orderings correctly per platform — the only broken case is when *no existing path is found*. The fix is a one-word gate:

```suggestion
  if (isDriveSlug && IS_WINDOWS) {
    const drive = parts[0].toUpperCase();
    const rest = parts.slice(1).join('/');
    return rest ? `${drive}:/${rest}` : `${drive}:/`;
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/__tests__/cwd-from-slug.test.ts
Line: 24-26

Comment:
**Fallback test asserts Windows behaviour on all platforms**

This test runs unconditionally on Unix CI and currently "passes" only because the fallback bug above isn't gated. Once that bug is fixed, the test will fail on Unix (where the correct fallback is `/D/Workspace/project/alpha`). Mirror the Windows-only guard used in the test above, or make the expectation platform-aware:

```suggestion
  itWindows('falls back to drive-letter path format when no candidate exists', () => {
    expect(cwdFromSlug('D-Workspace-project-alpha')).toBe('D:/Workspace/project/alpha');
  });
```

Then add a Unix counterpart:
```ts
it('falls back to Unix path for single-letter-prefix slug on non-Windows', () => {
  if (process.platform !== 'win32') {
    expect(cwdFromSlug('D-Workspace-project-alpha')).toBe('/D/Workspace/project/alpha');
  }
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 178b7fc</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->