### PR TITLE
fix(codex): handle huge session files

### DIFF
--- a/.github/instructions/parsers.instructions.md
+++ b/.github/instructions/parsers.instructions.md
@@ -37,8 +37,8 @@ Both must be registered in `src/parsers/registry.ts` with all `ToolAdapter` fiel
 
 ## JSONL Streaming
 
-- Stream JSONL with `readline.createInterface` — never `fs.readFileSync` for session files
-- Use helpers from `src/utils/jsonl.ts` (`readJsonlFile`, `scanJsonlHead`) when applicable
+- Stream JSONL with helpers from `src/utils/jsonl.ts` (`readJsonlFile`, `scanJsonlHead`) when applicable
+- Never use `fs.readFileSync` for session files
 - Keep only the last ~10 messages in `recentMessages` — do not accumulate the entire conversation
 
 ## Tool Summarizer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Agent behavior instructions for `continues` — the cross-tool AI session handof
 - **Logging**: use `logger` from `src/logger.ts` for all diagnostic output. Never use bare `console.log`/`console.warn`/`console.error` in library code. TUI display goes through `@clack/prompts` or `chalk` via the display layer.
 - **Error types**: throw typed errors from `src/errors.ts` on user-facing paths, not bare `new Error()`.
 - **Tool activity**: use `SummaryCollector` from `src/utils/tool-summarizer.ts` in every parser. Do not build `ToolUsageSummary[]` arrays manually.
-- **JSONL**: stream with `readline.createInterface`, never `fs.readFileSync` + `split('\n')`.
+- **JSONL**: use the shared streaming helpers in `src/utils/jsonl.ts`, never `fs.readFileSync` + `split('\n')`.
 - **SQLite** (OpenCode, Crush parsers): use built-in `node:sqlite` — do not add third-party SQLite dependencies.
 - **Biome rules in force**: `noEmptyBlockStatements` (error), `noUnusedImports` (error), `useConst` (error). Empty `catch {}` blocks fail the linter; use `catch (err) { logger.debug(...) }` instead.
 
@@ -45,7 +45,7 @@ All five steps are required. Missing any one is a bug. See `CLAUDE.md` for detai
 
 - **Writing to tool storage directories** — the tool is read-only. Any write to `~/.claude/`, `~/.codex/`, etc. is a severe bug.
 - **`exec()` with string interpolation** — always use `spawn()` with an argument array in `resume.ts`. Session IDs and paths can contain shell metacharacters.
-- **`fs.readFileSync`/`fs.writeFileSync` in parsers** — these block the event loop. Use async fs APIs or `readline`.
+- **`fs.readFileSync`/`fs.writeFileSync` in parsers** — these block the event loop. Use async fs APIs or shared streaming helpers.
 - **Duplicating parser-helpers** — `cleanSummary`, `extractRepoFromCwd`, `homeDir` live in `src/utils/parser-helpers.ts`. Import them; do not reimplement.
 - **Hardcoding tool names** — derive from `TOOL_NAMES` or `SessionSource`. Never write `if (tool === 'claude' || tool === 'codex' || ...)`.
 - **Importing `node:sqlite` outside OpenCode/Crush parsers** — SQLite is only needed for those two tools. Do not spread this dependency.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -16,7 +16,7 @@ Review guidelines for the `continues` CLI tool — a read-only session parser an
 - Use `process.exitCode = N` instead of `process.exit(N)`.
 - Biome handles linting and formatting — do not introduce ESLint or Prettier configs.
 - Parser functions must return `Promise<UnifiedSession[]>` and `Promise<SessionContext>` respectively. Both must be registered in `src/parsers/registry.ts`.
-- JSONL parsing must stream with `readline.createInterface` — do not load entire files into memory with `fs.readFileSync`.
+- JSONL parsing must use the shared streaming helpers in `src/utils/jsonl.ts` where possible — do not load entire files into memory with `fs.readFileSync`.
 - Use the `SummaryCollector` class from `src/utils/tool-summarizer.ts` for tool activity summaries. Do not manually build summary arrays.
 - Shared helpers (`cleanSummary`, `extractRepoFromCwd`, `homeDir`) live in `src/utils/parser-helpers.ts`. Do not duplicate these in individual parsers.
 - Error hierarchy: use typed errors from `src/errors.ts` (`ParseError`, `SessionNotFoundError`, `ToolNotAvailableError`, `UnknownSourceError`, `IndexError`, `StorageError`) rather than bare `throw new Error()` for user-facing error paths.

--- a/src/__tests__/shared-utils.test.ts
+++ b/src/__tests__/shared-utils.test.ts
@@ -3,9 +3,9 @@
  * Covers: jsonl, fs-helpers, content, tool-extraction, parser-helpers additions.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { ConversationMessage } from '../types/index.js';
 import { classifyToolName } from '../types/tool-names.js';
@@ -66,6 +66,15 @@ describe('readJsonlFile', () => {
     expect(result).toHaveLength(2);
   });
 
+  it('skips oversized lines without buffering them', async () => {
+    const dir = makeTmpDir();
+    const file = path.join(dir, 'test.jsonl');
+    fs.writeFileSync(file, '{"ok":true}\n{"payload":"abcdefghijklmnopqrstuvwxyz"}\n{"ok":false}\n');
+
+    const result = await readJsonlFile<{ ok: boolean }>(file, { maxLineChars: 12 });
+    expect(result).toEqual([{ ok: true }, { ok: false }]);
+  });
+
   it('returns empty array for non-existent file', async () => {
     const result = await readJsonlFile('/tmp/nonexistent-file.jsonl');
     expect(result).toEqual([]);
@@ -108,6 +117,44 @@ describe('scanJsonlHead', () => {
     await scanJsonlHead('/tmp/nonexistent.jsonl', 10, () => 'continue');
     // No error thrown
   });
+
+  it('keeps scanning after skipping an oversized line', async () => {
+    const dir = makeTmpDir();
+    const file = path.join(dir, 'test.jsonl');
+    fs.writeFileSync(file, '{"i":0}\n{"payload":"abcdefghijklmnopqrstuvwxyz"}\n{"i":2}\n');
+
+    const visited: number[] = [];
+    await scanJsonlHead(
+      file,
+      5,
+      (parsed) => {
+        visited.push((parsed as { i: number }).i);
+        return 'continue';
+      },
+      { maxLineChars: 10 },
+    );
+
+    expect(visited).toEqual([0, 2]);
+  });
+
+  it('stops at the configured byte limit without visiting partial lines', async () => {
+    const dir = makeTmpDir();
+    const file = path.join(dir, 'test.jsonl');
+    fs.writeFileSync(file, '{"i":0}\n{"i":1}\n');
+
+    const visited: number[] = [];
+    await scanJsonlHead(
+      file,
+      5,
+      (parsed) => {
+        visited.push((parsed as { i: number }).i);
+        return 'continue';
+      },
+      { maxBytes: 12 },
+    );
+
+    expect(visited).toEqual([0]);
+  });
 });
 
 describe('getFileStats', () => {
@@ -119,6 +166,15 @@ describe('getFileStats', () => {
     const stats = await getFileStats(file);
     expect(stats.lines).toBe(3);
     expect(stats.bytes).toBeGreaterThan(0);
+  });
+
+  it('counts a final unterminated line', async () => {
+    const dir = makeTmpDir();
+    const file = path.join(dir, 'test.jsonl');
+    fs.writeFileSync(file, '{"a":1}\n{"a":2}');
+
+    const stats = await getFileStats(file);
+    expect(stats.lines).toBe(2);
   });
 });
 
@@ -604,7 +660,9 @@ describe('extractAnthropicToolData structured data', () => {
     const messages: AnthropicMessage[] = [
       {
         role: 'assistant',
-        content: [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '/src/app.ts', offset: 10, limit: 50 } }],
+        content: [
+          { type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '/src/app.ts', offset: 10, limit: 50 } },
+        ],
       },
     ];
 
@@ -685,7 +743,9 @@ describe('extractAnthropicToolData structured data', () => {
       },
       {
         role: 'user',
-        content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'Found 3 matches\nsrc/a.ts\nsrc/b.ts\nsrc/c.ts' }],
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu1', content: 'Found 3 matches\nsrc/a.ts\nsrc/b.ts\nsrc/c.ts' },
+        ],
       },
     ];
 
@@ -724,7 +784,14 @@ describe('extractAnthropicToolData structured data', () => {
     const messages: AnthropicMessage[] = [
       {
         role: 'assistant',
-        content: [{ type: 'tool_use', id: 'tu1', name: 'mcp__github__list_issues', input: { repo: 'test/repo', state: 'open' } }],
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu1',
+            name: 'mcp__github__list_issues',
+            input: { repo: 'test/repo', state: 'open' },
+          },
+        ],
       },
       {
         role: 'user',
@@ -750,7 +817,9 @@ describe('extractAnthropicToolData structured data', () => {
       },
       {
         role: 'user',
-        content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'Permission denied\nexit code 1', is_error: true }],
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu1', content: 'Permission denied\nexit code 1', is_error: true },
+        ],
       },
     ];
     const { summaries } = extractAnthropicToolData(messages);

--- a/src/parsers/codex.ts
+++ b/src/parsers/codex.ts
@@ -1,5 +1,7 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type {
   ConversationMessage,
@@ -9,13 +11,11 @@ import type {
   UnifiedSession,
 } from '../types/index.js';
 import type { CodexMessage, CodexSessionMeta } from '../types/schemas.js';
+import { countDiffStats, extractStdoutTail } from '../utils/diff.js';
 import { findFiles } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepo, homeDir } from '../utils/parser-helpers.js';
-import { countDiffStats, extractStdoutTail } from '../utils/diff.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 import {
   extractExitCode,
   mcpSummary,
@@ -29,6 +29,9 @@ import {
 const CODEX_SESSIONS_DIR = process.env.CODEX_HOME
   ? path.join(process.env.CODEX_HOME, 'sessions')
   : path.join(homeDir(), '.codex', 'sessions');
+
+const MAX_EXACT_LINE_COUNT_BYTES = 1024 * 1024;
+const MAX_METADATA_SCAN_BYTES = 1024 * 1024;
 
 /**
  * Find all Codex session files recursively
@@ -49,26 +52,34 @@ async function parseSessionInfo(filePath: string): Promise<{
   let meta: CodexSessionMeta | null = null;
   let firstUserMessage = '';
 
-  await scanJsonlHead(filePath, 150, (parsed) => {
-    const msg = parsed as Record<string, unknown>;
+  await scanJsonlHead(
+    filePath,
+    150,
+    (parsed) => {
+      const msg = parsed as Record<string, unknown>;
 
-    if (msg.type === 'session_meta' && !meta) {
-      meta = msg as unknown as CodexSessionMeta;
-    }
-
-    if (!firstUserMessage && msg.type === 'event_msg') {
-      const payload = msg.payload as Record<string, unknown> | undefined;
-      if (payload?.type === 'user_message') {
-        firstUserMessage = (payload.message as string) || '';
+      if (msg.type === 'session_meta' && !meta) {
+        meta = msg as unknown as CodexSessionMeta;
       }
-    }
 
-    if (!firstUserMessage && msg.type === 'message' && (msg as Record<string, unknown>).role === 'user') {
-      firstUserMessage = typeof msg.content === 'string' ? (msg.content as string) : '';
-    }
+      if (!firstUserMessage && msg.type === 'event_msg') {
+        const payload = msg.payload as Record<string, unknown> | undefined;
+        if (payload?.type === 'user_message') {
+          firstUserMessage = (payload.message as string) || '';
+        }
+      }
 
-    return 'continue';
-  });
+      if (!firstUserMessage && msg.type === 'message' && (msg as Record<string, unknown>).role === 'user') {
+        firstUserMessage = typeof msg.content === 'string' ? (msg.content as string) : '';
+      }
+
+      if (meta && firstUserMessage) {
+        return 'stop';
+      }
+      return 'continue';
+    },
+    { maxBytes: MAX_METADATA_SCAN_BYTES },
+  );
 
   return { meta, firstUserMessage };
 }
@@ -101,8 +112,11 @@ export async function parseCodexSessions(): Promise<UnifiedSession[]> {
       if (!parsed) continue;
 
       const { meta, firstUserMessage } = await parseSessionInfo(filePath);
-      const stats = await getFileStats(filePath);
       const fileStats = fs.statSync(filePath);
+      const stats =
+        fileStats.size > MAX_EXACT_LINE_COUNT_BYTES
+          ? { lines: 0, bytes: fileStats.size }
+          : await getFileStats(filePath);
 
       const cwd = meta?.payload?.cwd || '';
       const gitUrl = meta?.payload?.git?.repository_url;
@@ -198,7 +212,10 @@ function trackShellFileWrites(cmd: string, collector: SummaryCollector): void {
 /**
  * Extract tool usage summaries and files modified using shared SummaryCollector
  */
-function extractToolData(messages: CodexMessage[], config?: VerbosityConfig): { summaries: ToolUsageSummary[]; filesModified: string[] } {
+function extractToolData(
+  messages: CodexMessage[],
+  config?: VerbosityConfig,
+): { summaries: ToolUsageSummary[]; filesModified: string[] } {
   const collector = new SummaryCollector(config);
   const outputsById = new Map<string, string>();
 
@@ -253,9 +270,13 @@ function extractToolData(messages: CodexMessage[], config?: VerbosityConfig): { 
           } else if (name === 'write_stdin') {
             collector.add('write_stdin', `stdin: "${truncate(String(args.input || args.data || ''), 60)}"`);
           } else if (['read_mcp_resource', 'list_mcp_resources', 'list_mcp_resource_templates'].includes(name)) {
-            collector.add('mcp-resource', `${name}: ${truncate(String(args.uri || args.server_label || '(all)'), 60)}`, {
-              data: { category: 'mcp', toolName: name, params: String(args.uri || args.server_label || '') },
-            });
+            collector.add(
+              'mcp-resource',
+              `${name}: ${truncate(String(args.uri || args.server_label || '(all)'), 60)}`,
+              {
+                data: { category: 'mcp', toolName: name, params: String(args.uri || args.server_label || '') },
+              },
+            );
           } else if (name === 'request_user_input') {
             const question = truncate(String(args.prompt || args.message || ''), 80);
             collector.add('user-input', `ask: "${question}"`, {
@@ -475,7 +496,15 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
   }
 
   // Generate markdown for injection
-  const markdown = generateHandoffMarkdown(session, trimmed, filesModified, pendingTasks, toolSummaries, sessionNotes, resolvedConfig);
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    sessionNotes,
+    resolvedConfig,
+  );
 
   return {
     session,

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -2,34 +2,140 @@
  * Shared JSONL reading utilities.
  * Replaces 5+ identical readAllMessages() functions across parsers.
  */
-import * as fs from 'fs';
-import * as readline from 'readline';
+import * as fs from 'node:fs';
+import { StringDecoder } from 'node:string_decoder';
 import { logger } from '../logger.js';
+
+const DEFAULT_MAX_LINE_CHARS = 16 * 1024 * 1024;
+
+export interface JsonlReadOptions {
+  /**
+   * Maximum JSONL record size to buffer. Oversized records are skipped so
+   * malformed or tool-output-heavy sessions cannot crash Node's readline buffer.
+   */
+  maxLineChars?: number;
+  /** Maximum bytes to scan before returning. Leaves any partial trailing line unvisited. */
+  maxBytes?: number;
+}
+
+async function scanJsonlLines(
+  filePath: string,
+  visitor: (line: string, lineIndex: number) => 'continue' | 'stop',
+  options: JsonlReadOptions = {},
+): Promise<void> {
+  if (!fs.existsSync(filePath)) return;
+
+  const maxLineChars = options.maxLineChars ?? DEFAULT_MAX_LINE_CHARS;
+  const decoder = new StringDecoder('utf8');
+  const stream = fs.createReadStream(filePath);
+  let lineBuffer = '';
+  let lineIndex = 0;
+  let skippingOversizedLine = false;
+  let stopped = false;
+  let bytesRead = 0;
+
+  const finishLine = (): 'continue' | 'stop' => {
+    if (skippingOversizedLine) {
+      logger.debug('jsonl: skipping oversized line at index', lineIndex, 'in', filePath);
+      skippingOversizedLine = false;
+      lineBuffer = '';
+      lineIndex++;
+      return 'continue';
+    }
+
+    const line = lineBuffer.endsWith('\r') ? lineBuffer.slice(0, -1) : lineBuffer;
+    lineBuffer = '';
+    const action = visitor(line, lineIndex);
+    lineIndex++;
+    return action;
+  };
+
+  const consumeText = (text: string): 'continue' | 'stop' => {
+    let start = 0;
+
+    while (start < text.length) {
+      const newlineIndex = text.indexOf('\n', start);
+      const segmentEnd = newlineIndex === -1 ? text.length : newlineIndex;
+      const segment = text.slice(start, segmentEnd);
+
+      if (!skippingOversizedLine) {
+        if (lineBuffer.length + segment.length > maxLineChars) {
+          skippingOversizedLine = true;
+          lineBuffer = '';
+        } else {
+          lineBuffer += segment;
+        }
+      }
+
+      if (newlineIndex === -1) {
+        break;
+      }
+
+      if (finishLine() === 'stop') {
+        return 'stop';
+      }
+      start = newlineIndex + 1;
+    }
+
+    return 'continue';
+  };
+
+  try {
+    for await (const chunk of stream) {
+      let buffer = chunk as Buffer;
+      if (options.maxBytes !== undefined && bytesRead + buffer.length > options.maxBytes) {
+        buffer = buffer.subarray(0, Math.max(0, options.maxBytes - bytesRead));
+        stopped = true;
+      }
+      bytesRead += buffer.length;
+
+      if (buffer.length > 0 && consumeText(decoder.write(buffer)) === 'stop') {
+        stopped = true;
+      }
+
+      if (stopped) {
+        stream.destroy();
+        break;
+      }
+    }
+
+    if (!stopped) {
+      const remaining = decoder.end();
+      if (remaining && consumeText(remaining) === 'stop') {
+        stopped = true;
+      }
+
+      if (!stopped && (lineBuffer.length > 0 || skippingOversizedLine)) {
+        finishLine();
+      }
+    }
+  } catch (err) {
+    logger.debug('jsonl: failed to stream', filePath, err);
+  }
+}
 
 /**
  * Read an entire JSONL file into an array.
  * Each line is JSON.parse'd; invalid lines are silently skipped.
  * Returns an empty array if the file doesn't exist or can't be read.
  */
-export async function readJsonlFile<T = unknown>(filePath: string): Promise<T[]> {
+export async function readJsonlFile<T = unknown>(filePath: string, options?: JsonlReadOptions): Promise<T[]> {
   if (!fs.existsSync(filePath)) return [];
 
-  return new Promise((resolve) => {
-    const items: T[] = [];
-    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-
-    rl.on('line', (line) => {
+  const items: T[] = [];
+  await scanJsonlLines(
+    filePath,
+    (line) => {
       try {
         items.push(JSON.parse(line));
       } catch (err) {
         logger.debug('jsonl: skipping invalid line in', filePath, err);
       }
-    });
-
-    rl.on('close', () => resolve(items));
-    rl.on('error', () => resolve(items));
-  });
+      return 'continue';
+    },
+    options,
+  );
+  return items;
 }
 
 /**
@@ -41,43 +147,24 @@ export async function scanJsonlHead(
   filePath: string,
   maxLines: number,
   visitor: (parsed: unknown, lineIndex: number) => 'continue' | 'stop',
+  options?: JsonlReadOptions,
 ): Promise<void> {
   if (!fs.existsSync(filePath)) return;
 
-  return new Promise((resolve) => {
-    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-    let lineIndex = 0;
-    let stopped = false;
-
-    rl.on('line', (line) => {
-      if (stopped || lineIndex >= maxLines) {
-        if (!stopped) {
-          stopped = true;
-          rl.close();
-          stream.close();
-        }
-        return;
-      }
-
+  await scanJsonlLines(
+    filePath,
+    (line, lineIndex) => {
+      if (lineIndex >= maxLines) return 'stop';
       try {
         const parsed = JSON.parse(line);
-        const action = visitor(parsed, lineIndex);
-        if (action === 'stop') {
-          stopped = true;
-          rl.close();
-          stream.close();
-        }
+        return visitor(parsed, lineIndex);
       } catch (err) {
         logger.debug('jsonl: skipping invalid line at index', lineIndex, 'in', filePath, err);
       }
-
-      lineIndex++;
-    });
-
-    rl.on('close', () => resolve());
-    rl.on('error', () => resolve());
-  });
+      return 'continue';
+    },
+    options,
+  );
 }
 
 /**
@@ -86,14 +173,25 @@ export async function scanJsonlHead(
  */
 export async function getFileStats(filePath: string): Promise<{ lines: number; bytes: number }> {
   const stats = fs.statSync(filePath);
+  if (stats.size === 0) return { lines: 0, bytes: stats.size };
 
-  return new Promise((resolve) => {
+  try {
     let lines = 0;
-    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    let lastByte: number | undefined;
+    const stream = fs.createReadStream(filePath);
 
-    rl.on('line', () => lines++);
-    rl.on('close', () => resolve({ lines, bytes: stats.size }));
-    rl.on('error', () => resolve({ lines: 0, bytes: stats.size }));
-  });
+    for await (const chunk of stream) {
+      const buffer = chunk as Buffer;
+      for (const byte of buffer) {
+        if (byte === 10) lines++;
+      }
+      lastByte = buffer[buffer.length - 1];
+    }
+
+    if (lastByte !== 10) lines++;
+    return { lines, bytes: stats.size };
+  } catch (err) {
+    logger.debug('jsonl: failed to count lines in', filePath, err);
+    return { lines: 0, bytes: stats.size };
+  }
 }

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -182,10 +182,16 @@ export async function getFileStats(filePath: string): Promise<{ lines: number; b
 
     for await (const chunk of stream) {
       const buffer = chunk as Buffer;
-      for (const byte of buffer) {
-        if (byte === 10) lines++;
+      let offset = 0;
+      let newlineIndex = buffer.indexOf(10, offset);
+      while (newlineIndex !== -1) {
+        lines++;
+        offset = newlineIndex + 1;
+        newlineIndex = buffer.indexOf(10, offset);
       }
-      lastByte = buffer[buffer.length - 1];
+      if (buffer.length > 0) {
+        lastByte = buffer[buffer.length - 1];
+      }
     }
 
     if (lastByte !== 10) lines++;


### PR DESCRIPTION
fixes #39

tracked this down to codex session files, not the aggregate index. on this machine `~/.codex/sessions` has multi-gb jsonl files, and node `readline` can blow up while buffering a single record.

### **what changed:**
  - replace unbounded jsonl readline buffering with a bounded chunk scanner
  - skip oversized records instead of crashing the index build
  - cap codex metadata scans and skip exact line counts for large codex files
  - add regression coverage for oversized jsonl records

**tests:**
  - `pnpm test`
  - `pnpm build`
  - `pnpm exec biome check src/utils/jsonl.ts src/parsers/codex.ts src/__tests__/shared-utils.test.ts`
  - `pnpm exec tsx src/cli.ts list -n 1 --source codex --rebuild`

**also**
  - `pnpm run check` currently fails on existing repo-wide biome diagnostics outside this patch

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

This PR replaces Node's `readline`-based JSONL parsing in `src/utils/jsonl.ts` with a custom chunk-level scanner (`scanJsonlLines`) that enforces a per-line character cap (`DEFAULT_MAX_LINE_CHARS = 16 MB`) and an optional byte-read ceiling (`maxBytes`). `codex.ts` gains two new guards: a 1 MB byte cap on metadata scans, and a fast-path that skips exact line counting for files over 1 MB. The fix is well-scoped and well-tested.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no correctness issues; remaining comments are P2 style/performance suggestions.

All findings are P2. The core scanner logic is correct, the maxBytes/maxLineChars semantics are consistent, chunk-boundary and multi-byte UTF-8 edge cases are handled properly, and the new tests cover the key regression paths. Nothing blocks merge.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/jsonl.ts | New scanJsonlLines core — logic is correct; minor: double existsSync guards in readJsonlFile/scanJsonlHead, and the byte-by-byte loop in getFileStats could be faster (Buffer.indexOf), but only used for files ≤ 1 MB so negligible in practice. |
| src/parsers/codex.ts | Adds early-stop + maxBytes cap to parseSessionInfo and skips expensive line count for large files — correct and minimal. |
| src/__tests__/shared-utils.test.ts | New regression tests cover oversized-line skipping, maxBytes truncation, and unterminated final line — all correct; remaining changes are pure cosmetic reformatting. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fs.createReadStream] --> B[for await chunk]
    B --> C{maxBytes exceeded?}
    C -- yes --> D[truncate buffer\nstopped = true]
    C -- no --> E[decoder.write buffer]
    D --> E
    E --> F[consumeText decoded text]
    F --> G{newline found?}
    G -- no --> H[append to lineBuffer\nbreak]
    G -- yes --> I{lineBuffer + segment\n> maxLineChars?}
    I -- yes --> J[skippingOversizedLine = true\nclear lineBuffer]
    I -- no --> K[lineBuffer += segment]
    J --> L[finishLine: skip + log]
    K --> L2[finishLine: call visitor]
    L --> M{stopped?}
    L2 --> M
    M -- yes --> N[stream.destroy\nbreak]
    M -- no --> B
    H --> O{stopped?}
    O -- no --> P[decoder.end\nfinishLine remaining]
    O -- yes --> Q[done]
    P --> Q
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/utils/jsonl.ts
Line: 122-138

Comment:
**Redundant `existsSync` guard**

`readJsonlFile` checks `existsSync` before delegating to `scanJsonlLines`, which checks it again internally. Same duplication in `scanJsonlHead` (line 152). The inner check in `scanJsonlLines` is the authoritative one — the outer check is dead weight.

```suggestion
export async function readJsonlFile<T = unknown>(filePath: string, options?: JsonlReadOptions): Promise<T[]> {
  const items: T[] = [];
  await scanJsonlLines(
    filePath,
    (line) => {
      try {
        items.push(JSON.parse(line));
      } catch (err) {
        logger.debug('jsonl: skipping invalid line in', filePath, err);
      }
      return 'continue';
    },
    options,
  );
  return items;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/utils/jsonl.ts
Line: 183-190

Comment:
**`for...of` byte loop is ~10× slower than `indexOf`**

Iterating a `Buffer` with `for (const byte of buffer)` goes through the JS iterator protocol on every byte. For the 1 MB files this is called on, a `Buffer.indexOf(10, offset)` scan is meaningfully faster and cleaner:

```suggestion
    for await (const chunk of stream) {
      const buffer = chunk as Buffer;
      let offset = 0;
      let idx: number;
      while ((idx = buffer.indexOf(10, offset)) !== -1) {
        lines++;
        offset = idx + 1;
      }
      lastByte = buffer.length > 0 ? buffer[buffer.length - 1] : lastByte;
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(jsonl): prevent readline crash on hu..."](https://github.com/yigitkonur/cli-continues/commit/3b2d88281df55ea764bbb457d7c7b13eaae67a09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28123153)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->