### PR TITLE
feat(cursor): support cursor-agent binary fallback

### DIFF
--- a/src/__tests__/forward-flags.test.ts
+++ b/src/__tests__/forward-flags.test.ts
@@ -210,6 +210,21 @@ describe('cross-tool forwarding', () => {
     expect(command).toContain('--search');
   });
 
+  it('shows both preferred and fallback binaries in cursor native command preview', () => {
+    const session: UnifiedSession = {
+      id: 'abc123456789',
+      source: 'cursor',
+      cwd: '/tmp/project',
+      lines: 10,
+      bytes: 120,
+      createdAt: new Date('2026-02-20T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-20T00:00:00.000Z'),
+      originalPath: '/tmp/session.jsonl',
+    };
+
+    expect(getResumeCommand(session)).toBe('cursor-agent --resume abc123456789 (or: agent --resume abc123456789)');
+  });
+
   it('does not add default approval flags to gemini command preview', () => {
     const session: UnifiedSession = {
       id: 'abc123456789',

--- a/src/__tests__/forward-flags.test.ts
+++ b/src/__tests__/forward-flags.test.ts
@@ -43,7 +43,8 @@ describe('cross-tool forwarding', () => {
   });
 
   it('maps cursor target using agent semantics', () => {
-    expect(adapters.cursor.binaryName).toBe('agent');
+    expect(adapters.cursor.binaryName).toBe('cursor-agent');
+    expect(adapters.cursor.binaryFallbacks).toEqual(['agent']);
 
     const resolved = resolveCrossToolForwarding('cursor', {
       rawArgs: ['--sandbox', 'workspace-write', '--model', 'gpt-5', '--approve-mcps'],

--- a/src/__tests__/resume-binary.test.ts
+++ b/src/__tests__/resume-binary.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getToolBinaryCandidates, resolveToolBinaryName } from '../utils/resume.js';
+
+describe('tool binary resolution', () => {
+  it('prefers cursor-agent with agent as fallback', () => {
+    expect(getToolBinaryCandidates('cursor')).toEqual(['cursor-agent', 'agent']);
+  });
+
+  it('chooses cursor-agent when it is available', async () => {
+    const binaryName = await resolveToolBinaryName('cursor', async (candidate) => candidate === 'cursor-agent');
+
+    expect(binaryName).toBe('cursor-agent');
+  });
+
+  it('falls back to agent when cursor-agent is unavailable', async () => {
+    const binaryName = await resolveToolBinaryName('cursor', async (candidate) => candidate === 'agent');
+
+    expect(binaryName).toBe('agent');
+  });
+
+  it('returns null when no cursor binary is available', async () => {
+    const binaryName = await resolveToolBinaryName('cursor', async () => false);
+
+    expect(binaryName).toBeNull();
+  });
+});

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -763,7 +763,7 @@ register({
   extractContext: extractCursorContext,
   nativeResumeArgs: (s) => ['--resume', s.id],
   crossToolArgs: (prompt) => [prompt],
-  resumeCommandDisplay: (s) => `cursor-agent --resume ${s.id}`,
+  resumeCommandDisplay: (s) => `cursor-agent --resume ${s.id} (or: agent --resume ${s.id})`,
   mapHandoffFlags: mapCursorAgentFlags,
 });
 

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -48,6 +48,8 @@ export interface ToolAdapter {
   envVar?: string;
   /** CLI binary name for availability checks and spawning */
   binaryName: string;
+  /** Additional binary names to try when the primary name is unavailable */
+  binaryFallbacks?: string[];
   /** Discover and index all sessions */
   parseSessions: () => Promise<UnifiedSession[]>;
   /** Extract full context for cross-tool handoff */
@@ -755,12 +757,13 @@ register({
   label: 'Cursor AI',
   color: chalk.blueBright,
   storagePath: '~/.cursor/projects/*/agent-transcripts/',
-  binaryName: 'agent',
+  binaryName: 'cursor-agent',
+  binaryFallbacks: ['agent'],
   parseSessions: parseCursorSessions,
   extractContext: extractCursorContext,
   nativeResumeArgs: (s) => ['--resume', s.id],
   crossToolArgs: (prompt) => [prompt],
-  resumeCommandDisplay: (s) => `agent --resume ${s.id}`,
+  resumeCommandDisplay: (s) => `cursor-agent --resume ${s.id}`,
   mapHandoffFlags: mapCursorAgentFlags,
 });
 

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -167,13 +167,13 @@ export async function crossToolResume(
 
   const adapter = adapters[target];
   if (!adapter) throw new Error(`Unknown target: ${target}`);
-  const binaryName = await requireToolBinaryName(target);
 
   if (contextOptions?.debugPrompt) {
     console.log(prompt);
     return;
   }
 
+  const binaryName = await requireToolBinaryName(target);
   const resolved = resolveCrossToolForwarding(target, forwarding);
   const defaultInitArgs = getDefaultHandoffInitArgs(target, resolved.extraArgs);
   await runCommand(binaryName, [...defaultInitArgs, ...resolved.extraArgs, ...adapter.crossToolArgs(prompt, cwd)], cwd);

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset, loadConfig } from '../config/index.js';
+import { ToolNotAvailableError } from '../errors.js';
 import { logger } from '../logger.js';
 import { ALL_TOOLS, adapters } from '../parsers/registry.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
@@ -21,6 +22,12 @@ export interface HandoffContextOptions {
   configPath?: string;
   chain?: boolean;
   debugPrompt?: boolean;
+}
+
+export function getToolBinaryCandidates(tool: SessionSource): string[] {
+  const adapter = adapters[tool];
+  if (!adapter) return [];
+  return [adapter.binaryName, ...(adapter.binaryFallbacks ?? [])];
 }
 
 /**
@@ -114,7 +121,8 @@ export async function nativeResume(session: UnifiedSession): Promise<void> {
   const cwd = session.cwd || process.cwd();
   const adapter = adapters[session.source];
   if (!adapter) throw new Error(`Unknown session source: ${session.source}`);
-  await runCommand(adapter.binaryName, adapter.nativeResumeArgs(session), cwd);
+  const binaryName = await requireToolBinaryName(session.source);
+  await runCommand(binaryName, adapter.nativeResumeArgs(session), cwd);
 }
 
 /**
@@ -159,6 +167,7 @@ export async function crossToolResume(
 
   const adapter = adapters[target];
   if (!adapter) throw new Error(`Unknown target: ${target}`);
+  const binaryName = await requireToolBinaryName(target);
 
   if (contextOptions?.debugPrompt) {
     console.log(prompt);
@@ -167,11 +176,7 @@ export async function crossToolResume(
 
   const resolved = resolveCrossToolForwarding(target, forwarding);
   const defaultInitArgs = getDefaultHandoffInitArgs(target, resolved.extraArgs);
-  await runCommand(
-    adapter.binaryName,
-    [...defaultInitArgs, ...resolved.extraArgs, ...adapter.crossToolArgs(prompt, cwd)],
-    cwd,
-  );
+  await runCommand(binaryName, [...defaultInitArgs, ...resolved.extraArgs, ...adapter.crossToolArgs(prompt, cwd)], cwd);
 }
 
 /**
@@ -300,6 +305,24 @@ async function isBinaryAvailable(binaryName: string): Promise<boolean> {
   });
 }
 
+export async function resolveToolBinaryName(
+  tool: SessionSource,
+  isAvailable: (binaryName: string) => Promise<boolean> = isBinaryAvailable,
+): Promise<string | null> {
+  for (const candidate of getToolBinaryCandidates(tool)) {
+    if (await isAvailable(candidate)) return candidate;
+  }
+  return null;
+}
+
+async function requireToolBinaryName(tool: SessionSource): Promise<string> {
+  const binaryName = await resolveToolBinaryName(tool);
+  if (binaryName) return binaryName;
+
+  const adapter = adapters[tool];
+  throw new ToolNotAvailableError(adapter?.label ?? tool);
+}
+
 /**
  * Get available tools
  */
@@ -307,7 +330,7 @@ export async function getAvailableTools(): Promise<SessionSource[]> {
   const checks = await Promise.allSettled(
     ALL_TOOLS.map(async (name) => ({
       name,
-      ok: await isBinaryAvailable(adapters[name].binaryName),
+      ok: (await resolveToolBinaryName(name)) !== null,
     })),
   );
 


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

# Review all of  them with eye of John Carmack-like simplicity with elegeance approach and apply the one only if required

<h3>Greptile Summary</h3>

Adds `cursor-agent` as the preferred binary for Cursor AI with `agent` as a legacy fallback. The `ToolAdapter` interface gains an optional `binaryFallbacks` field, and `resume.ts` gains `resolveToolBinaryName` which tries candidates in order and returns the first available one. The fallback logic is clean, well-tested, and fits the registry-driven architecture correctly.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — the only finding is a cosmetic display mismatch when the legacy fallback binary is in use.
- All remaining findings are P2. Runtime binary resolution is correct; nativeResume, crossToolResume, and getAvailableTools all use the new resolver. Tests cover the primary, fallback, and null cases. The resumeCommandDisplay string mismatch is a minor UX issue that does not affect actual command execution.
- src/parsers/registry.ts — resumeCommandDisplay line 766
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/resume.ts | Adds getToolBinaryCandidates, resolveToolBinaryName (exported, injectable), and requireToolBinaryName; integrates them into nativeResume, crossToolResume, and getAvailableTools cleanly. Logic is correct and properly uses ToolNotAvailableError. |
| src/parsers/registry.ts | Adds optional binaryFallbacks field to ToolAdapter interface; changes cursor binaryName from 'agent' to 'cursor-agent' with 'agent' as fallback. resumeCommandDisplay hardcodes 'cursor-agent' regardless of which binary is resolved at runtime. |
| src/__tests__/resume-binary.test.ts | New test file covering candidate ordering, primary preference, fallback, and null-return cases for resolveToolBinaryName. Full coverage of the new logic paths. |
| src/__tests__/forward-flags.test.ts | Updates existing test to assert binaryName is now 'cursor-agent' and binaryFallbacks is ['agent']. Correct and minimal. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as CLI (resume/crossToolResume)
    participant R as requireToolBinaryName()
    participant RR as resolveToolBinaryName()
    participant GC as getToolBinaryCandidates()
    participant IA as isBinaryAvailable()

    C->>R: requireToolBinaryName('cursor')
    R->>RR: resolveToolBinaryName('cursor')
    RR->>GC: getToolBinaryCandidates('cursor')
    GC-->>RR: ['cursor-agent', 'agent']
    RR->>IA: isBinaryAvailable('cursor-agent')
    alt cursor-agent found
        IA-->>RR: true
        RR-->>R: 'cursor-agent'
    else cursor-agent missing
        IA-->>RR: false
        RR->>IA: isBinaryAvailable('agent')
        alt agent found
            IA-->>RR: true
            RR-->>R: 'agent'
        else neither found
            IA-->>RR: false
            RR-->>R: null
            R-->>C: throws ToolNotAvailableError
        end
    end
    R-->>C: resolved binaryName
    C->>C: runCommand(binaryName, args, cwd)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/parsers/registry.ts
Line: 766

Comment:
**`resumeCommandDisplay` out of sync with resolved binary**

This function always returns `cursor-agent --resume ${s.id}`, but at runtime `requireToolBinaryName` may resolve to the `agent` fallback instead. If a user only has the legacy `agent` binary installed, the TUI/help display shows a command they can't actually run. The runtime behavior is correct; the display is not.

```suggestion
  resumeCommandDisplay: (s) => `cursor-agent --resume ${s.id} (or: agent --resume ${s.id})`,
```

Or better: accept that the display reflects the preferred binary and add a note in parentheses, or make `getResumeCommand` in `resume.ts` accept the already-resolved `binaryName` as an argument so it can display what was actually used.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cursor): support cursor-agent binar..."](https://github.com/yigitkonur/cli-continues/commit/8cb74632b8b6702922f7851bf44d36db6839f9f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28357661)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->