### PR TITLE
[codex] parser fidelity hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,14 @@ continues resume abc123 --in gemini
 
 # Or pass flags through to the destination tool:
 continues resume abc123 --in codex --yolo --search --add-dir /tmp
+
+# Or print the exact handoff prompt without launching the target tool:
+continues resume abc123 --in codex --debug-prompt
 ```
 
 `continues` maps common flags (model, sandbox, auto-approve, extra dirs) to the target tool's equivalent. Anything it doesn't recognize gets passed through as-is.
+
+`--debug-prompt` is for handoff inspection and testing. It writes the handoff file as usual, then prints the exact prompt that would be passed to the target agent and exits without launching it.
 
 ### Scripting & CI
 

--- a/docs/parser-documentation/00-overview.md
+++ b/docs/parser-documentation/00-overview.md
@@ -1,0 +1,111 @@
+# Parser Documentation Master Overview
+
+Access date: 2026-04-15
+
+This directory is now a complete parser-research package for `continues`. The five context folders cover storage format, message schema, tool-call fidelity, direct-access recipes, and handoff-pointer design across all 16 canonical tools defined in `src/types/tool-names.ts`.
+
+## What The Research Now Establishes
+
+The current product problem is not that `continues` fails to read sessions at all. The deeper issue is that the parser layer mixes three concerns that need to be separated:
+
+1. schema truth
+2. readability-oriented summarization
+3. handoff navigation
+
+The current codebase is strongest at summarization. It is weaker at surfacing raw-storage truth and weaker still at showing the receiving agent how to go deeper.
+
+Across the five contexts, the strongest cross-cutting finding is consistent:
+
+- the current four-preset top-level model in `src/config/verbosity.ts` is the wrong user-facing abstraction
+- the handoff needs a top-of-document technical pointer block
+- exact upstream tool/function names should survive the extraction pipeline
+- assistant-message reconstruction needs to be treated as a parser problem, not a markdown-rendering problem
+- several tool adapters are materially stale versus current upstream storage reality
+
+## Highest-Risk Drift Versus Current Code
+
+These are the most urgent mismatches repeatedly confirmed across contexts:
+
+| Tool | Main drift | Why it matters |
+| --- | --- | --- |
+| Gemini | Current upstream code writes JSONL append logs, while `src/parsers/gemini.ts` still targets older JSON session objects. | Discovery, message reconstruction, tool-call recovery, and pointer design are all at risk. |
+| Kiro | Public docs now describe SQLite-backed session storage under `~/.kiro/`, while `src/parsers/kiro.ts` targets legacy JSON under app-support paths. | The parser may be aimed at the wrong product surface or a stale backend. |
+| Antigravity | Current parser targets `code_tracker` records, while current evidence points toward other conversation stores and/or tracker formats. | Session discovery and transcript fidelity are highly provisional. |
+| Qwen Code | Current official repo/runtime evidence points to different runtime roots than the parser assumes. | `continues` may miss sessions entirely on current installs. |
+| Crush | Current parser assumes a global DB path, but current evidence points to project-local `.crush/crush.db`. | Discovery and session selection can be wrong. |
+| Amp | Current parser assumptions about thread storage are weakly documented and likely incomplete. | Pointer design and reliability are low-confidence. |
+| Kilo Code | Evidence conflicts between legacy VS Code `ui_messages.json` task storage and newer DB-backed/OpenCode-style backends. | The current parser may be tied to a legacy branch only. |
+| Cursor | Transcript fidelity is intentionally partial in some first-party statements. | Any handoff should warn about transcript completeness limits. |
+
+## Strongest Product-Level Conclusions
+
+### 1. Simplify the user-facing contract, but do not collapse every concern into one toggle
+
+The user-facing problem is not “how many samples should I see.” It is “can I continue immediately, and can I go deeper when I need to.” The local research strongly supported a two-mode design, but the adversarial internet verification found that major CLIs more often separate:
+
+- a human-readable session/transcript surface
+- a machine-readable or inspection-oriented output surface
+- explicit session/checkpoint/raw inspection commands
+
+So the safer conclusion is:
+
+- keep moving away from `minimal | standard | verbose | full` as the main user-facing contract
+- but do not assume `default | full` alone is the final answer
+- keep room for a separate machine/inspection axis such as structured output or explicit inspect modes
+
+### 2. Add raw-storage orientation early, but keep it concise and navigational
+
+The local research favored a top-of-document technical pointer block. The external verification supports that only if the block is treated as navigational metadata rather than the universal primary payload.
+
+What should appear early is:
+
+- where the real raw source lives
+- what backend it uses
+- what session handle is canonical
+- how to inspect deeper data immediately
+- how trustworthy the parser view is
+
+The pointer block should be short in the default human-facing view and richer in deeper/debug/inspection views. Transcript and summary content should remain first-class, not demoted into a secondary concern for every user.
+
+### 3. Preserve raw fidelity alongside summarized categories
+
+`SummaryCollector` and the grouped markdown sections are useful, but they should not be the only truth carried forward. The next redesign should preserve:
+
+- exact upstream tool/function names
+- argument carrier location
+- result carrier location
+- raw-fidelity warning when outputs are omitted or transcript completeness is partial
+
+The external verification also found a useful refinement:
+
+- exact upstream names should survive in raw/debug/full views
+- normalized labels can still remain in the default human summary where they improve readability
+
+### 4. Treat assistant-message reconstruction as tool-specific
+
+Recent-message trimming is unsafe when it assumes one uniform turn model. The research repeatedly showed that assistant output may be split across:
+
+- assistant text records
+- assistant tool-call records
+- user tool-result carrier records
+- append-log mutations or rewinds
+- structured part tables in SQLite
+
+The redesign needs tool-specific reconstruction before truncation.
+
+## What Is Now Complete
+
+- `storage-format/`: verified or challenged current storage-root assumptions
+- `message-schema/`: documented assistant-message and chronology models
+- `tool-call-map/`: mapped exact tool-call encoding and fidelity losses
+- `access-recipes/`: documented how to inspect deeper raw data directly
+- `handoff-pointers/`: translated evidence into default/full pointer-block recommendations
+- `prompts/2026-04-15-cto-session-schema-audit.md`: research mission prompt
+
+## What Still Needs To Happen
+
+- implement the redesign in code
+- validate unresolved tools from live local captures
+- update parser help text and registry metadata to stop presenting legacy paths as canonical
+
+Use `01-parser-redesign-backlog.md` for implementation order and `99-open-questions.md` for unresolved validation targets.

--- a/docs/parser-documentation/01-parser-redesign-backlog.md
+++ b/docs/parser-documentation/01-parser-redesign-backlog.md
@@ -1,0 +1,283 @@
+# Parser Redesign Backlog
+
+This file turns the research package into an implementation sequence.
+
+## P0: User-Facing Contract
+
+### 1. Replace top-level preset language with a simpler human-facing contract
+
+Current anchor:
+
+- `src/config/verbosity.ts`
+- `src/cli.ts`
+
+Required outcome:
+
+- user-facing flags and docs stop presenting `minimal | standard | verbose | full` as the main public model
+- the default human-facing contract is simpler than today
+- if needed, a separate machine/inspection axis remains explicit instead of being accidentally overloaded into one detail toggle
+- existing internal rendering caps can stay behind the scenes if needed
+- inspect/dump/resume/handoff behavior can still map to detailed internals without exposing four preset names as the main API
+
+### 2. Add concise technical guidance near the top of the handoff
+
+Current anchor:
+
+- `src/utils/markdown.ts`
+- `src/utils/resume.ts`
+
+Required outcome:
+
+- a concise technical pointer block appears before or alongside the main summary
+- includes raw source path, backend format, session identifier, quick-inspect recipe, and confidence note
+- the default human-facing view stays skimmable
+- deeper/debug/full views expand with backend-specific retrieval depth without burying the main continuation summary
+
+### 3. Separate raw fidelity from summarized tool categories
+
+Current anchor:
+
+- `src/utils/tool-summarizer.ts`
+- `src/utils/markdown.ts`
+
+Required outcome:
+
+- grouped summaries can remain
+- exact upstream tool/function names are preserved somewhere in the handoff or a raw appendix
+- argument/result carrier information is not lost
+- normalized aliases remain available in the default human summary where they improve readability
+
+## P1: Parser Corrections By Risk
+
+### 4. Gemini parser version detection
+
+Current anchor:
+
+- `src/parsers/gemini.ts`
+
+Required outcome:
+
+- detect and support legacy JSON and current JSONL append-log variants
+- reconstruct effective history before trimming
+- preserve tool-call fidelity from current upstream structures
+- consider `projects.json` / short-id mapping for better workspace attribution where it is stable enough to trust
+
+### 5. Kiro backend clarification and parser split
+
+Current anchor:
+
+- `src/parsers/kiro.ts`
+- `src/parsers/registry.ts`
+
+Required outcome:
+
+- distinguish normal CLI SQLite storage under `~/.kiro/` from ACP session storage under `~/.kiro/sessions/cli/`
+- decide whether this repo supports Kiro IDE, Kiro CLI, or both
+- align discovery with the verified backend(s)
+- surface uncertainty explicitly if both backends remain in play
+
+### 6. Antigravity source-of-truth correction
+
+Current anchor:
+
+- `src/parsers/antigravity.ts`
+
+Required outcome:
+
+- verify canonical session store
+- shift the documented default toward `conversations/*.pb` + `brain/<id>/` + UI/index state where evidence supports it
+- stop treating provisional tracker assumptions as settled
+- downgrade confidence or disable parser path if evidence remains weak
+
+### 7. Qwen Code runtime-root correction
+
+Current anchor:
+
+- `src/parsers/qwen-code.ts`
+- `src/parsers/registry.ts`
+
+Required outcome:
+
+- use the correct runtime-root/env-var contract
+- ensure current installs are discoverable
+- align docs and code around `projects/.../chats/*.jsonl` as the primary transcript store rather than treating `tmp/` as a competing primary path
+
+### 8. Crush and Amp discovery correction
+
+Current anchor:
+
+- `src/parsers/crush.ts`
+- `src/parsers/amp.ts`
+- `src/parsers/registry.ts`
+
+Required outcome:
+
+- correct DB/thread root assumptions
+- make pointer blocks reflect actual raw locations
+- downgrade Amp storage-path certainty until a first-party local transcript contract exists
+
+### 9. Droid and Kilo Code backend-family clarification
+
+Current anchor:
+
+- `src/parsers/droid.ts`
+- `src/parsers/cline.ts`
+- `src/parsers/registry.ts`
+
+Required outcome:
+
+- downgrade Droid’s `sessions/...` path from canonical truth to confidence-graded observation unless stronger first-party proof is found
+- evaluate whether first-party `projects/.../*.jsonl` transcript-path examples should become the documented default
+- explicitly decide whether `kilo-code` stays in the Cline-family parser or gets its own backend path
+- support the possibility that both extension-side `ui_messages.json` and shared-core/DB-backed storage are live product surfaces
+- document that decision in code comments and docs
+
+### 10. Qwen runtime/storage cleanup
+
+Current anchor:
+
+- `src/parsers/qwen-code.ts`
+- `src/parsers/registry.ts`
+
+Required outcome:
+
+- treat `projects/.../chats/*.jsonl` as the primary transcript store
+- treat `tmp/` and `history/` as auxiliary roots, not competing canonical transcript paths
+- prefer `QWEN_RUNTIME_DIR` over older env-var assumptions
+
+### 11. Codex archived sessions and token-count correction
+
+Current anchor:
+
+- `src/parsers/codex.ts`
+- `src/types/schemas.ts`
+
+Required outcome:
+
+- scan both active `sessions/` and `archived_sessions/`
+- parse `event_msg.token_count` from the current nested `payload.info.*` shape instead of relying on older flatter assumptions
+- reassess coverage of modern response-item variants against current first-party Codex protocol
+
+## P2: Message And Tool Fidelity
+
+### 12. Tool-specific recent-message reconstruction
+
+Current anchor:
+
+- `src/parsers/claude.ts`
+- `src/parsers/codex.ts`
+- `src/parsers/gemini.ts`
+- `src/parsers/opencode.ts`
+- `src/parsers/qwen-code.ts`
+
+Required outcome:
+
+- reconstruct effective assistant/user chronology before trimming
+- stop treating user-carried tool results as ordinary human turns
+- keep assistant tool activity close enough to the conversation to remain strategically useful
+
+### 13. Richer OpenCode and Crush extraction
+
+Current anchor:
+
+- `src/parsers/opencode.ts`
+- `src/parsers/crush.ts`
+
+Required outcome:
+
+- leverage structured DB parts, not only flattened text
+- preserve exact tool names and result states
+- honor `OPENCODE_DB` and channel DB variants
+- stop deriving OpenCode tool summaries only from legacy JSON session files when SQLite is authoritative
+
+### 14. Cursor completeness warning
+
+Current anchor:
+
+- `src/parsers/cursor.ts`
+- `src/utils/markdown.ts`
+
+Required outcome:
+
+- mark transcript completeness limits when raw storage is known to omit outputs or other fidelity
+- align parser confidence with the stronger caution already present in the docs
+- evaluate a confidence-graded secondary ingestion path for richer local Cursor state without presenting undocumented stores as canonical
+
+### 15. Confidence-graded source labeling in handoffs and docs
+
+Current anchor:
+
+- `src/utils/markdown.ts`
+- `src/parsers/registry.ts`
+- docs under `docs/parser-documentation/`
+
+Required outcome:
+
+- distinguish vendor-documented facts from local observation and unresolved inference
+- surface weaker storage claims as weaker instead of presenting them with the same confidence as first-party-documented paths
+- make docs-vs-parser mismatches explicit when the docs have already advanced beyond the implementation
+
+## P3: Docs, Tests, And Registry Hygiene
+
+### 16. Shared artifact and MCP discovery layer
+
+Current anchor:
+
+- shared parser utilities under `src/utils/`
+- `src/parsers/registry.ts`
+
+Required outcome:
+
+- add a shared artifact-scanning utility inspired by agentlytics’ `editors/base.js` + `editors/index.js`
+- add shared MCP config discovery instead of keeping MCP knowledge only in docs
+- keep this as parser-adjacent context, not UI-only metadata
+
+### 17. Update registry help text to stop implying canonical truth
+
+Current anchor:
+
+- `src/parsers/registry.ts`
+
+Required outcome:
+
+- storage-path strings become clearly descriptive rather than authoritative
+- variant-aware help text where necessary
+
+### 18. Expand fixtures/tests for backend variants
+
+Current anchor:
+
+- `src/__tests__/fixtures/index.ts`
+- `src/__tests__/unit-conversions.test.ts`
+- parser-specific tests
+
+Required outcome:
+
+- tests cover legacy/current variants where research found drift
+- regression tests explicitly protect the simplified human-facing contract plus any separate machine/inspection surface
+- tests cover confidence-graded warnings for weaker backends where practical
+- add fixtures or regression cases for the strongest agentlytics-vs-us mismatches where practical
+
+### 19. Align README with current tool reality
+
+Current anchor:
+
+- `README.md`
+
+Required outcome:
+
+- update tool counts and capability descriptions
+- explain the new handoff structure once implemented
+- avoid overselling undocumented storage internals as stable product truth
+
+### 20. If sessionr integration becomes a product feature, treat async as nondeterministic for new-session ID recovery
+
+Current anchor:
+
+- any future integration docs or code paths that invoke `sessionr`
+
+Required outcome:
+
+- prefer sync JSON output when deterministic created-session IDs are required
+- do not assume `--new --async` can always tell you which session to read afterward
+- if async is used, make the recovery path explicit and defensive

--- a/docs/parser-documentation/99-open-questions.md
+++ b/docs/parser-documentation/99-open-questions.md
@@ -1,0 +1,96 @@
+# Consolidated Open Questions
+
+Access date: 2026-04-15
+
+This file merges the unresolved items that still block full parser confidence.
+
+## Highest Priority
+
+### Kiro
+
+- Is the supported target Kiro IDE, Kiro CLI, or both?
+- If SQLite under `~/.kiro/` is canonical for normal CLI chat, what exact DB filename/schema should `continues` read?
+- Are the current parser’s `workspace-sessions/*.json` files still live anywhere outside exports/tests, or only an IDE-private/internal/export surface?
+
+### Antigravity
+
+- What schema governs the observed `.pb` conversation files under `~/.gemini/antigravity/conversations/`?
+- Are `code_tracker` files auxiliary telemetry/code-edit state or some parser-useful secondary surface?
+- What is the public first-party encryption/decryption contract, if any, for `.pb` conversation files?
+
+### Gemini
+
+- Which current installs still emit legacy JSON session objects?
+- Should discovery detect JSON vs JSONL per session root or per file signature?
+- Should the parser use `projects.json` / short-id mapping for workspace attribution, or is that too coupled to internal registry details?
+
+### Kilo Code
+
+- Is any current Kilo shipping surface still actively writing `ui_messages.json`, or should that now be treated as migration-only/legacy-only in this repo?
+- Should `continues` explicitly support both extension-side legacy artifacts and the DB-backed/OpenCode-derived runtime, or only the canonical live store?
+
+## Medium Priority
+
+### Cursor
+
+- How complete are local `agent-transcripts` relative to exported transcripts?
+- Are tool inputs always present locally, or only on some builds/channels?
+- Should the parser emit an explicit transcript-completeness warning by default for Cursor-derived handoffs?
+
+### Factory Droid
+
+- Did `~/.factory/projects/.../*.jsonl` fully replace `~/.factory/sessions/...`, or do both still coexist across versions/surfaces?
+- What are the exact continuation semantics on disk: fresh file on resume, append to same file, or version-dependent behavior?
+
+### Amp
+
+- What is the exact on-disk schema/path of the client-side local thread history?
+- Are local CLI thread artifacts a stable parser target, or is the web/server thread the only safe canonical surface?
+
+### Copilot
+
+- What role does per-session `session.db` play relative to `events.jsonl` and the global `session-store.db`?
+- Should `continues` use it for richer tool/rewind/file context?
+- Should Copilot discovery honor `COPILOT_HOME` / `--config-dir` fully and use `session-store.db` as a discovery/enrichment fallback when raw files are partial?
+
+### Codex
+
+- Which secondary artifacts should be exposed by default in the pointer block: rollout file only, or rollout plus state/history/index sidecars?
+- Should the product explicitly warn that rollouts are primary but not guaranteed to capture every product surface perfectly, such as review-mode logging gaps?
+- Does any current rollout sample still emit top-level token counters, or should nested `payload.info.*` be treated as the only supported shape?
+
+### Handoff Contract
+
+- What exact public API should represent the separate machine/inspection surface if the human-facing contract is simplified?
+- Should same-tool debug become “show native resume/action path” instead of a hard error?
+- Should prompt-debug output gain a structured machine-readable envelope in addition to plain text?
+- Should artifact and MCP discovery become a shared parser-adjacent feature in `continues` rather than remain only in documentation?
+
+## Recommended Next Validation Pass
+
+Run live local captures for:
+
+- `gemini`
+- `kiro`
+- `antigravity`
+- `cursor`
+- `amp`
+- `droid`
+- `kilo-code`
+
+For each, capture the file tree after:
+
+1. first prompt
+2. first assistant response
+3. first tool call
+4. resume
+5. compact/rewind if supported
+6. archive/export if supported
+
+Then compare the live tree to the corresponding docs in:
+
+- `storage-format/`
+- `message-schema/`
+- `tool-call-map/`
+- `access-recipes/`
+- `handoff-pointers/`

--- a/docs/parser-documentation/README.md
+++ b/docs/parser-documentation/README.md
@@ -1,0 +1,100 @@
+# Parser Documentation Research
+
+This directory is the evidence base for schema accuracy work in `continues`.
+
+The immediate driver is a parser-quality problem:
+
+- session extraction is inconsistent across tools
+- verbosity reduction is too open-ended at the top level
+- the handoff lacks a concise technical pointer block for deeper inspection
+- tool activity often becomes normalized in ways that hide the exact original function names
+- assistant-message coverage needs independent validation per tool
+
+The goal of this research set is to give future parser and handoff work a hard evidence base instead of assumptions.
+
+## Top-Level Entry Points
+
+Start here if you need the integrated picture rather than a single context:
+
+- `docs/parser-documentation/00-overview.md`
+- `docs/parser-documentation/01-parser-redesign-backlog.md`
+- `docs/parser-documentation/99-open-questions.md`
+
+If you need mission-driven follow-up work, start here:
+
+- `docs/parser-documentation/prompts/2026-04-15-cto-session-schema-audit.md`
+- `docs/parser-documentation/prompts/2026-04-15-default-full-handoff-redesign.md`
+- `docs/parser-documentation/prompts/2026-04-15-live-storage-capture-validation.md`
+
+## Output Layout
+
+Research outputs belong under:
+
+- `docs/parser-documentation/storage-format/`
+- `docs/parser-documentation/message-schema/`
+- `docs/parser-documentation/tool-call-map/`
+- `docs/parser-documentation/access-recipes/`
+- `docs/parser-documentation/handoff-pointers/`
+- `docs/parser-documentation/prompts/`
+
+`[context]` is the folder name above. Treat it as a variable-like placeholder in prompt language and mission docs.
+
+Within each context folder, documents should follow:
+
+- `01-claude.md`
+- `02-codex.md`
+- `03-copilot.md`
+- `04-gemini.md`
+- `05-opencode.md`
+- `06-droid.md`
+- `07-cursor.md`
+- `08-amp.md`
+- `09-kiro.md`
+- `10-crush.md`
+- `11-cline.md`
+- `12-roo-code.md`
+- `13-kilo-code.md`
+- `14-antigravity.md`
+- `15-kimi.md`
+- `16-qwen-code.md`
+
+If a context needs an overview or synthesis file, reserve:
+
+- `00-overview.md`
+- `99-open-questions.md`
+
+## Research Standard
+
+Every tool document should be evidence-backed and should explicitly distinguish:
+
+- documented fact
+- observed example
+- inference
+- unresolved uncertainty
+
+When possible, include:
+
+- storage path and env-var overrides
+- file/database format
+- session-id semantics
+- how assistant messages are represented
+- how tool calls are represented
+- how to retrieve deeper data directly
+- how this should inform handoff pointer design
+
+## Document Ceiling
+
+The research wave may create up to 100 markdown documents here if the evidence justifies it. That is a ceiling, not a target.
+
+## Current Code Anchors
+
+Start with these files when grounding the research against the product:
+
+- `src/types/tool-names.ts`
+- `src/parsers/registry.ts`
+- `src/config/verbosity.ts`
+- `src/utils/markdown.ts`
+- `src/utils/tool-summarizer.ts`
+- `src/parsers/*.ts`
+
+The main mission brief for the schema audit lives in `docs/parser-documentation/prompts/2026-04-15-cto-session-schema-audit.md`.

--- a/docs/parser-documentation/access-recipes/00-overview.md
+++ b/docs/parser-documentation/access-recipes/00-overview.md
@@ -1,0 +1,92 @@
+# Access Recipes Overview
+
+This folder answers one product question: what should a future handoff put at the top so a downstream agent can inspect deeper raw data without guessing.
+
+## Most Actionable Pointer Fields
+
+- Raw source path.
+- Storage family: `jsonl`, `json`, `yaml+jsonl`, `sqlite`, or mixed.
+- Session ID and any alternate IDs used by indexes or sidecars.
+- One message-range recipe.
+- One tool-call recipe.
+- One "deeper artifacts" recipe for sidecars like subagents, snapshots, checkpoints, or DB tables.
+
+## Highest-Value Retrieval Patterns
+
+### JSONL append logs
+
+These are the easiest to pointerize because the raw source is directly sliceable with line numbers.
+
+- Claude, Codex, Droid, Cursor, Kimi, and Qwen all have JSONL-backed primary logs in at least one known format.
+- For "messages 10-30", the baseline pattern is:
+
+```bash
+awk 'NR>=10 && NR<=30' "$SESSION_FILE" | jq .
+```
+
+- For "tool calls between messages 10 and 30", the main trick is filtering the tool-carrying records after line slicing:
+
+```bash
+awk 'NR>=10 && NR<=30' "$SESSION_FILE" \
+  | jq -cr 'select(.type=="response_item" and .payload.type=="function_call")'
+```
+
+### JSON session blobs
+
+These are best pointerized with array indexes, not line numbers.
+
+- Gemini current local installs still show `session-*.json` blobs under `~/.gemini/tmp/*/chats/`.
+- Amp threads are single JSON files under `~/.local/share/amp/threads/`.
+- Kiro exposes explicit JSON save/load flows even though current parser assumptions target a different on-disk layout.
+
+```bash
+jq '.messages[9:30]' "$SESSION_JSON"
+```
+
+### SQLite
+
+SQLite-backed tools need both table discovery and one or two canned joins.
+
+- OpenCode: `opencode.db` is the richest single raw source in the entire tool set.
+- Crush: `crush.db` is small and readable, with core data in `sessions` and `messages`.
+- Codex also keeps a state DB alongside rollout JSONL; the parser currently ignores it.
+- Copilot ships a `session.db`, but observed local installs use it for todos, not conversation replay.
+
+```bash
+sqlite3 "$DB" '.tables'
+sqlite3 "$DB" 'PRAGMA table_info(session);'
+```
+
+## Highest-Risk Parser Mismatches
+
+- Gemini: current parser expects JSON session blobs; current upstream Gemini CLI code writes JSONL records in `chatRecordingService.ts`. This looks like a format transition that the redesign should surface explicitly.
+- Codex: current parser reads rollout JSONL only; local installs also expose `session_index.jsonl`, `history.jsonl`, `archived_sessions/`, and a state SQLite DB with `threads` and `thread_spawn_edges`.
+- Copilot: current parser reads `workspace.yaml` and `events.jsonl`, but local sessions also contain `rewind-snapshots/`, `files/`, `checkpoints/`, `vscode.metadata.json`, and `session.db`.
+- Kiro: current parser targets `~/Library/Application Support/Kiro/workspace-sessions/*.json`, but current first-party Kiro CLI docs describe `~/.kiro/` SQLite-backed auto-save plus JSON export/import commands.
+- Antigravity: current parser assumes `~/.gemini/antigravity/code_tracker/` contains JSON/JSONL conversation logs; local observation on this machine shows `code_tracker/active/` behaving like tracked file snapshots, not chat transcripts.
+- Claude: local observation confirmed `.jsonl` transcripts plus sibling `subagents/` and `tool-results/`, but did not find `sessions-index.json` even though multiple first-party issues discuss it.
+
+## Recommended Pointer Block Shape
+
+For the redesign, the pointer block should be compact and executable:
+
+```text
+Raw source: ~/.codex/sessions/2026/04/15/rollout-...jsonl
+Format: JSONL
+Session ID: 019d...
+Inspect messages 10-30: awk 'NR>=10 && NR<=30' "$file" | jq .
+Inspect tool calls: jq -cr 'select(.type=="response_item" and .payload.type=="function_call")' "$file"
+Deeper artifacts: ~/.codex/state_5.sqlite -> tables: threads, thread_spawn_edges
+```
+
+## Sources
+
+- [Claude Code settings](https://code.claude.com/docs/en/settings) (accessed 2026-04-15)
+- [OpenAI Codex CLI features](https://developers.openai.com/codex/cli/features) (accessed 2026-04-15)
+- [Gemini CLI session management](https://geminicli.com/docs/cli/session-management/) (accessed 2026-04-15)
+- [Google blog: Gemini CLI session management](https://developers.googleblog.com/pick-up-exactly-where-you-left-off-with-session-management-in-gemini-cli/) (accessed 2026-04-15)
+- [google-gemini/gemini-cli: chatRecordingService.ts](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts) (accessed 2026-04-15)
+- [openai/codex: codex-rs/rollout/src/recorder.rs](https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder.rs) (accessed 2026-04-15)
+- [anomalyco/opencode: session.sql.ts](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/session/session.sql.ts) (accessed 2026-04-15)
+- [docs.cline.bot: Task History Recovery Guide](https://docs.cline.bot/troubleshooting/task-history-recovery) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/01-claude.md
+++ b/docs/parser-documentation/access-recipes/01-claude.md
@@ -1,0 +1,60 @@
+# Claude Access Recipes
+
+## Raw Source
+
+- Documented fact: Claude Code settings docs confirm session persistence can be disabled with `CLAUDE_CODE_SKIP_PROMPT_HISTORY`, and old session files are cleaned up via `cleanupPeriodDays`, but the docs do not publish the transcript path directly. Source: [settings docs](https://code.claude.com/docs/en/settings) (accessed 2026-04-15).
+- Documented fact, user-reported: first-party issues describe raw session files under `~/.claude/projects/` as `.jsonl`, and discuss missing or stale `sessions-index.json`. Sources: [issue #18897](https://github.com/anthropics/claude-code/issues/18897), [issue #25032](https://github.com/anthropics/claude-code/issues/25032) (accessed 2026-04-15).
+- Observed example: on this machine, Claude stores transcripts as `~/.claude/projects/<project-slug>/<session-id>.jsonl` and also creates a sibling directory `~/.claude/projects/<project-slug>/<session-id>/` containing `subagents/` and sometimes `tool-results/`. Observed 2026-04-15.
+- Unresolved: current first-party docs do not confirm whether `sessions-index.json` is still part of current releases, and local observation did not find any such file on this machine.
+
+## Retrieval Patterns
+
+### Slice messages 10-30 from the transcript
+
+```bash
+file=~/.claude/projects/<project>/<session>.jsonl
+awk 'NR>=10 && NR<=30' "$file" | jq .
+```
+
+### Extract tool uses between those lines
+
+```bash
+awk 'NR>=10 && NR<=30' "$file" \
+  | jq -cr '
+      select(.type=="assistant" and (.message.content|type)=="array")
+      | .message.content[]?
+      | select(.type=="tool_use")
+      | {name, id, input}
+    '
+```
+
+### Find assistant messages that include edit-related tool calls
+
+```bash
+jq -cr '
+  select(.type=="assistant" and (.message.content|type)=="array")
+  | .message.content[]?
+  | select(.type=="tool_use" and (.name|test("Write|Edit|MultiEdit|Bash")))
+' "$file"
+```
+
+### Inspect subagent and external tool-result sidecars
+
+```bash
+session_dir="${file%.jsonl}"
+find "$session_dir/subagents" -type f 2>/dev/null
+find "$session_dir/tool-results" -type f 2>/dev/null
+```
+
+## Current Parser Comparison
+
+- Current parser assumptions are mostly aligned on the primary transcript path and the sibling `subagents/` and `tool-results/` folders.
+- The current handoff renderer only points to the main `.jsonl` file. For Claude, the pointer block should also expose the sibling session directory because subagent transcripts and oversized tool outputs live there.
+- Current parser code does not rely on `sessions-index.json`, which is good because local observation did not find it, but the redesign should still mention the index uncertainty explicitly.
+
+## Sources
+
+- [Claude Code settings](https://code.claude.com/docs/en/settings) (accessed 2026-04-15)
+- [anthropics/claude-code issue #18897](https://github.com/anthropics/claude-code/issues/18897) (accessed 2026-04-15)
+- [anthropics/claude-code issue #25032](https://github.com/anthropics/claude-code/issues/25032) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/02-codex.md
+++ b/docs/parser-documentation/access-recipes/02-codex.md
@@ -1,0 +1,62 @@
+# Codex Access Recipes
+
+## Raw Source
+
+- Documented fact: OpenAI docs say Codex stores transcripts locally and tells users to copy session IDs from files under `~/.codex/sessions/`. Source: [Codex CLI features](https://developers.openai.com/codex/cli/features) (accessed 2026-04-15).
+- Documented fact: upstream code writes rollout JSONL files and explicitly shows inspection with `jq` and `fx`. Source: [openai/codex `recorder.rs`](https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder.rs) (accessed 2026-04-15).
+- Documented fact: upstream code creates dated subdirectories under `sessions/YYYY/MM/DD/` for rollout files and also maintains a state DB path per Codex home. Source: same repo file plus local state DB observation on 2026-04-15.
+- Observed example: this machine also has `~/.codex/session_index.jsonl`, `~/.codex/history.jsonl`, `~/.codex/archived_sessions/`, and `~/.codex/state_5.sqlite`. Observed 2026-04-15.
+
+## Retrieval Patterns
+
+### Locate the rollout file for a thread ID
+
+```bash
+id=019d9048-4378-73b2-a207-94b82b3ab6b7
+find ~/.codex/sessions ~/.codex/archived_sessions -name "rollout-*-$id.jsonl"
+```
+
+### Slice messages 10-30
+
+```bash
+awk 'NR>=10 && NR<=30' "$ROLLOUT" | jq .
+```
+
+### Extract function calls and join outputs
+
+```bash
+jq -cr '
+  select(.type=="response_item" and (.payload.type=="function_call" or .payload.type=="function_call_output"))
+  | .payload
+' "$ROLLOUT"
+```
+
+### Query thread metadata and spawn relationships from SQLite
+
+```bash
+sqlite3 ~/.codex/state_5.sqlite '.tables'
+sqlite3 ~/.codex/state_5.sqlite \
+  'SELECT id, title, rollout_path, cwd, git_branch, model, reasoning_effort FROM threads ORDER BY updated_at DESC LIMIT 20;'
+sqlite3 ~/.codex/state_5.sqlite \
+  'SELECT parent_thread_id, child_thread_id, status FROM thread_spawn_edges LIMIT 20;'
+```
+
+### Inspect the lightweight indexes
+
+```bash
+sed -n '1,20p' ~/.codex/session_index.jsonl | jq .
+sed -n '1,20p' ~/.codex/history.jsonl | jq .
+```
+
+## Current Parser Comparison
+
+- Current parser reads rollout JSONL only. That is enough for conversation replay but not enough for a strong pointer block.
+- The redesign should expose `rollout_path` plus the existence of the state SQLite DB and index JSONL files.
+- Current parser also ignores `archived_sessions/`, which matters for resumed or archived work.
+
+## Sources
+
+- [Codex CLI features](https://developers.openai.com/codex/cli/features) (accessed 2026-04-15)
+- [openai/codex `recorder.rs`](https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder.rs) (accessed 2026-04-15)
+- [openai/codex discussion #3827](https://github.com/openai/codex/discussions/3827) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/03-copilot.md
+++ b/docs/parser-documentation/access-recipes/03-copilot.md
@@ -1,0 +1,58 @@
+# Copilot Access Recipes
+
+## Raw Source
+
+- Documented fact, user-reported in first-party tracker: local session-state uses `workspace.yaml` and `events.jsonl` under `~/.copilot/session-state/`. Source: [github/copilot-cli issue #2396](https://github.com/github/copilot-cli/issues/2396) (accessed 2026-04-15).
+- Documented fact, user-reported in first-party tracker: long-lived sessions may also involve `session.db`, and `events.jsonl` can contain multiple `session.start`, `session.resume`, and `session.shutdown` segments. Source: [issue #2209](https://github.com/github/copilot-cli/issues/2209) (accessed 2026-04-15).
+- Observed example: local session directories on this machine contain `workspace.yaml`, `events.jsonl`, `checkpoints/`, `files/`, `rewind-snapshots/`, optional `vscode.metadata.json`, and sometimes `session.db`. Observed 2026-04-15.
+- Observed example: the sampled `session.db` on this machine contains only `todos` and `todo_deps`, not the main conversation transcript. Observed 2026-04-15.
+
+## Retrieval Patterns
+
+### Read workspace metadata
+
+```bash
+dir=~/.copilot/session-state/<session-id>
+sed -n '1,40p' "$dir/workspace.yaml"
+```
+
+### Slice event rows 10-30
+
+```bash
+awk 'NR>=10 && NR<=30' "$dir/events.jsonl" | jq .
+```
+
+### Extract assistant tool requests in that slice
+
+```bash
+awk 'NR>=10 && NR<=30' "$dir/events.jsonl" \
+  | jq -cr '
+      select(.type=="assistant.message")
+      | {timestamp, content:.data.content, toolRequests:(.data.toolRequests // [])}
+    '
+```
+
+### Inspect rewind snapshot metadata
+
+```bash
+sed -n '1,120p' "$dir/rewind-snapshots/index.json" | jq .
+```
+
+### Discover whether `session.db` is worth querying
+
+```bash
+sqlite3 "$dir/session.db" '.tables'
+sqlite3 "$dir/session.db" 'SELECT * FROM todos LIMIT 20;'
+```
+
+## Current Parser Comparison
+
+- Current parser reads `workspace.yaml` and `events.jsonl`, which is correct for core conversation recovery.
+- The current handoff misses deeper artifacts that are useful for technical follow-up: `rewind-snapshots/index.json`, checkpoint markdown, sidecar files, and the presence or absence of a meaningful `session.db`.
+- The redesign should not assume `session.db` contains transcript rows; local observation suggests it may only hold task/todo state.
+
+## Sources
+
+- [github/copilot-cli issue #2396](https://github.com/github/copilot-cli/issues/2396) (accessed 2026-04-15)
+- [github/copilot-cli issue #2209](https://github.com/github/copilot-cli/issues/2209) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/04-gemini.md
+++ b/docs/parser-documentation/access-recipes/04-gemini.md
@@ -1,0 +1,54 @@
+# Gemini Access Recipes
+
+## Raw Source
+
+- Documented fact: first-party session-management docs place saved sessions under `~/.gemini/tmp/<project_hash>/chats/` and say sessions include prompts, model responses, tool executions, token usage, and reasoning summaries. Source: [Gemini CLI session management](https://geminicli.com/docs/cli/session-management/) (accessed 2026-04-15).
+- Documented fact: Google’s blog says the feature is automatic from v0.20.0+, project-scoped, and restorable via `/resume`, `--resume`, and `--list-sessions`. Source: [Google blog post](https://developers.googleblog.com/pick-up-exactly-where-you-left-off-with-session-management-in-gemini-cli/) (accessed 2026-04-15).
+- Documented fact: current upstream repo code writes append-only JSONL chat records with metadata updates, message records, thoughts, tokens, tool calls, rewind markers, and subagent chat directories. Source: [google-gemini/gemini-cli `chatRecordingService.ts`](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts) (accessed 2026-04-15).
+- Observed example: this machine still stores `session-*.json` blobs in `~/.gemini/tmp/<project>/chats/`, and those JSON files contain a top-level `messages` array with `type`, `content`, `thoughts`, `tokens`, and `model`. Observed 2026-04-15.
+- Inference: Gemini CLI appears to be in a storage transition from JSON session blobs to JSONL chat records; future pointer blocks should include both the path and the detected format version.
+
+## Retrieval Patterns
+
+### If the session is a JSON blob
+
+```bash
+file=~/.gemini/tmp/<project>/chats/session-2026-04-06T08-43-867ca735.json
+jq '.messages[9:30]' "$file"
+```
+
+### Tool calls from a JSON blob
+
+```bash
+jq -cr '
+  .messages[9:30][]
+  | select(.type=="gemini" and (.toolCalls // [] | length > 0))
+  | .toolCalls[]
+' "$file"
+```
+
+### If the install has switched to JSONL
+
+```bash
+awk 'NR>=10 && NR<=30' "$JSONL_CHAT" | jq .
+```
+
+### Resume/list commands that are worth surfacing in a pointer block
+
+```bash
+gemini --list-sessions
+gemini --resume
+gemini --resume <SESSION_ID>
+```
+
+## Current Parser Comparison
+
+- Current parser matches the observed local JSON format, not the current upstream JSONL writer on `main`.
+- The redesign should expose the actual file format it detected so downstream agents know whether to use `jq '.messages[...]'` or line-oriented JSONL slicing.
+- Current handoff also omits the possibility of richer JSONL-only artifacts like rewind records and subagent chat directories.
+
+## Sources
+
+- [Gemini CLI session management](https://geminicli.com/docs/cli/session-management/) (accessed 2026-04-15)
+- [Google blog: Gemini CLI session management](https://developers.googleblog.com/pick-up-exactly-where-you-left-off-with-session-management-in-gemini-cli/) (accessed 2026-04-15)
+- [google-gemini/gemini-cli `chatRecordingService.ts`](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts) (accessed 2026-04-15)

--- a/docs/parser-documentation/access-recipes/05-opencode.md
+++ b/docs/parser-documentation/access-recipes/05-opencode.md
@@ -1,0 +1,64 @@
+# OpenCode Access Recipes
+
+## Raw Source
+
+- Documented fact: current upstream OpenCode stores sessions in SQLite tables `session`, `message`, `part`, `todo`, and `session_entry`. Source: [anomalyco/opencode `session.sql.ts`](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/session/session.sql.ts) (accessed 2026-04-15).
+- Documented fact: upstream migration code confirms an older JSON storage tree under `storage/project`, `storage/session`, `storage/message`, `storage/part`, `storage/todo`, `storage/permission`, and `storage/session_share`. Source: [anomalyco/opencode `json-migration.ts`](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/storage/json-migration.ts) (accessed 2026-04-15).
+- Observed example: this machine has `~/.local/share/opencode/opencode.db`, plus sidecars like `storage/session_diff/`, `tool-output/`, `snapshot/`, `log/`, and `opencode.db-wal`. Observed 2026-04-15.
+
+## Retrieval Patterns
+
+### Discover tables and session rows
+
+```bash
+db=~/.local/share/opencode/opencode.db
+sqlite3 "$db" '.tables'
+sqlite3 "$db" 'SELECT id, project_id, title, directory, time_updated FROM session ORDER BY time_updated DESC LIMIT 20;'
+```
+
+### Pull messages 10-30 for one session
+
+```bash
+sqlite3 "$db" "
+  SELECT m.id, json_extract(m.data,'$.role') AS role, m.time_created
+  FROM message m
+  WHERE m.session_id = 'ses_...'
+  ORDER BY m.time_created, m.id
+  LIMIT 21 OFFSET 9;
+"
+```
+
+### Join message parts to find assistant tool parts and edits
+
+```bash
+sqlite3 "$db" "
+  SELECT p.message_id, json_extract(m.data,'$.role') AS role,
+         json_extract(p.data,'$.type') AS part_type,
+         json_extract(p.data,'$.tool') AS tool_name,
+         json_extract(p.data,'$.state.status') AS tool_status
+  FROM part p
+  JOIN message m ON m.id = p.message_id
+  WHERE p.session_id = 'ses_...'
+  ORDER BY m.time_created, p.id;
+"
+```
+
+### Fallback JSON tree inspection
+
+```bash
+find ~/.local/share/opencode/storage/session -name 'ses_*.json'
+find ~/.local/share/opencode/storage/message/ses_... -name 'msg_*.json' | sort
+find ~/.local/share/opencode/storage/part/msg_... -name 'prt_*.json' | sort
+```
+
+## Current Parser Comparison
+
+- Current parser already supports both SQLite and legacy JSON files, which is good.
+- The current handoff still omits deeper tables and sidecars that matter for technical continuation: `session_entry`, `event`, `workspace`, `tool-output`, and `session_diff`.
+- For OpenCode, the pointer block should prefer the SQLite DB path plus a one-line `session_id`, because that is the most information-dense raw source.
+
+## Sources
+
+- [anomalyco/opencode `session.sql.ts`](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/session/session.sql.ts) (accessed 2026-04-15)
+- [anomalyco/opencode `json-migration.ts`](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/storage/json-migration.ts) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/06-droid.md
+++ b/docs/parser-documentation/access-recipes/06-droid.md
@@ -1,0 +1,51 @@
+# Droid Access Recipes
+
+## Raw Source
+
+- Documented fact: Factory CLI supports explicit session resume via `droid exec -s <id>` and interactive session browsing via `/sessions`, but its public docs do not publish the raw transcript path or format. Source: [Factory CLI reference](https://docs.factory.ai/reference/cli-reference) (accessed 2026-04-15).
+- Documented fact: Factory quickstart confirms interactive sessions exist, but does not describe raw storage. Source: [Factory quickstart](https://docs.factory.ai/cli/getting-started/quickstart) (accessed 2026-04-15).
+- Observed example: on this machine, Droid stores JSONL transcripts under `~/.factory/sessions/<workspace-slug>/<session-id>.jsonl` with paired `<session-id>.settings.json` files in the same directory. Observed 2026-04-15.
+- Observed example: the sampled transcript starts with a `session_start` object, then `message` records whose `message.content` blocks look Anthropic-like, while the settings sidecar holds model and token usage. Observed 2026-04-15.
+
+## Retrieval Patterns
+
+### Find a session and inspect the first records
+
+```bash
+find ~/.factory/sessions -name '*.jsonl' | head
+sed -n '1,10p' ~/.factory/sessions/<workspace>/<session>.jsonl | jq .
+```
+
+### Slice messages 10-30
+
+```bash
+awk 'NR>=10 && NR<=30' ~/.factory/sessions/<workspace>/<session>.jsonl | jq .
+```
+
+### Extract assistant tool-use blocks
+
+```bash
+jq -cr '
+  select(.type=="message" and .message.role=="assistant")
+  | .message.content[]?
+  | select(.type=="tool_use")
+' ~/.factory/sessions/<workspace>/<session>.jsonl
+```
+
+### Read the settings sidecar
+
+```bash
+sed -n '1,120p' ~/.factory/sessions/<workspace>/<session>.settings.json | jq .
+```
+
+## Current Parser Comparison
+
+- Current parser assumptions about `.jsonl` plus `.settings.json` are strongly supported by local observation.
+- The parser is using the right primary source, but the handoff pointer should mention the settings sidecar explicitly because that is where model and aggregated token usage live.
+- Public Factory docs are currently too thin to treat the path itself as documented fact; keep it labeled as observed example unless Factory publishes it.
+
+## Sources
+
+- [Factory CLI reference](https://docs.factory.ai/reference/cli-reference) (accessed 2026-04-15)
+- [Factory quickstart](https://docs.factory.ai/cli/getting-started/quickstart) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/07-cursor.md
+++ b/docs/parser-documentation/access-recipes/07-cursor.md
@@ -1,0 +1,50 @@
+# Cursor Access Recipes
+
+## Raw Source
+
+- Documented fact: first-party Cursor docs for shared transcripts do not describe local raw storage. Source: [Cursor shared transcripts](https://cursor.com/help/ai-features/shared-transcripts) (accessed 2026-04-15).
+- Observed example: on this machine, Cursor stores project-scoped agent transcripts under `~/.cursor/projects/<project-slug>/agent-transcripts/<session-id>.jsonl`, alongside `repo.json`, `.workspace-trusted`, and `worker.log`. Observed 2026-04-15.
+- Observed example: sampled transcript rows are plain JSON objects with `role` and `message.content[]` blocks that resemble Anthropic transcript blocks.
+- Unresolved: I did not find a first-party Cursor doc that confirms the `agent-transcripts` path or guarantees the JSONL schema.
+
+## Retrieval Patterns
+
+### Discover transcript files
+
+```bash
+find ~/.cursor/projects -path '*/agent-transcripts/*.jsonl'
+```
+
+### Slice messages 10-30
+
+```bash
+awk 'NR>=10 && NR<=30' ~/.cursor/projects/<slug>/agent-transcripts/<session>.jsonl | jq .
+```
+
+### Extract assistant tool calls or text blocks
+
+```bash
+jq -cr '
+  select(.role=="assistant")
+  | .message.content[]?
+  | select(.type=="tool_use" or .type=="text")
+' ~/.cursor/projects/<slug>/agent-transcripts/<session>.jsonl
+```
+
+### Use sidecars for repo context
+
+```bash
+sed -n '1,80p' ~/.cursor/projects/<slug>/repo.json | jq .
+tail -n 50 ~/.cursor/projects/<slug>/worker.log
+```
+
+## Current Parser Comparison
+
+- Current parser assumption about `~/.cursor/projects/*/agent-transcripts/` is supported by local observation.
+- The parser currently only points to the transcript. The redesign should also expose the project slug and `repo.json` because Cursor has no native resume CLI here, so downstream navigation depends on project context as much as transcript context.
+- Because first-party storage docs are missing, Cursor should stay labeled as observed/inferred rather than documented fact.
+
+## Sources
+
+- [Cursor shared transcripts](https://cursor.com/help/ai-features/shared-transcripts) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/08-amp.md
+++ b/docs/parser-documentation/access-recipes/08-amp.md
@@ -1,0 +1,47 @@
+# Amp Access Recipes
+
+## Raw Source
+
+- Documented fact: Amp’s manual talks about threads, handoffs, thread references by ID or URL, `amp threads continue`, and a debug tool that can edit a thread in JSON, but it does not publish local storage paths. Source: [Amp manual](https://ampcode.com/manual) (accessed 2026-04-15).
+- Observed example: this machine stores thread JSON at `~/.local/share/amp/threads/T-....json` and also has `~/.local/share/amp/history.jsonl`, plus config/state files like `session.json`, `secrets.json`, and `device-id.json`. Observed 2026-04-15.
+- Observed example: sampled thread JSON has top-level keys like `id`, `created`, `messages`, `meta.traces`, and `env.initial`, while `history.jsonl` stores lightweight `{text,cwd}` rows.
+
+## Retrieval Patterns
+
+### Inspect a thread JSON file
+
+```bash
+find ~/.local/share/amp/threads -name 'T-*.json'
+jq '{id, created, message_count:(.messages|length), env, usageLedger}' ~/.local/share/amp/threads/T-....json
+```
+
+### Pull messages 10-30 from the JSON array
+
+```bash
+jq '.messages[9:30]' ~/.local/share/amp/threads/T-....json
+```
+
+### Find text blocks inside assistant or user messages
+
+```bash
+jq -cr '
+  .messages[9:30][]
+  | {role, messageId, text:[.content[]? | select(.type=="text") | .text]}
+' ~/.local/share/amp/threads/T-....json
+```
+
+### Use the lightweight prompt history
+
+```bash
+sed -n '1,20p' ~/.local/share/amp/history.jsonl | jq .
+```
+
+## Current Parser Comparison
+
+- Current parser path assumption `~/.local/share/amp/threads/` matches local observation.
+- The parser currently ignores `history.jsonl`, which is a cheap way to recover recent prompt text and cwd even if thread parsing fails.
+- Amp docs do not currently elevate the local path to documented fact, so keep the path labeled as observed example.
+
+## Sources
+
+- [Amp manual](https://ampcode.com/manual) (accessed 2026-04-15)

--- a/docs/parser-documentation/access-recipes/09-kiro.md
+++ b/docs/parser-documentation/access-recipes/09-kiro.md
@@ -1,0 +1,47 @@
+# Kiro Access Recipes
+
+## Raw Source
+
+- Documented fact: current first-party Kiro CLI docs say sessions are auto-saved per directory in a SQLite database under `~/.kiro/`, and also support JSON save/load/export style flows such as `/chat save <path>` and `/chat load <path>`. Sources: [chat docs](https://kiro.dev/docs/cli/chat/), [session management docs](https://kiro.dev/docs/cli/chat/session-management/), [CLI commands](https://kiro.dev/docs/cli/reference/cli-commands/) (accessed 2026-04-15).
+- Documented fact: Kiro docs explicitly say `/chat save` writes JSON files and `/chat load` reads JSON files; script hooks can receive or emit session JSON over stdin/stdout. Same sources, accessed 2026-04-15.
+- Current parser assumption: `~/Library/Application Support/Kiro/workspace-sessions/<workspace>/*.json`. This is not supported by current first-party Kiro CLI docs.
+- Observed example: this machine has `~/.kiro/` but no obvious session DB or exported chat files, and `~/Library/Application Support/Kiro/workspace-sessions/` does not exist. Observed 2026-04-15.
+- Unresolved: the current parser may be targeting an older Kiro IDE/macOS layout or a different product surface than the current Kiro CLI docs.
+
+## Retrieval Patterns
+
+### Official CLI-level access
+
+```bash
+kiro-cli chat --list-sessions
+kiro-cli chat --resume
+/chat save backup.json
+/chat load backup.json
+```
+
+### Probe the documented local storage root
+
+```bash
+find ~/.kiro -maxdepth 4 \( -name '*.db' -o -name '*.sqlite' -o -name '*.json' \)
+```
+
+### If the parser-targeted legacy JSON layout exists
+
+```bash
+find ~/Library/'Application Support'/Kiro/workspace-sessions -name '*.json' ! -name 'sessions.json'
+jq '.history[9:30]' ~/Library/'Application Support'/Kiro/workspace-sessions/<workspace>/<session>.json
+```
+
+## Current Parser Comparison
+
+- This is one of the clearest mismatches in the audit.
+- Current parser targets a macOS JSON layout that current first-party CLI docs do not describe.
+- The redesign should not present Kiro storage as settled. The pointer block should either detect the actual local layout at runtime or state that the parser is using a legacy/alternate storage strategy.
+
+## Sources
+
+- [Kiro chat docs](https://kiro.dev/docs/cli/chat/) (accessed 2026-04-15)
+- [Kiro session management docs](https://kiro.dev/docs/cli/chat/session-management/) (accessed 2026-04-15)
+- [Kiro CLI commands](https://kiro.dev/docs/cli/reference/cli-commands/) (accessed 2026-04-15)
+- [Kiro slash commands](https://kiro.dev/docs/cli/reference/slash-commands/) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/10-crush.md
+++ b/docs/parser-documentation/access-recipes/10-crush.md
@@ -1,0 +1,66 @@
+# Crush Access Recipes
+
+## Raw Source
+
+- Documented fact: Crush stores data in a SQLite database named `crush.db`. Source: [charmbracelet/crush `connect.go`](https://github.com/charmbracelet/crush/blob/main/internal/db/connect.go) (accessed 2026-04-15).
+- Documented fact: core transcript data lives in `sessions` and `messages`, with message content stored as JSON in the `parts` column. Sources: [sessions.sql](https://github.com/charmbracelet/crush/blob/main/internal/db/sql/sessions.sql), [messages.sql](https://github.com/charmbracelet/crush/blob/main/internal/db/sql/messages.sql), [initial migration](https://github.com/charmbracelet/crush/blob/main/internal/db/migrations/20250424200609_initial.sql) (accessed 2026-04-15).
+- Current parser assumption `~/.crush/crush.db` is strongly supported by upstream code.
+- Observed example: there is no local `~/.crush/crush.db` on this machine, so the doc below is source-backed but not locally verified here.
+
+## Retrieval Patterns
+
+### Discover schema
+
+```bash
+db=~/.crush/crush.db
+sqlite3 "$db" '.tables'
+sqlite3 "$db" 'PRAGMA table_info(sessions);'
+sqlite3 "$db" 'PRAGMA table_info(messages);'
+```
+
+### List recent sessions
+
+```bash
+sqlite3 "$db" "
+  SELECT id, title, updated_at, prompt_tokens, completion_tokens
+  FROM sessions
+  ORDER BY updated_at DESC
+  LIMIT 20;
+"
+```
+
+### Pull messages 10-30 from one session
+
+```bash
+sqlite3 "$db" "
+  SELECT id, role, parts, created_at
+  FROM messages
+  WHERE session_id = '...'
+  ORDER BY created_at ASC
+  LIMIT 21 OFFSET 9;
+"
+```
+
+### Extract text from `parts`
+
+```bash
+sqlite3 "$db" "
+  SELECT json_extract(value,'$.data.text')
+  FROM messages, json_each(messages.parts)
+  WHERE session_id = '...' AND json_extract(value,'$.type') = 'text';
+"
+```
+
+## Current Parser Comparison
+
+- Current parser points at the correct DB and core tables.
+- The handoff should expose the DB path plus one ready-to-run SQL snippet, because Crush is not line-oriented.
+- Current parser does not mention the `files` table from the initial migration; if that table is still in use, it is a likely source for "assistant messages with edits stored" style questions.
+
+## Sources
+
+- [charmbracelet/crush `connect.go`](https://github.com/charmbracelet/crush/blob/main/internal/db/connect.go) (accessed 2026-04-15)
+- [charmbracelet/crush `sessions.sql`](https://github.com/charmbracelet/crush/blob/main/internal/db/sql/sessions.sql) (accessed 2026-04-15)
+- [charmbracelet/crush `messages.sql`](https://github.com/charmbracelet/crush/blob/main/internal/db/sql/messages.sql) (accessed 2026-04-15)
+- [charmbracelet/crush initial migration](https://github.com/charmbracelet/crush/blob/main/internal/db/migrations/20250424200609_initial.sql) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/11-cline.md
+++ b/docs/parser-documentation/access-recipes/11-cline.md
@@ -1,0 +1,55 @@
+# Cline Access Recipes
+
+## Raw Source
+
+- Documented fact: first-party recovery docs place task history under the extension globalStorage directory, with `taskHistory.json` as the index and per-task folders in `tasks/<task-id>/`. Source: [Task History Recovery Guide](https://docs.cline.bot/troubleshooting/task-history-recovery) (accessed 2026-04-15).
+- Documented fact: each task folder contains `api_conversation_history.json`, `ui_messages.json`, and `task_metadata.json`. Same source, accessed 2026-04-15.
+- Documented fact: upstream code names the same files and also writes per-task temp exports like `conversation_history_<timestamp>.json` and `.txt`. Source: [cline/cline `src/core/storage/disk.ts`](https://github.com/cline/cline/blob/main/src/core/storage/disk.ts) (accessed 2026-04-15).
+- Current parser assumption matches the default VS Code path: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/`.
+
+## Retrieval Patterns
+
+### Find the task root
+
+```bash
+base=~/Library/'Application Support'/Code/User/globalStorage/saoudrizwan.claude-dev
+find "$base/tasks" -maxdepth 2 -type f | head -n 30
+```
+
+### Read rendered UI messages
+
+```bash
+jq '.[9:30]' "$base/tasks/<task-id>/ui_messages.json"
+```
+
+### Read API-level conversation history
+
+```bash
+jq '.[9:30]' "$base/tasks/<task-id>/api_conversation_history.json"
+```
+
+### Read task metadata and history index
+
+```bash
+jq . "$base/tasks/<task-id>/task_metadata.json"
+jq . "$base/taskHistory.json"
+```
+
+### Rebuild or inspect task history
+
+```bash
+cd "$base/state"
+ls taskHistory.backup.*.json
+```
+
+## Current Parser Comparison
+
+- Current parser only reads `ui_messages.json`.
+- That is not enough for the redesign. `api_conversation_history.json` is the deeper raw source for tool calls and provider-facing message blocks, and `task_metadata.json` carries model/context metadata.
+- The pointer block for Cline should include both the task folder and the fact that `taskHistory.json` is only an index.
+
+## Sources
+
+- [Task History Recovery Guide](https://docs.cline.bot/troubleshooting/task-history-recovery) (accessed 2026-04-15)
+- [cline/cline `src/core/storage/disk.ts`](https://github.com/cline/cline/blob/main/src/core/storage/disk.ts) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/12-roo-code.md
+++ b/docs/parser-documentation/access-recipes/12-roo-code.md
@@ -1,0 +1,52 @@
+# Roo Code Access Recipes
+
+## Raw Source
+
+- Documented fact: Roo stores per-task history under `tasks/<task-id>/history_item.json` and maintains a cached `_index.json` under `tasks/`. Source: [Roo TaskHistoryStore](https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/TaskHistoryStore.ts) (accessed 2026-04-15).
+- Documented fact: Roo stores UI messages in `ui_messages.json`, API conversation history in `api_conversation_history.json`, and uses `getTaskDirectoryPath(globalStoragePath, taskId)` to resolve `tasks/<task-id>/`. Sources: [taskMessages.ts](https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/taskMessages.ts), [apiMessages.ts](https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/apiMessages.ts), [storage.ts](https://github.com/RooCodeInc/Roo-Code/blob/main/src/utils/storage.ts) (accessed 2026-04-15).
+- Documented fact: Roo supports a configurable `customStoragePath`; the default path is the extension host `globalStoragePath`. Source: `storage.ts`, accessed 2026-04-15.
+- User-reported first-party issues discuss `ui_messages.json` bloat and export mismatches, which reinforces that `ui_messages.json` is a raw persisted artifact, not just a cache. Sources: [issue #8690](https://github.com/RooCodeInc/Roo-Code/issues/8690), [issue #9580](https://github.com/RooCodeInc/Roo-Code/issues/9580) (accessed 2026-04-15).
+
+## Retrieval Patterns
+
+### Resolve the default task root
+
+```bash
+base=~/Library/'Application Support'/Code/User/globalStorage/rooveterinaryinc.roo-cline
+find "$base/tasks" -maxdepth 2 -type f | head -n 30
+```
+
+### Inspect the fast index and per-task history
+
+```bash
+jq . "$base/tasks/_index.json"
+jq . "$base/tasks/<task-id>/history_item.json"
+```
+
+### Compare rendered UI and API-level history
+
+```bash
+jq '.[9:30]' "$base/tasks/<task-id>/ui_messages.json"
+jq '.[9:30]' "$base/tasks/<task-id>/api_conversation_history.json"
+```
+
+### Inspect task metadata
+
+```bash
+jq . "$base/tasks/<task-id>/task_metadata.json"
+```
+
+## Current Parser Comparison
+
+- Current parser treats Roo like a Cline-family tool and reads only `ui_messages.json`.
+- Upstream Roo code shows a richer task folder structure and an optional `customStoragePath`. The redesign should mention both the default path and the possibility that the real source of truth has moved.
+- For technical continuation, `api_conversation_history.json` is the more important deep-inspection source than `ui_messages.json`.
+
+## Sources
+
+- [Roo TaskHistoryStore](https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/TaskHistoryStore.ts) (accessed 2026-04-15)
+- [Roo taskMessages.ts](https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/taskMessages.ts) (accessed 2026-04-15)
+- [Roo apiMessages.ts](https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/apiMessages.ts) (accessed 2026-04-15)
+- [Roo storage.ts](https://github.com/RooCodeInc/Roo-Code/blob/main/src/utils/storage.ts) (accessed 2026-04-15)
+- [Roo issue #8690](https://github.com/RooCodeInc/Roo-Code/issues/8690) (accessed 2026-04-15)
+- [Roo issue #9580](https://github.com/RooCodeInc/Roo-Code/issues/9580) (accessed 2026-04-15)

--- a/docs/parser-documentation/access-recipes/13-kilo-code.md
+++ b/docs/parser-documentation/access-recipes/13-kilo-code.md
@@ -1,0 +1,44 @@
+# Kilo Code Access Recipes
+
+## Raw Source
+
+- Documented fact: current first-party Kilo CLI docs support continuing sessions, exporting a session as JSON, importing session JSON, `/sessions`, `/copy`, and `/export`. Source: [Kilo CLI docs](https://kilo.ai/docs/code-with-ai/platforms/cli) (accessed 2026-04-15).
+- Documented fact: first-party architecture docs say Kilo CLI has a Session Manager with persistent session state, conversation history, and checkpoints, and that the CLI lives in `packages/opencode/`. Source: [Kilo architecture](https://kilo.ai/docs/contributing/architecture) (accessed 2026-04-15).
+- Current parser assumption: `kilo-code` uses a VS Code globalStorage task layout at `.../globalStorage/kilocode.kilo-code/tasks/`, mirroring Cline-family storage.
+- Unresolved: I did not find first-party Kilo docs or code that confirm the parser’s VS Code task-folder layout for `kilo-code`, and the first-party CLI docs instead point toward CLI session persistence plus JSON export/import.
+
+## Retrieval Patterns
+
+### First-party CLI path: use export/import when you need raw JSON now
+
+```bash
+kilo --continue
+kilo export <sessionID> > session.json
+kilo import session.json
+```
+
+### Parser-targeted extension path: treat as provisional
+
+```bash
+base=~/Library/'Application Support'/Code/User/globalStorage/kilocode.kilo-code
+find "$base/tasks" -maxdepth 2 -type f | head -n 30
+```
+
+### If the extension layout matches the Cline family
+
+```bash
+jq '.[9:30]' "$base/tasks/<task-id>/ui_messages.json"
+jq '.[9:30]' "$base/tasks/<task-id>/api_conversation_history.json"
+```
+
+## Current Parser Comparison
+
+- This tool should be treated as unresolved, not stable.
+- The parser currently assumes a Cline-family extension layout, but first-party Kilo CLI docs emphasize CLI session persistence and JSON export/import instead.
+- For redesign purposes, the pointer block should either detect which Kilo surface is present or explicitly say that the parser is using an unverified extension-storage model.
+
+## Sources
+
+- [Kilo CLI docs](https://kilo.ai/docs/code-with-ai/platforms/cli) (accessed 2026-04-15)
+- [Kilo architecture](https://kilo.ai/docs/contributing/architecture) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/14-antigravity.md
+++ b/docs/parser-documentation/access-recipes/14-antigravity.md
@@ -1,0 +1,43 @@
+# Antigravity Access Recipes
+
+## Raw Source
+
+- Documented fact: current first-party Antigravity docs pages reviewed for this audit do not describe local session storage, `code_tracker`, browser recordings, or raw transcript files. Sources: [docs root](https://antigravity.google/docs), [docs home](https://antigravity.google/docs/home), [browser docs](https://antigravity.google/docs/browser) (accessed 2026-04-15).
+- Current parser assumption: `~/.gemini/antigravity/code_tracker/` contains JSON or JSONL conversation logs with `{type, content, timestamp}` style entries.
+- Observed example: this machine does have `~/.gemini/antigravity/code_tracker/`, but `code_tracker/active/` looks like tracked workspace file snapshots, not chat transcripts, and a search for `*.json` / `*.jsonl` under `code_tracker/` returned only a normal project JSON file, not a session log. Observed 2026-04-15.
+- Observed example: this machine also has `~/.gemini/antigravity/browser_recordings/<id>/*.jpg`, which may matter for browser-task replay but is not currently surfaced by the parser.
+- Unresolved: the current parser appears likely wrong or at least incomplete for present-day Antigravity storage.
+
+## Retrieval Patterns
+
+### Inspect directory composition before assuming transcript files exist
+
+```bash
+find ~/.gemini/antigravity -maxdepth 3 | head -n 80
+find ~/.gemini/antigravity/code_tracker -type f | head -n 40
+```
+
+### Check whether any chat-like JSON/JSONL logs exist
+
+```bash
+find ~/.gemini/antigravity/code_tracker -type f \( -name '*.json' -o -name '*.jsonl' \)
+```
+
+### Inspect browser recordings if the task involved the Antigravity browser
+
+```bash
+find ~/.gemini/antigravity/browser_recordings -maxdepth 2 -type f | head -n 40
+```
+
+## Current Parser Comparison
+
+- This is the highest-risk mismatch in the audit.
+- The parser expects chat-like JSON entries in `code_tracker/`, but local observation suggests `code_tracker/active/` is a file-tracking area rather than a conversation log.
+- A redesign pointer block should not pretend this raw source is verified. It should surface the path as tentative and fall back to directory inspection instructions.
+
+## Sources
+
+- [Antigravity docs root](https://antigravity.google/docs) (accessed 2026-04-15)
+- [Antigravity docs home](https://antigravity.google/docs/home) (accessed 2026-04-15)
+- [Antigravity browser docs](https://antigravity.google/docs/browser) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/15-kimi.md
+++ b/docs/parser-documentation/access-recipes/15-kimi.md
@@ -1,0 +1,47 @@
+# Kimi Access Recipes
+
+## Raw Source
+
+- Documented fact: upstream Kimi CLI creates session directories under a work-dir-scoped sessions root, writes `context.jsonl`, and also writes a `wire.jsonl` file with a metadata header plus typed wire records. Sources: [MoonshotAI/kimi-cli `session.py`](https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/session.py), [MoonshotAI/kimi-cli `wire/file.py`](https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/wire/file.py) (accessed 2026-04-15).
+- Documented fact: `metadata.json` is optional in Kimi, and session lookup also uses `kimi.json` work-dir metadata. Source: `session.py`, accessed 2026-04-15.
+- Observed example: this machine has `~/.kimi/kimi.json`, `~/.kimi/sessions/<workdir-hash>/<session-id>/context.jsonl`, and `wire.jsonl`. Observed 2026-04-15.
+- Observed example: `wire.jsonl` begins with a metadata line like `{\"type\":\"metadata\",\"protocol_version\":\"1.3\"}`, followed by `TurnBegin` wire records. Observed 2026-04-15.
+
+## Retrieval Patterns
+
+### Map work directories to hashed session roots
+
+```bash
+sed -n '1,120p' ~/.kimi/kimi.json | jq .
+find ~/.kimi/sessions -maxdepth 2 -type d
+```
+
+### Inspect wire metadata and first records
+
+```bash
+sed -n '1,10p' ~/.kimi/sessions/<workdir-hash>/<session-id>/wire.jsonl | jq .
+```
+
+### Inspect the message history JSONL
+
+```bash
+awk 'NR>=1 && NR<=30' ~/.kimi/sessions/<workdir-hash>/<session-id>/context.jsonl | jq .
+```
+
+### If `metadata.json` exists, use it
+
+```bash
+sed -n '1,80p' ~/.kimi/sessions/<workdir-hash>/<session-id>/metadata.json | jq .
+```
+
+## Current Parser Comparison
+
+- Current parser reads `context.jsonl` and optional `metadata.json`, which aligns with upstream code.
+- The parser currently ignores `wire.jsonl`, but `wire.jsonl` is valuable for turn boundaries, protocol version, and subagent-like wire events.
+- For Kimi, the pointer block should include both `context.jsonl` and `wire.jsonl`.
+
+## Sources
+
+- [MoonshotAI/kimi-cli `session.py`](https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/session.py) (accessed 2026-04-15)
+- [MoonshotAI/kimi-cli `wire/file.py`](https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/wire/file.py) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/16-qwen-code.md
+++ b/docs/parser-documentation/access-recipes/16-qwen-code.md
@@ -1,0 +1,48 @@
+# Qwen Code Access Recipes
+
+## Raw Source
+
+- Documented fact: first-party Qwen issue discussion references current history under `~/.qwen/history/<project_hash>/` and temp working state under `~/.qwen/tmp/<project_hash>/`, and proposes project-local chat export. Source: [Qwen issue #2373](https://github.com/QwenLM/qwen-code/issues/2373) (accessed 2026-04-15).
+- Documented fact: current upstream repo code writes append-only JSONL chat records under `~/.qwen/tmp/<project_id>/chats/`, with record fields like `uuid`, `parentUuid`, `sessionId`, `type`, `message`, `usageMetadata`, `toolCallResult`, and `systemPayload`. Source: [QwenLM/qwen-code `chatRecordingService.ts`](https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/services/chatRecordingService.ts) (accessed 2026-04-15).
+- Current parser assumption: `.qwen/projects/<sanitized-cwd>/chats/*.jsonl` with part-based `functionCall` and `functionResponse` fields.
+- Observed example: this machine has `~/.qwen/` config and skills, but no local chat JSONL files to verify the active path. Observed 2026-04-15.
+- Inference: Qwen storage, like Gemini, appears to have changed over time; current parser path likely needs re-verification.
+
+## Retrieval Patterns
+
+### Probe the currently documented temp/history roots
+
+```bash
+find ~/.qwen/tmp -path '*/chats/*.jsonl' 2>/dev/null
+find ~/.qwen/history -maxdepth 3 2>/dev/null
+```
+
+### If JSONL chats exist, slice rows 10-30
+
+```bash
+awk 'NR>=10 && NR<=30' ~/.qwen/tmp/<project>/chats/<session>.jsonl | jq .
+```
+
+### Extract tool-result or system records
+
+```bash
+jq -cr 'select(.type=="tool_result" or .type=="system")' ~/.qwen/tmp/<project>/chats/<session>.jsonl
+```
+
+### First-party export path
+
+```bash
+qwen chat export --session <session_id> --output ./qwen/chat-history/
+```
+
+## Current Parser Comparison
+
+- Current parser targets `.qwen/projects/*/chats/*.jsonl`, but upstream code and issue discussion point to `~/.qwen/tmp/<project>/chats/` and `~/.qwen/history/`.
+- This is likely a parser-staleness problem rather than a missing pointer problem.
+- For redesign purposes, Qwen should expose the detected path at runtime instead of a fixed hardcoded convention.
+
+## Sources
+
+- [Qwen issue #2373](https://github.com/QwenLM/qwen-code/issues/2373) (accessed 2026-04-15)
+- [QwenLM/qwen-code `chatRecordingService.ts`](https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/services/chatRecordingService.ts) (accessed 2026-04-15)
+

--- a/docs/parser-documentation/access-recipes/99-open-questions.md
+++ b/docs/parser-documentation/access-recipes/99-open-questions.md
@@ -1,0 +1,59 @@
+# Open Questions
+
+## Highest-Priority Questions
+
+### Kiro: which product surface does the parser target?
+
+- Current parser targets `~/Library/Application Support/Kiro/workspace-sessions/*.json`.
+- Current first-party Kiro CLI docs describe `~/.kiro/` SQLite-backed auto-save plus JSON save/load commands.
+- Action: verify a current Kiro install with active sessions and identify whether the macOS JSON layout still exists for the IDE or whether the parser is stale.
+
+### Antigravity: is `code_tracker` session data or file-tracking data?
+
+- Current parser assumes chat-like JSON/JSONL logs in `~/.gemini/antigravity/code_tracker/`.
+- Local observation on 2026-04-15 showed `code_tracker/active/` behaving like file snapshots, not transcripts.
+- Action: find first-party engineering docs or current installs that actually show Antigravity conversation storage before trusting this parser path.
+
+### Qwen Code: which root is current, `projects/` or `tmp/`?
+
+- Current parser targets `.qwen/projects/*/chats/*.jsonl`.
+- First-party repo code points at `~/.qwen/tmp/<project>/chats/`.
+- First-party issue discussion also references `~/.qwen/history/<project_hash>/` and `~/.qwen/tmp/<project_hash>/`.
+- Action: verify against a current local install with real chat data.
+
+### Gemini: should the parser pivot to JSONL?
+
+- Current parser matches observed local JSON blobs.
+- Current upstream repo code writes JSONL chat records.
+- Action: detect format version at runtime and support both, rather than betting on one.
+
+### Kilo Code: extension storage or CLI session manager?
+
+- Current parser assumes a VS Code extension task layout similar to Roo/Cline.
+- First-party Kilo docs emphasize CLI session persistence, JSON export/import, and architecture around `packages/opencode/`.
+- Action: confirm whether `kilo-code` in this repo is meant to parse the editor extension, the CLI, or both.
+
+## Medium-Priority Questions
+
+### Codex: which secondary artifacts should be pointerized by default?
+
+- Local installs include rollout JSONL, `session_index.jsonl`, `history.jsonl`, `archived_sessions/`, and a state SQLite DB.
+- Action: decide whether the pointer block should always include the state DB path or only when a session has spawn edges / archival context.
+
+### Copilot: should the redesign expose rewind snapshots?
+
+- Local sessions include `rewind-snapshots/index.json`.
+- Action: decide whether checkpoint/rewind metadata belongs in the pointer block or only in full mode.
+
+### Claude: is `sessions-index.json` still a live concern?
+
+- Multiple first-party issues discuss it.
+- Local observation on this machine found no `sessions-index.json` at all.
+- Action: verify against a clean current Claude install before assuming the resume index still exists.
+
+## Sources
+
+- [Kiro session management docs](https://kiro.dev/docs/cli/chat/session-management/) (accessed 2026-04-15)
+- [Qwen issue #2373](https://github.com/QwenLM/qwen-code/issues/2373) (accessed 2026-04-15)
+- [google-gemini/gemini-cli `chatRecordingService.ts`](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts) (accessed 2026-04-15)
+- [Antigravity docs root](https://antigravity.google/docs) (accessed 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/00-overview.md
+++ b/docs/parser-documentation/handoff-pointers/00-overview.md
@@ -1,0 +1,94 @@
+# Handoff Pointer Redesign Overview
+
+## Why this context exists
+
+The current handoff markdown starts with a readable session overview, not a raw-storage briefing. In `src/utils/markdown.ts`, the top section is a generic table with source, session ID, working directory, optional session file, and message count; the raw source path is repeated later under `## Source Data`, after summaries, tool activity, reasoning, and recent conversation. In `src/config/verbosity.ts`, the top-level contract is still `minimal | standard | verbose | full`, which makes volume tunable but does not make the first screen more navigable.
+
+This folder recommends replacing that model with a two-mode pointer contract:
+
+- `default`: concise, operational, enough to continue safely
+- `full`: same first block expanded with backend-specific depth and retrieval recipes
+
+The pointer block should come before the summary/conversation body.
+
+## Default-mode contract
+
+Every tool-specific default pointer should try to expose:
+
+- `Source` and `session ID`
+- `Raw source path` or `DB path + session key`
+- `Raw backend/format` such as JSONL, JSON, YAML+JSONL, or SQLite
+- `Volume` as lines, messages, or rows when cheap to compute
+- `Native continue handle` such as session ID, thread ID, or resume command
+- `Quick inspect` recipe tailored to the backend
+- `Confidence note` when the parser is using a legacy or export-only format
+
+This is the smallest useful block that lets a downstream agent decide whether the current markdown is enough or whether it should inspect the raw store directly.
+
+## Full-mode contract
+
+`full` should keep the same first six fields, then add only backend-specific depth:
+
+- Companion artifacts such as sidecar settings, tool-results folders, subagent logs, checkpoints, or DB tables
+- Record-type counts when the backend is append-only and counting is practical
+- Two to four direct retrieval commands or SQL queries
+- Parser caveats versus upstream reality
+- Variant markers for tools that have legacy and current formats in the wild
+
+The key design point: `full` should add navigational depth, not just more prose.
+
+## Strongest findings
+
+- `Claude`, `Copilot`, `Cline`, `Roo Code`, `Kilo Code`, `Kimi`, `Crush`, and `Qwen Code` all support high-value pointer blocks because their raw stores are deterministic enough to name concrete files and retrieval commands.
+- `OpenCode` needs a variant-aware pointer because real installations may have both legacy JSON storage and SQLite, and migration behavior is a known source of drift.
+- `Codex` needs a split pointer between documented `CODEX_HOME` state and the actual rollout file the parser is reading. The docs emphasize `history.jsonl`; the open-source CLI code writes resumable rollouts under `sessions/YYYY/MM/DD/rollout-*.jsonl`.
+- `Cursor` needs a completeness warning. First-party forum posts confirm local `agent-transcripts` files exist, but Cursor staff also acknowledged that at least one `.jsonl` transcript/export path dropped `tool_use` data and likely omits `tool_result`.
+- `Gemini`, `Kiro`, and `Antigravity` are the highest-risk mismatches:
+  - `Gemini`: upstream repo code now records append-only JSONL chat logs, while `continues` still parses older single-file JSON session objects.
+  - `Kiro`: official docs describe SQLite under `~/.kiro/`, while `continues` still parses legacy-looking JSON session files.
+  - `Antigravity`: upstream Gemini repo now exposes tracker JSON under per-project temp/session directories, while `continues` still targets an older `code_tracker` line-oriented format.
+- `Droid` and `Amp` have weaker first-party disclosure for on-disk raw session layout than the repo currently assumes. Their pointer blocks should include confidence labels until the raw stores are re-verified from local captures or stronger first-party evidence.
+
+## Recommended repo-level direction
+
+1. Replace the current preset names with a first-class `pointerMode: default | full`, and let the existing low-level caps stay internal.
+2. Move the raw-storage pointer block to the top of the handoff, ahead of summary and recent conversation.
+3. Make the pointer block variant-aware for tools with known format drift (`gemini`, `opencode`, `kiro`, `antigravity`, possibly `kilo-code`).
+4. Add an explicit `schema confidence` field when the parser is built from observation rather than published first-party storage docs.
+5. Prefer direct-access recipes over narrative. A receiver should be able to copy one command and deepen immediately.
+
+## High-risk comparisons with current code
+
+- `src/utils/markdown.ts` currently exposes the raw session file too late and never names the backend format.
+- `src/config/verbosity.ts` currently uses four user-facing preset names; the redesign goal is two clear modes without losing retrieval depth.
+- Several parsers flatten or normalize data before the receiver sees it:
+  - `codex` prefers merged conversation messages and grouped tool summaries over raw record-type context.
+  - `cursor` and `droid` inherit Anthropic-style tool extraction but do not expose transcript completeness warnings.
+  - `cline`-family parsers ignore companion files even though first-party docs say they matter for recovery and checkpoints.
+  - `opencode`, `gemini`, `kiro`, and `antigravity` all have backend/variant questions that the current handoff cannot signal.
+
+## File map
+
+- `01-claude.md`
+- `02-codex.md`
+- `03-copilot.md`
+- `04-gemini.md`
+- `05-opencode.md`
+- `06-droid.md`
+- `07-cursor.md`
+- `08-amp.md`
+- `09-kiro.md`
+- `10-crush.md`
+- `11-cline.md`
+- `12-roo-code.md`
+- `13-kilo-code.md`
+- `14-antigravity.md`
+- `15-kimi.md`
+- `16-qwen-code.md`
+- `99-open-questions.md`
+
+## Sources
+
+- Local repo anchors: `src/config/verbosity.ts`, `src/utils/markdown.ts`, `src/utils/resume.ts`, `src/parsers/*.ts` (read 2026-04-15)
+- Canonical tool list: `src/types/tool-names.ts` (read 2026-04-15)
+- Mission brief and context docs in `docs/parser-documentation/` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/01-claude.md
+++ b/docs/parser-documentation/handoff-pointers/01-claude.md
@@ -1,0 +1,55 @@
+# Claude
+
+## Documented Facts
+
+- Official Claude Code docs say transcripts live under `~/.claude/projects/<project>/<session>.jsonl`, with large tool output spilled into `projects/<project>/<session>/tool-results/`. If `CLAUDE_CONFIG_DIR` is set, the same layout moves under that directory. They also document `file-history/<session>/` and other sidecar data under `~/.claude/`.
+
+## Observed Example
+
+- `src/parsers/claude.ts` reads UUID-named JSONL files under the `projects/` tree, then derives the sidecar directory by stripping `.jsonl`. It already knows how to inspect `subagents/` and `tool-results/`.
+- `src/__tests__/fixtures/index.ts` creates a Claude fixture as newline-delimited JSON objects with `type`, `sessionId`, `cwd`, `gitBranch`, `timestamp`, and `message`.
+
+## Inference
+
+- Claude can support one of the strongest pointer blocks in the product because the raw transcript path, sidecar directory, and record count are all deterministic and cheap to compute.
+
+## Unresolved Uncertainty
+
+- None that block a pointer block. The main caveat is persistence can be disabled by user settings or flags, so absence of transcript data should be treated as a real runtime condition, not parser failure.
+
+## Default-Mode Pointer Block
+
+- `Session`: Claude Code / `<session-id>`
+- `Raw transcript`: `<claude-config-dir>/projects/<project>/<session-id>.jsonl`
+- `Backend`: JSONL transcript
+- `Volume`: `<line-count>` JSONL records
+- `Companions`: include `tool-results/` and `subagents/` counts only when non-zero
+- `Quick inspect`: `sed -n '1,12p' <session>.jsonl` and `tail -n 12 <session>.jsonl`
+- `Deepen`: `ls <session-dir>/tool-results <session-dir>/subagents`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Sidecars`: explicit paths for `tool-results/`, `subagents/`, and `file-history/<session-id>/` when present
+- `Raw cues`: note whether compacted history markers are present
+- `Record mix`: counts of `assistant`, `user`, `queue-operation`, and compact-summary records when cheap
+- `Focused retrieval`:
+  - `rg -n '"type":"queue-operation"|isCompactSummary|tool_result|tool_use' <session>.jsonl`
+  - `find <session-dir>/subagents -maxdepth 1 -type f`
+  - `find <session-dir>/tool-results -maxdepth 1 -type f -ls`
+
+## Why This Is Feasible
+
+- `continues` already has `session.originalPath`, line counts, subagent parsing, and `tool-results` directory inspection in `src/parsers/claude.ts`.
+- The sidecar directory is deterministic: `<session>.jsonl` without the extension.
+
+## Current `continues` Comparison
+
+- Current handoff markdown shows the session file path, but it appears inside the generic overview table and later `Source Data`, not as a top-of-handoff retrieval guide.
+- Current presets change truncation and detail volume, but they do not expose the sidecar directories or tell the receiver how to inspect them.
+
+## Sources
+
+- Official docs: https://code.claude.com/docs/en/claude-directory (accessed 2026-04-15)
+- Local parser: `src/parsers/claude.ts` (read 2026-04-15)
+- Local fixture generator: `src/__tests__/fixtures/index.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/02-codex.md
+++ b/docs/parser-documentation/handoff-pointers/02-codex.md
@@ -1,0 +1,58 @@
+# Codex
+
+## Documented Facts
+
+- OpenAI documents `CODEX_HOME` as the local Codex state root, defaulting to `~/.codex`.
+- The open-source Codex CLI code writes resumable rollout files under `CODEX_HOME/sessions/YYYY/MM/DD/rollout-<timestamp>-<uuid>.jsonl`.
+- The same repo exports `experimental_resume` helpers and thread listing code that treat those rollout files as the resumable session source.
+- An official discussion says session IDs are generated at session start and resume relies on the ID stored inside the JSONL, not the filename you rename later.
+
+## Observed Example
+
+- `src/parsers/codex.ts` reads `session_meta`, `event_msg`, `response_item`, and `turn_context` records from `rollout-*.jsonl`.
+- `src/__tests__/fixtures/index.ts` creates Codex fixtures in the same rollout filename pattern and includes `session_meta` plus `event_msg` records.
+
+## Inference
+
+- The pointer block should name the rollout file actually parsed, even if user-facing docs also mention broader `CODEX_HOME` state such as `history.jsonl`. For handoff continuation, the rollout JSONL is the valuable artifact.
+
+## Unresolved Uncertainty
+
+- Official docs emphasize `history.jsonl`, while the open-source runtime centers resume and thread listing on rollout files. The safest pointer is to surface both the parsed rollout path and the broader `CODEX_HOME` root.
+
+## Default-Mode Pointer Block
+
+- `Session`: Codex CLI / `<session-id>`
+- `Raw rollout`: `<CODEX_HOME>/sessions/YYYY/MM/DD/rollout-<timestamp>-<session-id>.jsonl`
+- `Backend`: JSONL rollout log
+- `Volume`: `<line-count>` records
+- `Continue handle`: `codex -c experimental_resume="<rollout-path>"`
+- `Quick inspect`: `sed -n '1,12p' <rollout>.jsonl` and `rg -n '"type":"session_meta"|"type":"response_item"|"type":"event_msg"' <rollout>.jsonl`
+- `Context root`: show `CODEX_HOME` so the receiver knows where related history/config live
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Record mix`: counts of `session_meta`, `response_item`, `event_msg`, and `turn_context`
+- `Shape note`: `response_item` is richer for assistant text and tool calls; `event_msg` can duplicate conversational turns
+- `Focused retrieval`:
+  - `jq -c 'select(.type=="session_meta")' <rollout>.jsonl | head`
+  - `jq -c 'select(.type=="response_item")' <rollout>.jsonl | tail -n 20`
+  - `jq -c 'select(.type=="event_msg")' <rollout>.jsonl | tail -n 20`
+
+## Why This Is Feasible
+
+- `continues` already stores the rollout path in `session.originalPath`, derives the session ID from the filename, and streams the JSONL in `src/parsers/codex.ts`.
+- Record-type counts are cheap because the file is append-only JSONL.
+
+## Current `continues` Comparison
+
+- Current handoff output hides the difference between `response_item` and `event_msg`, even though that distinction matters when a receiver wants the highest-fidelity assistant/tool view.
+- Current presets do not tell the receiver that the raw transcript is a rollout file nested by date.
+
+## Sources
+
+- Official docs: https://developers.openai.com/codex/config-advanced (accessed 2026-04-15)
+- Official discussion: https://github.com/openai/codex/discussions/3827 (accessed 2026-04-15)
+- First-party repo code: `openai/codex` files `codex-rs/rollout/src/lib.rs`, `codex-rs/rollout/src/list.rs`, `codex-rs/rollout/src/recorder.rs` (read 2026-04-15)
+- Local parser and fixture: `src/parsers/codex.ts`, `src/__tests__/fixtures/index.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/03-copilot.md
+++ b/docs/parser-documentation/handoff-pointers/03-copilot.md
@@ -1,0 +1,59 @@
+# Copilot
+
+## Documented Facts
+
+- GitHub documents `~/.copilot` as the default Copilot CLI config/state root, overridable by `COPILOT_HOME` or `--config-dir`.
+- The same docs say `session-state/` stores session history and workspace data, with each session in its own directory containing `events.jsonl` plus workspace artifacts.
+- GitHub also documents `session-store.db` as a SQLite store for cross-session indexing/search.
+- GitHub’s session-data guide says sessions resume by session ID and `/session` exposes the active session ID and path details.
+
+## Observed Example
+
+- `src/parsers/copilot.ts` reads `<session-dir>/workspace.yaml` and `<session-dir>/events.jsonl`.
+- `src/__tests__/fixtures/index.ts` generates a Copilot fixture with `workspace.yaml` and event records like `session.start`, `user.message`, and `assistant.message`.
+
+## Inference
+
+- Copilot’s pointer block should be directory-centric, not file-centric: the handoff receiver needs the session directory, `events.jsonl`, `workspace.yaml`, and awareness that `session-store.db` exists outside the per-session folder.
+
+## Unresolved Uncertainty
+
+- None that block a strong pointer block. The main limitation is current `continues` only parses `workspace.yaml` and `events.jsonl`; it does not leverage `session-store.db`.
+
+## Default-Mode Pointer Block
+
+- `Session`: GitHub Copilot CLI / `<session-id>`
+- `Raw session dir`: `<COPILOT_HOME>/session-state/<session-id>/`
+- `Primary files`: `workspace.yaml`, `events.jsonl`
+- `Backend`: YAML + JSONL
+- `Volume`: `<event-line-count>` event rows
+- `Quick inspect`:
+  - `sed -n '1,40p' <session-dir>/workspace.yaml`
+  - `sed -n '1,12p' <session-dir>/events.jsonl`
+- `Resume handle`: `copilot --resume <session-id>`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Cross-session index`: `<COPILOT_HOME>/session-store.db`
+- `Workspace artifacts`: call out plans/checkpoints/tracked files when present in the session directory
+- `Event mix`: counts of `session.start`, `user.message`, `assistant.message`, and other non-conversation events
+- `Focused retrieval`:
+  - `rg -n '"type":"assistant.message"|"type":"user.message"' <session-dir>/events.jsonl`
+  - `sqlite3 <COPILOT_HOME>/session-store.db '.tables'`
+
+## Why This Is Feasible
+
+- `continues` already has the session directory in `session.originalPath`.
+- Event count is already tracked from `events.jsonl`, and `workspace.yaml` lives at a fixed sibling path.
+
+## Current `continues` Comparison
+
+- Current handoff text can mention the session directory, but it does not explicitly tell the receiver that the raw session is a folder with both YAML and JSONL, nor that a separate SQLite index exists.
+- Tool activity today is derived only from `assistant.message.toolRequests`, so the pointer block should not imply tool-result fidelity.
+
+## Sources
+
+- Official docs: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference (accessed 2026-04-15)
+- Official session guide: https://docs.github.com/en/copilot/how-tos/copilot-cli/chronicle (accessed 2026-04-15)
+- Local parser and fixture: `src/parsers/copilot.ts`, `src/__tests__/fixtures/index.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/04-gemini.md
+++ b/docs/parser-documentation/handoff-pointers/04-gemini.md
@@ -1,0 +1,63 @@
+# Gemini
+
+## Documented Facts
+
+- The current upstream Gemini CLI repo records chats in append-only JSONL files created under a project-specific temp directory’s `chats/` folder.
+- The same service writes metadata records and message records incrementally and can migrate older `.json` conversations into `.jsonl`.
+- A first-party discussion about chat save/resume still references project-temp JSON artifacts and older checkpoint-style JSON files under `~/.gemini/tmp`.
+
+## Observed Example
+
+- `src/parsers/gemini.ts` still parses older single-file JSON session objects from `~/.gemini/tmp/*/chats/session-*.json` and `~/.gemini/sessions/*.json`.
+- `src/__tests__/fixtures/index.ts` generates Gemini fixtures in that older single-JSON-object shape with a `messages[]` array.
+
+## Inference
+
+- Gemini needs a mandatory `storage variant` field in the pointer block.
+- The redesign should not present a single canonical raw format until parser support catches up with the current upstream JSONL recorder.
+
+## Unresolved Uncertainty
+
+- The exact user-visible coexistence rules between current JSONL chat logs, older single-file JSON sessions, and saved checkpoint JSON exports are not cleanly documented in one first-party place.
+- Current `continues` is still wired to the older JSON session format, so a fully accurate pointer block for current Gemini CLI data is not yet feasible from the repo alone.
+
+## Default-Mode Pointer Block
+
+- `Session`: Gemini CLI / `<session-id>`
+- `Storage variant`: one of `current JSONL chat log`, `legacy JSON session file`, or `unknown`
+- `Raw path`: actual file path that was parsed
+- `Backend`: `JSONL` or `JSON`
+- `Volume`: `<record-count>` or `<message-count>`
+- `Quick inspect`: variant-specific command
+  - JSONL: `sed -n '1,12p' <chat>.jsonl`
+  - JSON: `jq '.messages[:5]' <session>.json`
+- `Confidence`: `high` only when the variant was positively detected; otherwise `legacy-parser path`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Project key`: temp/project hash directory that contains the chat file
+- `Shape note`:
+  - current JSONL: append-only metadata + message records
+  - legacy JSON: one object with `sessionId`, timestamps, and `messages[]`
+- `Focused retrieval`:
+  - JSONL: `rg -n '"type":"user"|"type":"gemini"|toolCalls|thoughts' <chat>.jsonl`
+  - JSON: `jq '.messages[] | {type,id,timestamp}' <session>.json | head -n 20`
+- `Parser caveat`: current `continues` parser is legacy-oriented
+
+## Why This Is Feasible
+
+- Variant detection is cheap from filename and first record shape.
+- Once detected, both JSON and JSONL backends support straightforward counts and inspect commands.
+- What is not feasible today is claiming that the current repo parser already covers the upstream JSONL recorder.
+
+## Current `continues` Comparison
+
+- Current handoff generation assumes the older JSON session object and therefore cannot honestly surface the upstream recorder shape or its append-only semantics.
+- This is one of the clearest cases where a pointer block needs a `variant` and `confidence` field rather than a single normalized story.
+
+## Sources
+
+- First-party repo code: `google-gemini/gemini-cli` files `packages/core/src/services/chatRecordingService.ts` and `packages/core/src/config/storage.ts` (read 2026-04-15)
+- First-party discussion: https://github.com/google-gemini/gemini-cli/discussions/4974 (accessed 2026-04-15)
+- Local parser and fixture: `src/parsers/gemini.ts`, `src/__tests__/fixtures/index.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/05-opencode.md
+++ b/docs/parser-documentation/handoff-pointers/05-opencode.md
@@ -1,0 +1,68 @@
+# OpenCode
+
+## Documented Facts
+
+- First-party OpenCode issue threads confirm two real storage backends in the wild:
+  - SQLite at `~/.local/share/opencode/opencode.db`
+  - legacy JSON under `~/.local/share/opencode/storage/`
+- First-party code shows session/project/message/part data living under `storage/` for JSON mode and a channel-aware SQLite DB for newer builds.
+- The same issue threads document JSON-to-SQLite migration drift where old JSON session files can remain on disk even when SQLite becomes the live source.
+
+## Observed Example
+
+- `src/parsers/opencode.ts` explicitly tries SQLite first and falls back to JSON files.
+- The parser already models both layouts:
+  - SQLite tables for `session`, `project`, `message`, and `part`
+  - JSON files under `storage/session/`, `storage/project/`, `storage/message/`, and `storage/part/`
+
+## Inference
+
+- OpenCode needs a variant-aware pointer block every time. The receiver needs to know whether the handoff is grounded in SQLite or legacy JSON, because the deep-access recipe is completely different.
+
+## Unresolved Uncertainty
+
+- Channel-specific DB filenames and migration state can vary by installation. The pointer block should expose the actual resolved backend path, not a guessed default.
+
+## Default-Mode Pointer Block
+
+- `Session`: OpenCode / `<session-id>`
+- `Storage variant`: `sqlite` or `legacy-json`
+- `Primary source`:
+  - SQLite: `<data-dir>/opencode.db`
+  - JSON: `<data-dir>/storage/session/<project>/<session>.json`
+- `Backend`: `SQLite` or `JSON file tree`
+- `Volume`: message row count or message file count
+- `Quick inspect`:
+  - SQLite: `sqlite3 <db> '.tables'`
+  - JSON: `jq . <session>.json`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Related artifacts`:
+  - SQLite: note `session`, `project`, `message`, `part`
+  - JSON: explicit `project/`, `message/<session-id>/`, `part/<message-id>/`
+- `Migration note`: say whether stale JSON storage also exists when SQLite is active
+- `Focused retrieval`:
+  - SQLite:
+    - `sqlite3 <db> "select id, title, time_updated from session where id='<session-id>';"`
+    - `sqlite3 <db> "select id, data from message where session_id='<session-id>' order by time_created;"`
+  - JSON:
+    - `find <storage>/message/<session-id> -maxdepth 1 -type f | sort`
+    - `find <storage>/part -path '*/<message-id>/*.json'`
+
+## Why This Is Feasible
+
+- `continues` already distinguishes SQLite vs JSON in `src/parsers/opencode.ts`.
+- The backend-specific lookup paths are deterministic once the variant is known.
+
+## Current `continues` Comparison
+
+- Current handoff output exposes recent messages but not the backend variant, even though that is the most important retrieval decision for OpenCode.
+- Current tool summaries collapse session-level diff metadata into one edit summary; the pointer block should instead tell the receiver where the real messages/parts live.
+
+## Sources
+
+- First-party issue: https://github.com/anomalyco/opencode/issues/13654 (accessed 2026-04-15)
+- First-party repo code: `anomalyco/opencode` files `packages/opencode/src/storage/db.ts` and `packages/opencode/src/storage/storage.ts` (read 2026-04-15)
+- Local parser: `src/parsers/opencode.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/06-droid.md
+++ b/docs/parser-documentation/handoff-pointers/06-droid.md
@@ -1,0 +1,57 @@
+# Droid
+
+## Documented Facts
+
+- Factory’s official CLI docs expose session continuation by `session_id`, including `droid exec --session-id <id>` and streaming JSON/JSONL output that repeats `session_id`.
+- Factory’s settings docs document `~/.factory/settings.json` as the main user settings file and `cloudSessionSync` as a session-mirroring toggle.
+
+## Observed Example
+
+- `src/parsers/droid.ts` assumes a local store at `~/.factory/sessions/<workspace-slug>/<uuid>.jsonl` plus a sidecar `<uuid>.settings.json`.
+- The parser expects event records like `session_start`, `message`, `todo_state`, and `compaction_state`, and derives the working directory from `session_start.cwd` or the workspace slug.
+
+## Inference
+
+- Droid can support a useful pointer block, but it should include an explicit confidence label because first-party docs verified the session identifier and settings path more strongly than the raw on-disk session directory layout.
+
+## Unresolved Uncertainty
+
+- No strong first-party page was found that explicitly documents the raw `~/.factory/sessions/.../*.jsonl` layout the parser currently uses.
+- The next redesign should preserve a low-confidence marker until a real local capture or first-party code/docs confirm the session store path and file schema.
+
+## Default-Mode Pointer Block
+
+- `Session`: Factory Droid / `<session-id>`
+- `Confidence`: `observed-store` or similarly explicit wording
+- `Raw transcript`: `<factory-home>/sessions/<workspace-slug>/<session-id>.jsonl`
+- `Sidecar settings`: `<same-dir>/<session-id>.settings.json` when present
+- `Backend`: JSONL event log + JSON settings sidecar
+- `Volume`: `<event-count>` rows
+- `Quick inspect`:
+  - `sed -n '1,12p' <session>.jsonl`
+  - `jq . <session>.settings.json`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Event mix`: counts of `session_start`, `message`, `todo_state`, and `compaction_state`
+- `Recovery note`: Factory docs guarantee `session_id` continuation, even if the local file layout is still only observed
+- `Focused retrieval`:
+  - `rg -n '"type":"message"|"type":"todo_state"|"type":"compaction_state"' <session>.jsonl`
+  - `jq '{model,tokenUsage,assistantActiveTimeMs}' <session>.settings.json`
+
+## Why This Is Feasible
+
+- `continues` already stores the JSONL path and deterministically derives the settings sidecar path.
+- Event counts and quick retrieval commands are straightforward once the file is present.
+
+## Current `continues` Comparison
+
+- Current handoff output can summarize conversation, todos, and tool usage, but it does not tell the receiver where the `.settings.json` sidecar lives or that the storage-path claim is parser-observed rather than publicly documented.
+
+## Sources
+
+- Official CLI reference: https://docs.factory.ai/reference/cli-reference (accessed 2026-04-15)
+- Official exec overview: https://docs.factory.ai/cli/droid-exec/overview (accessed 2026-04-15)
+- Official settings docs: https://docs.factory.ai/cli/configuration/settings (accessed 2026-04-15)
+- Local parser: `src/parsers/droid.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/07-cursor.md
+++ b/docs/parser-documentation/handoff-pointers/07-cursor.md
@@ -1,0 +1,54 @@
+# Cursor
+
+## Documented Facts
+
+- First-party Cursor forum posts say historical data can remain intact under `.cursor/projects/agent-transcripts` even when the UI cannot load chat history because `state.vscdb` is corrupted.
+- In the same forum, Cursor staff said a `.jsonl` transcript/export path dropped `tool_use` data when Cursor moved from `.txt` to `.jsonl`, and likely still omits `tool_result` because of size.
+
+## Observed Example
+
+- `src/parsers/cursor.ts` reads `~/.cursor/projects/<project-slug>/agent-transcripts/<uuid>/<uuid>.jsonl`.
+- The parser treats each line as Anthropic-style content blocks and extracts tool summaries from the raw transcript, but there is no current receiver-visible warning about transcript completeness risk.
+
+## Inference
+
+- Cursor’s pointer block should always pair the transcript path with a completeness warning. A receiver should know that local transcript existence is high-confidence, but tool fidelity inside those transcripts is not fully trustworthy.
+
+## Unresolved Uncertainty
+
+- The forum evidence is about `.jsonl` transcript/export behavior, but it is still unclear whether local `agent-transcripts` and exported transcript files have identical completeness guarantees in all releases.
+
+## Default-Mode Pointer Block
+
+- `Session`: Cursor / `<session-id>`
+- `Raw transcript`: `~/.cursor/projects/<project-slug>/agent-transcripts/<session-id>/<session-id>.jsonl`
+- `Backend`: JSONL transcript
+- `Volume`: `<line-count>` rows
+- `Completeness`: `tool_use/tool_result fidelity may be incomplete; verify before relying on transcript-only tool history`
+- `Quick inspect`: `sed -n '1,12p' <transcript>.jsonl`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Project slug`: show the derived slug from the transcript path
+- `UI index note`: mention Cursor’s `state.vscdb` as the UI/session index state implicated in first-party recovery threads
+- `Focused retrieval`:
+  - `rg -n '"role":"assistant"|"role":"user"' <transcript>.jsonl`
+  - `rg -n 'tool_use|tool_result|Write|Delete|StrReplace' <transcript>.jsonl`
+- `Caveat`: tell the receiver to validate tool presence against the raw file, not just `continues` summaries
+
+## Why This Is Feasible
+
+- `continues` already has the transcript path and line count.
+- The warning is static and evidence-backed; it does not require extra runtime cost.
+
+## Current `continues` Comparison
+
+- Current handoff output implies a cleaner raw-tool story than Cursor’s first-party forum evidence supports.
+- A top-of-handoff pointer should make the transcript path and the completeness caveat visible before any normalized tool summary.
+
+## Sources
+
+- First-party forum recovery thread: https://forum.cursor.com/t/chat-history-not-loading-after-vs-code-settings-sync-possible-state-inconsistency/150559 (accessed 2026-04-15)
+- First-party forum transcript/tool-use thread: https://forum.cursor.com/t/jsonl-format-should-fully-record-the-tool-use-information/154777/4 (accessed 2026-04-15)
+- Local parser: `src/parsers/cursor.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/08-amp.md
+++ b/docs/parser-documentation/handoff-pointers/08-amp.md
@@ -1,0 +1,55 @@
+# Amp
+
+## Documented Facts
+
+- Amp’s first-party manual and streaming JSON docs are thread-centric: they expose thread IDs like `T-...`, show `amp threads continue`, and document streamed JSON containing `session_id`, `cwd`, tools, and usage.
+- Amp’s manual documents configuration and OAuth paths, but no strong first-party page in this research pass documented a local raw thread file store equivalent to the parser’s `threads/*.json`.
+
+## Observed Example
+
+- `src/parsers/amp.ts` assumes `~/.local/share/amp/threads/<id>.json`.
+- Local fixtures in `test-fixtures/amp/threads/` show a JSON object with `id`, `created`, `messages[]`, `usageLedger.events[]`, and `env.initial.tags[]`.
+
+## Inference
+
+- Amp’s pointer block should expose both the local thread file path and the web/thread identity when available, but it should mark the local file layout as observed rather than documented.
+
+## Unresolved Uncertainty
+
+- First-party docs were sufficient to verify thread IDs and continuation flows, but not the local `threads/*.json` store the parser reads.
+
+## Default-Mode Pointer Block
+
+- `Session`: Amp / `<thread-id>`
+- `Confidence`: `observed-local-json`
+- `Raw local thread`: `~/.local/share/amp/threads/<thread-id>.json`
+- `Web thread`: `https://ampcode.com/threads/<thread-id>` when the ID is URL-safe
+- `Backend`: JSON thread object
+- `Volume`: `<message-count>` messages
+- `Quick inspect`: `jq '{id,created,messages:(.messages|length)}' <thread>.json`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Usage ledger`: include whether `usageLedger.events` exists and how many events it contains
+- `Model hint`: expose `env.initial.tags` model tag when present
+- `Focused retrieval`:
+  - `jq '.messages[-6:]' <thread>.json`
+  - `jq '.usageLedger.events' <thread>.json`
+- `Caveat`: say that official docs strongly validate web/thread continuation, but not the local JSON storage path
+
+## Why This Is Feasible
+
+- The parser already reads the JSON thread file, counts messages, and extracts model/tokens from `usageLedger`.
+- The web thread URL is directly derivable from the thread ID when the ID uses Amp’s public `T-...` form.
+
+## Current `continues` Comparison
+
+- Current handoff output can show recent messages, but it does not expose the thread JSON path or tell the receiver that local storage is parser-observed while thread continuation is first-party documented.
+
+## Sources
+
+- Official manual: https://ampcode.com/manual (accessed 2026-04-15)
+- Official streaming JSON docs: https://ampcode.com/news/streaming-json (accessed 2026-04-15)
+- First-party thread example: https://ampcode.com/threads/T-39dc399d-08cc-4b10-ab17-e6bac8badea7 (accessed 2026-04-15)
+- Local parser and fixtures: `src/parsers/amp.ts`, `test-fixtures/amp/threads/test-thread-1.json` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/09-kiro.md
+++ b/docs/parser-documentation/handoff-pointers/09-kiro.md
@@ -1,0 +1,54 @@
+# Kiro
+
+## Documented Facts
+
+- Official Kiro docs say session data lives under `~/.kiro/`, uses SQLite, auto-saves every turn, and keys sessions by directory path.
+- Official Kiro docs expose session-management commands like `kiro-cli chat --resume`, `--resume-picker`, `--list-sessions`, and `--delete-session <SESSION_ID>`.
+
+## Observed Example
+
+- `src/parsers/kiro.ts` still reads JSON files under `~/Library/Application Support/Kiro/workspace-sessions/...`.
+- Local fixtures in `test-fixtures/kiro/workspace-sessions/` use a single JSON object with `sessionId`, `workspacePath`, `selectedModel`, and `history[]`.
+
+## Inference
+
+- Kiro is a high-risk mismatch. The pointer block for the redesign should reflect the official SQLite backend, not the legacy JSON fixture shape the current parser still uses.
+
+## Unresolved Uncertainty
+
+- The official docs do not publish the exact SQLite filename inside `~/.kiro/`.
+- Current `continues` cannot yet populate DB path, row count, or SQL retrieval commands from real upstream storage.
+
+## Default-Mode Pointer Block
+
+- `Session`: Kiro / `<session-id>`
+- `Backend`: `SQLite under ~/.kiro/`
+- `Storage root`: `~/.kiro/`
+- `Confidence`: `official-backend, current-parser-legacy`
+- `Resume handle`: `kiro-cli chat --resume` or `kiro-cli chat --resume-picker`
+- `Quick inspect`: `kiro-cli chat --list-sessions`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Mismatch note`: `continues` is still reading legacy JSON exports/fixtures, not the official SQLite backend
+- `State`: include working directory and UUID session ID when available from the current handoff context
+- `Focused retrieval`:
+  - `kiro-cli chat --list-sessions`
+  - `kiro-cli chat --resume`
+  - If future parser learns the DB filename, upgrade this section to SQL queries
+
+## Why This Is Feasible
+
+- The pointer block can honestly expose the official backend and current limitation even before the parser is rewritten.
+- What is not feasible today is claiming a concrete SQLite file path or row count from `continues` itself.
+
+## Current `continues` Comparison
+
+- Current handoff logic is still built around a JSON session file layout that conflicts with the current official Kiro storage story.
+- This tool should not share the same pointer contract as the stable JSONL tools until the parser is updated.
+
+## Sources
+
+- Official docs: https://kiro.dev/docs/cli/chat/session-management/ (accessed 2026-04-15)
+- Local parser and fixtures: `src/parsers/kiro.ts`, `test-fixtures/kiro/workspace-sessions/test-workspace/test-session-1.json` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/10-crush.md
+++ b/docs/parser-documentation/handoff-pointers/10-crush.md
@@ -1,0 +1,55 @@
+# Crush
+
+## Documented Facts
+
+- First-party Crush repo code persists sessions and messages in SQLite tables named `sessions` and `messages`.
+- The CLI session commands use session IDs, can list/show/delete/rename sessions, and operate on the database opened from the configured data directory.
+
+## Observed Example
+
+- `src/parsers/crush.ts` assumes the default DB path is `~/.crush/crush.db` and queries `sessions` plus `messages.parts`.
+- The parser already uses row counts from SQLite and treats `parts` as JSON arrays of typed message fragments.
+
+## Inference
+
+- Crush should have a database-first pointer block. Unlike JSONL tools, the meaningful identifier is `crush.db + session_id`.
+
+## Unresolved Uncertainty
+
+- The public docs page that would have been convenient to cite returned a `410` during scraping, so the strongest evidence in this pass is the first-party repo code rather than docs prose.
+- The exact default data directory can still be user-overridden with CLI config, so the pointer should expose the resolved DB path from the local installation when possible.
+
+## Default-Mode Pointer Block
+
+- `Session`: Crush / `<session-id>`
+- `Primary source`: `<data-dir>/crush.db`
+- `Backend`: SQLite
+- `Scope key`: `session_id=<session-id>`
+- `Volume`: `<message-row-count>` rows
+- `Quick inspect`:
+  - `sqlite3 <db> '.tables'`
+  - `sqlite3 <db> "select role, created_at from messages where session_id='<session-id>' order by created_at;" | head`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Tables`: highlight `sessions` and `messages`
+- `Shape note`: `messages.parts` is JSON and must be decoded to recover text blocks
+- `Focused retrieval`:
+  - `sqlite3 <db> "select * from sessions where id='<session-id>';" -json`
+  - `sqlite3 <db> "select role, parts, model, provider, created_at from messages where session_id='<session-id>' order by created_at;" -json`
+
+## Why This Is Feasible
+
+- `continues` already queries the DB and knows the session ID plus message row count.
+- The extra full-mode SQL recipes are directly aligned with the parser’s current extraction path.
+
+## Current `continues` Comparison
+
+- Current handoff output reduces Crush to recent messages and token counts, but the real raw source is a relational store with session/message tables and JSON `parts`.
+- The pointer block should make that DB reality explicit at the top.
+
+## Sources
+
+- First-party repo code: `charmbracelet/crush` files `internal/db/sql/sessions.sql`, `internal/db/sql/messages.sql`, and `internal/cmd/session.go` (read 2026-04-15)
+- Local parser: `src/parsers/crush.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/11-cline.md
+++ b/docs/parser-documentation/handoff-pointers/11-cline.md
@@ -1,0 +1,56 @@
+# Cline
+
+## Documented Facts
+
+- First-party Cline docs document global storage roots under VS Code or JetBrains and show the task directory structure:
+  - `state/taskHistory.json`
+  - `tasks/<task-id>/api_conversation_history.json`
+  - `tasks/<task-id>/ui_messages.json`
+  - `tasks/<task-id>/task_metadata.json`
+  - `checkpoints/<workspace-hash>/.git`
+- The same docs say `taskHistory.json` is only an index; the real conversation lives in the per-task folders.
+
+## Observed Example
+
+- `src/parsers/cline.ts` reads only `ui_messages.json` from the task folder.
+- `test-fixtures/cline/tasks/test-task-1/ui_messages.json` shows the raw event-array shape with `say` values like `text`, `api_req_started`, `reasoning`, and `completion_result`.
+
+## Inference
+
+- Cline’s pointer block should be task-directory-centric, not transcript-file-centric. The receiver needs `ui_messages.json` first, but it also needs to know companion files and checkpoints exist.
+
+## Unresolved Uncertainty
+
+- The parser currently ignores `api_conversation_history.json`, `task_metadata.json`, and checkpoint data, so full-mode depth is partly aspirational until extraction expands.
+
+## Default-Mode Pointer Block
+
+- `Session`: Cline / `<task-id>`
+- `Task dir`: `<globalStorage>/saoudrizwan.claude-dev/tasks/<task-id>/`
+- `Primary file`: `ui_messages.json`
+- `Backend`: JSON array event log
+- `Volume`: `<array-length>` events
+- `Quick inspect`: `jq '.[-12:]' <task-dir>/ui_messages.json`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Companions`: `api_conversation_history.json`, `task_metadata.json`
+- `Index`: mention `state/taskHistory.json`
+- `Checkpoint store`: mention `checkpoints/<workspace-hash>/.git`
+- `Focused retrieval`:
+  - `jq 'map(.say) | group_by(.) | map({say: .[0], count: length})' <task-dir>/ui_messages.json`
+  - `jq . <task-dir>/task_metadata.json`
+
+## Why This Is Feasible
+
+- `continues` already knows the `ui_messages.json` path; the sibling files are deterministic inside the same task directory.
+
+## Current `continues` Comparison
+
+- Current handoff output only reflects `ui_messages.json` even though first-party recovery docs make it clear that the task directory and checkpoint store are the real recovery surface.
+
+## Sources
+
+- Official docs: https://docs.cline.bot/troubleshooting/task-history-recovery (accessed 2026-04-15)
+- Local parser and fixture: `src/parsers/cline.ts`, `test-fixtures/cline/tasks/test-task-1/ui_messages.json` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/12-roo-code.md
+++ b/docs/parser-documentation/handoff-pointers/12-roo-code.md
@@ -1,0 +1,52 @@
+# Roo Code
+
+## Documented Facts
+
+- First-party Roo Code issue threads confirm task data lives under the extension’s globalStorage path and that `ui_messages.json` is a critical per-task file.
+- One issue explicitly references `$HOME/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/<task-id>` and lock files associated with `ui_messages.json`.
+
+## Observed Example
+
+- `src/parsers/cline.ts` intentionally treats Roo Code as a Cline-family format using the same `ui_messages.json` event array.
+- `test-fixtures/roo-code/tasks/test-task-1/ui_messages.json` matches the same raw schema pattern used for Cline and Kilo Code fixtures.
+
+## Inference
+
+- Roo Code should share the same pointer shape as Cline, but with an extension-specific base path and a lock-file warning because first-party issues show `ui_messages.json` lock contention is operationally relevant.
+
+## Unresolved Uncertainty
+
+- First-party Roo docs were lower-yield than issue threads for raw storage details in this pass, so the strongest explicit path evidence came from issue discussions rather than formal docs.
+
+## Default-Mode Pointer Block
+
+- `Session`: Roo Code / `<task-id>`
+- `Task dir`: `<globalStorage>/rooveterinaryinc.roo-cline/tasks/<task-id>/`
+- `Primary file`: `ui_messages.json`
+- `Backend`: JSON array event log
+- `Volume`: `<array-length>` events
+- `Quick inspect`: `jq '.[-12:]' <task-dir>/ui_messages.json`
+- `Health note`: mention `*.lock` files if present
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Companions`: `api_conversation_history.json`, `task_metadata.json`
+- `Lock state`: call out `ui_messages.json.lock` or related lock files when present
+- `Focused retrieval`:
+  - `find <task-dir> -maxdepth 1 -type f | sort`
+  - `jq 'map(.say) | group_by(.) | map({say: .[0], count: length})' <task-dir>/ui_messages.json`
+
+## Why This Is Feasible
+
+- `continues` already knows the task directory because `ui_messages.json` is the parsed source.
+- Companion files and locks are cheap sibling-file checks.
+
+## Current `continues` Comparison
+
+- Current handoff output reflects the shared Cline-family message parsing but does not reveal Roo-specific operational context such as `ui_messages.json` lock failures.
+
+## Sources
+
+- First-party issue: https://github.com/RooCodeInc/Roo-Code/issues/6022 (accessed 2026-04-15)
+- Local parser and fixture: `src/parsers/cline.ts`, `test-fixtures/roo-code/tasks/test-task-1/ui_messages.json` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/13-kilo-code.md
+++ b/docs/parser-documentation/handoff-pointers/13-kilo-code.md
@@ -1,0 +1,54 @@
+# Kilo Code
+
+## Documented Facts
+
+- First-party Kilo issue threads confirm an extension-style task store under `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks`, with `ui_messages.json` lock contention causing freezes.
+- The same issue shows `.lock` artifacts and repeated failures to save `ui_messages.json`.
+
+## Observed Example
+
+- `src/parsers/cline.ts` parses Kilo Code with the same `ui_messages.json` schema used for Cline/Roo.
+- `test-fixtures/kilo-code/tasks/test-task-1/ui_messages.json` matches that event-array format.
+- A separate first-party repo search also surfaced a newer `kilo.db` / opencode-derived codebase, which suggests platform/storage convergence or product split beyond what this parser currently handles.
+
+## Inference
+
+- The current handoff pointer for Kilo Code should stay focused on the extension task store the parser actually reads, while explicitly warning that Kilo’s broader product family may also have newer non-extension storage backends.
+
+## Unresolved Uncertainty
+
+- It is not yet clear whether the VS Code extension task store and the newer first-party `kilo.db` codebase are parallel products, a migration path, or two fronts of the same product line.
+
+## Default-Mode Pointer Block
+
+- `Session`: Kilo Code / `<task-id>`
+- `Task dir`: `<globalStorage>/kilocode.kilo-code/tasks/<task-id>/`
+- `Primary file`: `ui_messages.json`
+- `Backend`: JSON array event log
+- `Volume`: `<array-length>` events
+- `Quick inspect`: `jq '.[-12:]' <task-dir>/ui_messages.json`
+- `Health note`: include `ui_messages.json.lock` state when present
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Companions`: enumerate sibling task files and any lock files
+- `Variant note`: `continues` is using the extension task store, not the newer DB-backed Kilo codebase surfaced in first-party repo search
+- `Focused retrieval`:
+  - `find <task-dir> -maxdepth 1 -type f | sort`
+  - `jq 'map(.say) | group_by(.) | map({say: .[0], count: length})' <task-dir>/ui_messages.json`
+
+## Why This Is Feasible
+
+- The parser already resolves the extension task directory and reads `ui_messages.json`.
+- Sibling-file and lock checks are cheap and deterministic.
+
+## Current `continues` Comparison
+
+- Current handoff output hides the fact that Kilo Code is the most ambiguous member of the Cline-family tools in this audit: the parser reads extension task JSON, while first-party code search also exposed a newer DB-backed product surface.
+
+## Sources
+
+- First-party issue: https://github.com/Kilo-Org/kilocode/issues/3706 (accessed 2026-04-15)
+- First-party repo code search: `Kilo-Org/kilocode` files `packages/opencode/src/session/index.ts` and `packages/opencode/src/storage/db.ts` (read 2026-04-15)
+- Local parser and fixture: `src/parsers/cline.ts`, `test-fixtures/kilo-code/tasks/test-task-1/ui_messages.json` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/14-antigravity.md
+++ b/docs/parser-documentation/handoff-pointers/14-antigravity.md
@@ -1,0 +1,54 @@
+# Antigravity
+
+## Documented Facts
+
+- Current upstream Gemini CLI code exposes tracker storage under a project temp/session directory, with JSON task files under a `tracker/` subdirectory.
+- No strong first-party source from this pass confirmed the older `~/.gemini/antigravity/code_tracker/` line-log format that `continues` currently parses.
+
+## Observed Example
+
+- `src/parsers/antigravity.ts` reads `~/.gemini/antigravity/code_tracker/` and strips binary/protobuf prefixes from each line before parsing JSON objects with `type`, `content`, and `timestamp`.
+- Local fixtures under `test-fixtures/antigravity/code_tracker/` include both plain JSONL and binary-prefixed lines in that legacy shape.
+
+## Inference
+
+- Antigravity needs the strongest possible `variant + confidence` treatment in the redesign.
+- The pointer block should not pretend the parser’s legacy `code_tracker` format is the settled upstream truth.
+
+## Unresolved Uncertainty
+
+- Whether current Antigravity installs still emit `code_tracker` conversation logs, or whether that format has effectively been superseded by newer tracker JSON under Gemini’s temp/session tree.
+
+## Default-Mode Pointer Block
+
+- `Session`: Antigravity / `<session-id>`
+- `Storage variant`: `legacy code_tracker line log` or `unknown`
+- `Confidence`: `low` unless the raw file was directly observed
+- `Raw path`: actual file parsed by the session indexer
+- `Backend`: `binary-prefixed JSONL-ish line log`
+- `Volume`: `<line-count>` relevant user/assistant entries
+- `Quick inspect`: `perl -pe 's/^[^{]*//' <file> | sed -n '1,12p'`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Shape note`: each line is expected to reduce to `{type, content, timestamp}`
+- `Focused retrieval`:
+  - `perl -pe 's/^[^{]*//' <file> | jq -c '.' | head -n 20`
+  - `rg -n '"type": "user"|"type": "assistant"' <file>`
+- `Upstream mismatch`: note that current Gemini repo evidence points to newer tracker JSON under temp/session directories rather than `code_tracker`
+
+## Why This Is Feasible
+
+- The current parser already knows how to detect and strip the prefix bytes and count entries.
+- What is not feasible is claiming high confidence that this is the current upstream storage layout.
+
+## Current `continues` Comparison
+
+- Current handoff output treats Antigravity as a simple user/assistant text log, but the bigger issue is backend confidence, not message rendering.
+- This tool should get a pointer block that foregrounds uncertainty instead of smoothing it away.
+
+## Sources
+
+- First-party repo code: `google-gemini/gemini-cli` files `packages/core/src/services/trackerService.ts` and `packages/core/src/config/storage.ts` (read 2026-04-15)
+- Local parser and fixtures: `src/parsers/antigravity.ts`, `test-fixtures/antigravity/code_tracker/test-project/session.jsonl`, `test-fixtures/antigravity/code_tracker/test-project/session-binary.jsonl` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/15-kimi.md
+++ b/docs/parser-documentation/handoff-pointers/15-kimi.md
@@ -1,0 +1,59 @@
+# Kimi
+
+## Documented Facts
+
+- Official Kimi docs are unusually strong here: all runtime data lives under `~/.kimi/` unless `KIMI_SHARE_DIR` overrides it.
+- Official docs publish the full session directory layout:
+  - `sessions/<work-dir-hash>/<session-id>/context.jsonl`
+  - `wire.jsonl`
+  - `state.json`
+  - `subagents/<agent_id>/...`
+- Official docs also explain what each file means and that `context.jsonl` is used for `--continue` / `--session`.
+
+## Observed Example
+
+- `src/parsers/kimi.ts` matches that official shape closely, including hashed work-dir directories, optional `metadata.json` handling, and `context.jsonl` parsing.
+
+## Inference
+
+- Kimi deserves a rich pointer block even in default mode because the official docs make retrieval mechanics explicit and the parser already aligns with them.
+
+## Unresolved Uncertainty
+
+- None that block a strong pointer block. The main nuance is that `_usage` records expose a total token count snapshot rather than a full input/output split.
+
+## Default-Mode Pointer Block
+
+- `Session`: Kimi / `<session-id>`
+- `Raw session dir`: `~/.kimi/sessions/<work-dir-hash>/<session-id>/`
+- `Primary files`: `context.jsonl`, `wire.jsonl`, `state.json`
+- `Backend`: JSONL context + JSON state
+- `Volume`: `<context-line-count>` lines
+- `Quick inspect`:
+  - `sed -n '1,12p' <session-dir>/context.jsonl`
+  - `jq . <session-dir>/state.json`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Subagents`: include `subagents/` count and path when present
+- `State note`: surface key fields from `state.json` such as approval mode, plan mode, additional dirs, and subagent instances when cheap
+- `Focused retrieval`:
+  - `rg -n '"role": "_usage"|"role": "assistant"|"role": "user"' <session-dir>/context.jsonl`
+  - `find <session-dir>/subagents -maxdepth 2 -type f | sort`
+  - `sed -n '1,12p' <session-dir>/wire.jsonl`
+
+## Why This Is Feasible
+
+- `continues` already knows the session directory and parses `context.jsonl`.
+- `wire.jsonl`, `state.json`, and `subagents/` are deterministic siblings documented by the upstream tool itself.
+
+## Current `continues` Comparison
+
+- Current handoff output exposes only the parsed conversation and tool summary, not the equally important `wire.jsonl`, `state.json`, or subagent directory that the official tool treats as part of session restoration.
+
+## Sources
+
+- Official docs: https://moonshotai.github.io/kimi-cli/en/configuration/data-locations.html (accessed 2026-04-15)
+- First-party repo code: `MoonshotAI/kimi-cli` files `docs/en/configuration/data-locations.md`, `src/kimi_cli/session.py`, `src/kimi_cli/session_state.py`, and `src/kimi_cli/metadata.py` (read 2026-04-15)
+- Local parser: `src/parsers/kimi.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/16-qwen-code.md
+++ b/docs/parser-documentation/handoff-pointers/16-qwen-code.md
@@ -1,0 +1,54 @@
+# Qwen Code
+
+## Documented Facts
+
+- First-party Qwen code shows the runtime base is `~/.qwen` by default, overridable via `QWEN_RUNTIME_DIR`.
+- First-party storage code builds project directories under `<runtime-base>/projects/<sanitized-cwd>/`.
+- First-party session code stores chats in a `chats/` folder and models chat records as append-only JSONL with `uuid`, `parentUuid`, `sessionId`, timestamps, message content, usage metadata, and tool-result metadata.
+- A first-party issue asks for moving more chat/config/debug data into a workspace `.qwen` folder, which confirms the current runtime storage is still external enough to be worth surfacing.
+
+## Observed Example
+
+- `src/parsers/qwen-code.ts` matches the `projects/*/chats/*.jsonl` layout and reconstructs the main conversation path by walking `parentUuid`.
+
+## Inference
+
+- Qwen’s pointer block should highlight that the raw transcript is tree-structured JSONL, not a simple linear log. That tree property matters more than extra prose.
+
+## Unresolved Uncertainty
+
+- First-party Qwen code also uses a temp tree for checkpoints/history, and some comments still reference `tmp`; the parser’s current `projects/*/chats` assumption is supported by storage code, but the broader runtime layout is still evolving.
+
+## Default-Mode Pointer Block
+
+- `Session`: Qwen Code / `<session-id>`
+- `Raw transcript`: `<runtime-base>/projects/<sanitized-cwd>/chats/<session-id>.jsonl`
+- `Backend`: tree-structured JSONL
+- `Volume`: `<record-count>` total records
+- `Main path`: include `<main-path-message-count>` if cheap
+- `Quick inspect`: `sed -n '1,12p' <chat>.jsonl`
+
+## Full-Mode Pointer Block
+
+- Everything from default mode
+- `Tree note`: records branch via `uuid` and `parentUuid`; the visible chat is a reconstructed main path, not necessarily the full file
+- `Record mix`: counts for `user`, `assistant`, `tool_result`, and `system`
+- `Focused retrieval`:
+  - `rg -n '"type":"user"|"type":"assistant"|"type":"tool_result"|"type":"system"' <chat>.jsonl`
+  - `jq -c '{uuid,parentUuid,type,timestamp}' <chat>.jsonl | head -n 20`
+- `Runtime note`: show the resolved runtime base and mention `QWEN_RUNTIME_DIR` when it is set
+
+## Why This Is Feasible
+
+- `continues` already parses the JSONL and reconstructs the main path.
+- Record counts and main-path counts are cheap because the parser is already walking the record graph.
+
+## Current `continues` Comparison
+
+- Current handoff output flattens Qwen into recent conversation text and tool summaries, which hides the most important raw-storage fact: the source transcript is a branched record tree.
+
+## Sources
+
+- First-party repo code: `QwenLM/qwen-code` files `packages/core/src/config/storage.ts`, `packages/core/src/services/sessionService.ts`, and `packages/core/src/services/chatRecordingService.ts` (read 2026-04-15)
+- First-party issue: https://github.com/QwenLM/qwen-code/issues/2396 (accessed 2026-04-15)
+- Local parser: `src/parsers/qwen-code.ts` (read 2026-04-15)

--- a/docs/parser-documentation/handoff-pointers/99-open-questions.md
+++ b/docs/parser-documentation/handoff-pointers/99-open-questions.md
@@ -1,0 +1,66 @@
+# Open Questions
+
+## Highest-Priority Gaps
+
+### Gemini
+
+- Upstream Gemini CLI code now records append-only JSONL chat logs, but `continues` still parses older single-file JSON sessions.
+- Open question: which Gemini variants still emit the older JSON session object in real installs, and how should the parser detect JSON vs JSONL at discovery time without false positives?
+
+### Kiro
+
+- Official docs say Kiro stores sessions in SQLite under `~/.kiro/`, but the current parser still assumes legacy JSON files under `Library/Application Support/Kiro/workspace-sessions/`.
+- Open question: what is the exact SQLite filename/schema, and is the JSON layout still produced anywhere outside exports/tests?
+
+### Antigravity
+
+- Current parser targets `~/.gemini/antigravity/code_tracker/` line logs with binary prefixes.
+- Upstream Gemini repo evidence in this pass points instead to tracker JSON under per-project temp/session directories.
+- Open question: is `code_tracker` still a live product surface, or should the parser be rewritten around the newer tracker layout?
+
+### Cursor
+
+- First-party forum posts confirm local `agent-transcripts` survive UI/index corruption.
+- First-party forum posts also confirm at least one `.jsonl` transcript/export path dropped `tool_use` and likely omits `tool_result`.
+- Open question: do local `agent-transcripts` and exported transcripts share the same completeness limitations, or are they separate pipelines?
+
+### Factory Droid
+
+- First-party docs clearly expose `session_id` continuation and settings locations.
+- They did not, in this pass, publish the on-disk `~/.factory/sessions/.../*.jsonl` layout assumed by the parser.
+- Open question: can that raw session store be validated from first-party code/docs or from sanctioned local captures?
+
+### Amp
+
+- First-party docs strongly validate thread IDs, web thread URLs, and `amp threads continue`.
+- They did not, in this pass, validate the local JSON thread store under `~/.local/share/amp/threads/` that the parser reads.
+- Open question: is that local JSON store stable and official, or merely an observed implementation detail?
+
+### Kilo Code
+
+- The current parser clearly targets the VS Code extension task store (`ui_messages.json` under globalStorage).
+- First-party repo search also exposed a newer DB-backed codebase around `kilo.db`.
+- Open question: is the extension task store still the canonical storage backend for the product represented by this parser, or is a migration underway?
+
+## Lower-Priority Gaps
+
+### Codex
+
+- Official docs emphasize `CODEX_HOME` and `history.jsonl`, while first-party repo code centers resume on rollout files under `sessions/YYYY/MM/DD/rollout-*.jsonl`.
+- Open question: should the redesign surface both, or treat rollout files as the canonical handoff source and history as auxiliary state?
+
+### OpenCode
+
+- Migration issues show JSON and SQLite can coexist.
+- Open question: how should the handoff renderer describe installations where stale JSON exists but SQLite is authoritative, without misleading the receiver?
+
+### Crush
+
+- The repo code is clear about tables, but convenient public docs were less available during scraping.
+- Open question: do newer docs publish the default DB path and override behavior clearly enough to replace repo-code citations in end-user-facing research?
+
+## Recommended Follow-up Checks
+
+- Capture real local session stores for `gemini`, `kiro`, `antigravity`, `droid`, and `amp`.
+- Verify whether `cursor` local `agent-transcripts` preserve tool-use data better than exported transcripts.
+- Confirm whether `kilo-code` in this repo should remain grouped with the Cline-family extension store or be split into a new backend family.

--- a/docs/parser-documentation/message-schema/00-overview.md
+++ b/docs/parser-documentation/message-schema/00-overview.md
@@ -1,0 +1,46 @@
+# Message Schema Overview
+
+Access date: 2026-04-15
+
+This folder documents raw conversation/message storage, not just what `continues` currently renders. The highest-risk finding is that several parsers are anchored to older or narrower storage models than the current upstream tools.
+
+## Highest-Risk Mismatches
+
+| Tool | Risk | Why it matters |
+|---|---|---|
+| Gemini | High | The official `google-gemini/gemini-cli` code now writes append-only JSONL chat records with metadata, `$set`, and `$rewindTo`, but `src/parsers/gemini.ts` still assumes the older monolithic `session-*.json` shape. Assistant-message coverage and trimming can be materially wrong on current installs. |
+| Qwen Code | High | The official `QwenLM/qwen-code` code documents `~/.qwen/tmp/<project_id>/chats/*.jsonl`, while `src/parsers/qwen-code.ts` looks under `~/.qwen/projects/*/chats/`. The parser may simply miss current sessions. |
+| Antigravity | High | The current parser assumes JSON/JSONL records under `.gemini/antigravity/code_tracker/`, but the local install stores binary `.pb` files under `.gemini/antigravity/conversations/`. Current assistant-message assumptions are likely invalid. |
+| Kimi | High | Official Kimi CLI code uses `context.jsonl`, `wire.jsonl`, and `state.json`; the parser reads `context.jsonl` plus optional legacy `metadata.json` and ignores `wire.jsonl`/`state.json`. In sampled local sessions, `context.jsonl` was empty while `wire.jsonl` had usable chronology. |
+| OpenCode | Medium | The official schema stores assistant turns as a message row plus structured part rows (`text`, `tool`, `reasoning`, `step-start`, `step-finish`, `patch`, `compaction`, etc.). `src/parsers/opencode.ts` flattens only text parts into conversation messages, which hides assistant step boundaries and tool/result structure. |
+| Copilot | Medium | GitHub documents both raw session files and SQLite indexing. The parser only consumes `events.jsonl`, ignores the global `session-store.db`, and drops session directories that only expose newer `session.db` artifacts. |
+| Cursor | Medium | The parser assumes Anthropic-style tool blocks and token fields may exist in transcript JSONL, but sampled local transcripts were text-only, and Cursor forum feedback suggests tool-use data is not always fully preserved. |
+| Kilo Code | Medium | First-party issue evidence supports legacy `ui_messages.json` task storage, but the official repo also contains a newer `kilo.db`/OpenCode-style persistence layer. The current parser appears tied to the legacy extension path only. |
+
+## Assistant-Message Coverage Risks
+
+- Documented fact: Claude, Codex, Copilot, Gemini, OpenCode, Droid, Amp, Crush, Cline, Roo Code, Kimi, and Qwen all separate assistant turns from user turns in raw storage, but not always as one-record-per-turn.
+- Observed example: Claude and Droid frequently store tool results as `user` records containing `tool_result` blocks. Assistant text and assistant tool use are different records. Any naive “all user records are human turns” rule inflates recent-message tails and can hide assistant output.
+- Documented fact: Current Gemini and Qwen schemas are append-only JSONL with non-message records (`$set`, `$rewindTo`, `system`, compaction payloads). Message trimming must reconstruct effective history first.
+- Inference: Any cross-tool “last N lines” policy is unsafe. Recent-message trimming needs tool-specific reconstruction before truncation.
+
+## Recent-Message Trimming Risks
+
+- `src/parsers/codex.ts` intentionally prefers `response_item` over `event_msg`, but its “balanced tail” still discards older assistant-only spans once it backs up to the last user turn.
+- `src/parsers/claude.ts` is directionally correct to filter tool-result-only user entries, but it still trims after a tool-specific conversational filter, which can omit adjacent assistant tool-use context.
+- `src/parsers/opencode.ts`, `src/parsers/amp.ts`, and `src/parsers/kiro.ts` flatten message text without preserving assistant step/tool boundaries, so “recent conversation” can look simpler than the raw schema actually is.
+- `src/parsers/cursor.ts` and `src/parsers/copilot.ts` assume assistant messages always have enough text to stand alone, yet both tools can emit assistant turns that are mostly tool metadata.
+
+## Design Implications For `continues`
+
+- Separate “storage pointer” from “recent conversation.” The handoff should always expose raw path, format, and reconstruction notes first.
+- Reconstruct before trimming for Gemini, Qwen Code, Codex, Claude, and any tree/append-only format.
+- Distinguish human user input from tool-result carrier messages for Claude, Droid, Amp, and likely related Anthropic-style tools.
+- Treat assistant tool activity as first-class conversation structure, not only as side summaries, for OpenCode, Gemini, Qwen Code, Copilot, and Codex.
+- Surface storage-version uncertainty explicitly for Kiro, Antigravity, Cursor, and Kilo Code instead of pretending the parser assumptions are settled.
+
+## Source Notes
+
+- Documented fact sources are first-party docs/repos where available.
+- Observed examples come from local session artifacts on this machine, accessed 2026-04-15.
+- Open questions that still need upstream confirmation are collected in `99-open-questions.md`.

--- a/docs/parser-documentation/message-schema/01-claude.md
+++ b/docs/parser-documentation/message-schema/01-claude.md
@@ -1,0 +1,49 @@
+# Claude Code Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: Claude Code hook payloads expose `session_id` and `transcript_path`, and the docs show `transcript_path` values ending in `.jsonl` under `~/.claude/projects/...`. `SessionStart` differentiates `startup`, `resume`, `clear`, and `compact`. `PreCompact` and `PostCompact` are explicit hook phases.
+- Observed example: A sampled local transcript line is a JSON object with top-level fields such as `type`, `timestamp`, `sessionId`, `cwd`, `uuid`, `parentUuid`, and `message`.
+- Observed example: Sampled line types included `queue-operation`, `user`, `assistant`, and `attachment`.
+
+## Assistant Messages
+
+- Observed example: Assistant turns use `type: "assistant"` and `message.role: "assistant"`.
+- Observed example: `message.content` is block-based. Sampled assistant blocks included `text`, `tool_use`, and `thinking`.
+- Observed example: Assistant records also carried `message.model` and `message.usage`.
+
+## User Messages
+
+- Observed example: Human turns use `type: "user"` and `message.role: "user"`.
+- Observed example: Tool results also arrive as `type: "user"` lines whose `message.content` contains `tool_result` blocks, with fields like `tool_use_id` and result content.
+- Inference: Recent-message reconstruction must distinguish human user turns from tool-result carrier turns.
+
+## Ordering, Boundaries, And Compaction
+
+- Documented fact: The transcript is JSONL, so file order is the primary ordering model.
+- Observed example: Each line also carries its own ISO timestamp string.
+- Observed example: A sampled compacted-summary record carried `isCompactSummary: true`.
+- Documented fact: Claude’s hook lifecycle explicitly models compaction, and `SessionStart` can indicate `compact`.
+- Inference: Message boundaries are line-based, but a single logical assistant turn may span multiple adjacent lines: assistant tool-use, user tool-result, then assistant text.
+
+## Direct Access
+
+- Read the transcript directly: `jq -c . ~/.claude/projects/<project>/<session>.jsonl`
+- Find compacted summaries: `rg -n '"isCompactSummary":true' ~/.claude/projects`
+- Find tool-result carrier user lines: `rg -n '"tool_result"' ~/.claude/projects/<project>/<session>.jsonl`
+
+## Parser Comparison
+
+- `src/parsers/claude.ts` is correct to treat `user` tool-result-only messages differently from human input; the raw schema supports that distinction.
+- `src/parsers/claude.ts` also correctly models `queue-operation`, subagent side files, and compact-summary handling as Claude-specific features.
+- The parser still flattens assistant blocks into plain text for recent conversation, so assistant tool-use/thinking boundaries are lost in the handoff.
+- The current markdown renderer trims after parser-side filtering, which is safer than raw tail slicing but still does not preserve the full assistant/tool/result turn structure.
+
+## Sources
+
+- Anthropic hooks docs: https://docs.anthropic.com/en/docs/claude-code/hooks (accessed 2026-04-15)
+- Anthropic costs docs: https://docs.anthropic.com/en/docs/claude-code/costs (accessed 2026-04-15)
+- Observed local transcript: `~/.claude/projects/-/b234a1b2-b63f-4be6-84ab-43281cb07adf.jsonl` (accessed 2026-04-15)
+- Observed local compact-summary transcript: `~/.claude/projects/-Users-yigitkonur-dev-cli-codex-worker/8fb1ee76-8226-466c-823c-53d1e8292505.jsonl` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/02-codex.md
+++ b/docs/parser-documentation/message-schema/02-codex.md
@@ -1,0 +1,49 @@
+# Codex CLI Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: The official Codex recorder persists rollout files as `.jsonl` under `~/.codex/sessions/YYYY/MM/DD/`, with filenames like `rollout-YYYY-MM-DDTHH-MM-SS-<thread-id>.jsonl`.
+- Documented fact: Each persisted line is a `RolloutLine` with a top-level `timestamp` plus a flattened `RolloutItem`.
+- Documented fact: Persisted item categories include `session_meta`, `turn_context`, `event_msg`, `response_item`, and `compacted`.
+- Observed example: A local rollout file started with `session_meta`, then `event_msg`, `response_item`, `turn_context`, additional `response_item`, and `token_count`/task events.
+
+## Assistant Messages
+
+- Observed example: `response_item` lines with `payload.type: "message"` and `payload.role: "assistant"` are the richest assistant-message source.
+- Observed example: Assistant text lives inside `payload.content[]` items of type `output_text` or `text`.
+- Observed example: `event_msg` lines can also carry assistant text through `payload.type: "agent_message"` or `payload.type: "assistant_message"`.
+- Documented fact: `response_item` also has non-conversational assistant-adjacent entries such as `reasoning` and `ghost_snapshot`.
+
+## User Messages
+
+- Observed example: `response_item` lines with `payload.type: "message"` and `payload.role: "user"` carry user `input_text` parts.
+- Observed example: `event_msg` lines with `payload.type: "user_message"` duplicate or summarize the same turn.
+- Inference: `response_item` is the better conversational source when present; `event_msg` is a fallback/event stream.
+
+## Ordering, Boundaries, And Compaction
+
+- Documented fact: Rollouts are append-only JSONL; file order is canonical.
+- Documented fact: Every line also has its own top-level timestamp.
+- Documented fact: `compacted` lines exist in the official protocol.
+- Inference: Message reconstruction should prefer `response_item` for user/assistant turns, while still preserving `event_msg` and `compacted` as stateful side records.
+
+## Direct Access
+
+- Inspect a rollout: `jq -c . ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`
+- Find compacted records: `rg -n '"type":"compacted"' ~/.codex/sessions`
+- Find assistant response items: `rg -n '"role":"assistant"' ~/.codex/sessions/.../rollout-*.jsonl`
+
+## Parser Comparison
+
+- `src/parsers/codex.ts` is right to prefer `response_item` over `event_msg` for recent conversation and to skip system-injected user text like `<environment_context>`.
+- The parser does not currently model official `compacted` lines, so any compaction boundary is invisible to downstream handoff logic.
+- The current balanced-tail heuristic protects against long assistant-only tails, but it still converts the reconstructed message stream into plain alternating text without exposing line-level item types like `reasoning` or `ghost_snapshot`.
+
+## Sources
+
+- Codex recorder implementation: https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder.rs (accessed 2026-04-15)
+- Codex protocol definitions: https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs (accessed 2026-04-15)
+- Codex state extraction: https://github.com/openai/codex/blob/main/codex-rs/state/src/extract.rs (accessed 2026-04-15)
+- Observed local rollout: `~/.codex/sessions/2026/03/22/rollout-2026-03-22T06-04-51-019d15a5-f838-7413-a763-e04a7c2a62da.jsonl` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/03-copilot.md
+++ b/docs/parser-documentation/message-schema/03-copilot.md
@@ -1,0 +1,50 @@
+# GitHub Copilot CLI Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: GitHub documents `~/.copilot/session-state/` as the directory containing per-session history files and `~/.copilot/session-store.db` as the SQLite session store.
+- Documented fact: Per-session directories store `events.jsonl` plus workspace artifacts; the global SQLite store is a subset/index of the raw session files.
+- Documented fact: The raw session data includes prompts, Copilot responses, tools used, and file modifications.
+- Observed example: Local session directories contained `workspace.yaml`, `events.jsonl`, `vscode.metadata.json`, and in some cases a per-session `session.db`.
+- Observed example: The global `session-store.db` contained `sessions`, `turns`, and `session_files` tables.
+
+## Assistant Messages
+
+- Observed example: `events.jsonl` included `assistant.turn_start` and `assistant.message` events.
+- Observed example: `assistant.message.data` contained `messageId`, `content`, `toolRequests`, `interactionId`, `reasoningOpaque`, `reasoningText`, and `outputTokens`.
+- Observed example: Tool execution details also appeared as separate `tool.execution_start` events with `toolName`, `arguments`, and `toolCallId`.
+- Observed example: The SQLite `turns` table stored `assistant_response` per `turn_index`.
+
+## User Messages
+
+- Observed example: `user.message.data` contained `content`, `transformedContent`, `source`, `attachments`, and `interactionId`.
+- Observed example: The SQLite `turns` table stored `user_message` alongside `assistant_response`.
+
+## Ordering, Boundaries, And Indexing
+
+- Documented fact: Raw session files are written incrementally during a session and on session end.
+- Observed example: `events.jsonl` is an append-only event stream, not a normalized turns array.
+- Observed example: The global `turns` table normalizes ordering with `turn_index`, and `session_files` associates modified files to a `turn_index`.
+- Inference: `events.jsonl` is the richer raw source; the SQLite store is a searchable summary/index, not the full fidelity stream.
+
+## Direct Access
+
+- Per-session raw log: `jq -c . ~/.copilot/session-state/<session-id>/events.jsonl`
+- Global index schema: `sqlite3 ~/.copilot/session-store.db '.schema sessions' '.schema turns' '.schema session_files'`
+- List indexed turns: `sqlite3 ~/.copilot/session-store.db 'SELECT * FROM turns WHERE session_id = ... ORDER BY turn_index'`
+
+## Parser Comparison
+
+- `src/parsers/copilot.ts` correctly targets `events.jsonl` and `workspace.yaml` for the raw conversation path described in the docs.
+- The parser currently ignores explicit `tool.execution_*` events and only summarizes tool activity from `assistant.message.data.toolRequests`.
+- The parser also ignores the global `session-store.db`, even though GitHub documents it as the maintained cross-session index.
+- Observed local directories with `session.db` but no `events.jsonl` suggest the parser may miss some newer or incomplete session variants entirely because it filters out sessions with zero raw-event bytes.
+
+## Sources
+
+- GitHub Copilot CLI session data docs: https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle (accessed 2026-04-15)
+- GitHub Copilot CLI config dir reference: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference (accessed 2026-04-15)
+- Observed local event log: `~/.copilot/session-state/005a2626-fdd3-4393-85ab-1a4050afb71d/events.jsonl` (accessed 2026-04-15)
+- Observed local session store: `~/.copilot/session-store.db` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/04-gemini.md
+++ b/docs/parser-documentation/message-schema/04-gemini.md
@@ -1,0 +1,50 @@
+# Gemini CLI Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: The official `google-gemini/gemini-cli` code now records conversations as append-only JSONL files under `~/.gemini/tmp/<project-id>/chats/`.
+- Documented fact: Current chat files begin with partial metadata records and then append message records, `$set` metadata updates, and `$rewindTo` rewind markers.
+- Documented fact: The current message-record model includes `type: 'user' | 'gemini' | 'info' | 'error' | 'warning'`.
+- Observed example: A local older-format session file was a single JSON object with `sessionId`, `projectHash`, `startTime`, `lastUpdated`, and `messages[]`.
+- Observed example: Local `~/.gemini/projects.json` maps absolute project roots to short project IDs used in `~/.gemini/tmp/<project-id>/...`.
+
+## Assistant Messages
+
+- Documented fact: In the current official schema, assistant turns use `type: "gemini"`.
+- Documented fact: `gemini` messages can carry `content`, `toolCalls`, `thoughts`, `tokens`, and `model`.
+- Observed example: In the sampled legacy JSON file, `gemini` entries also contained `toolCalls`, `thoughts`, `tokens`, and `model`.
+
+## User Messages
+
+- Documented fact: User turns use `type: "user"` in both the current JSONL schema and the sampled legacy JSON schema.
+- Documented fact: The loader’s first-user extraction reads text from `content` parts and treats those as the primary prompt text.
+
+## Ordering, Boundaries, And Rewind
+
+- Documented fact: Current storage is append-only JSONL, but effective history is not just file order.
+- Documented fact: `$rewindTo` records truncate later logical messages, and repeated records with the same message `id` are aggregated on load.
+- Documented fact: Metadata updates are appended as `$set` records rather than rewriting the file.
+- Inference: Any recent-message extraction that does not replay `$rewindTo` and merge duplicate message IDs can produce the wrong conversation tail.
+
+## Direct Access
+
+- Current-format files: `find ~/.gemini/tmp -path '*/chats/*.jsonl'`
+- Legacy-format files: `find ~/.gemini/tmp -path '*/chats/*.json'`
+- Project-ID mapping: `cat ~/.gemini/projects.json`
+
+## Parser Comparison
+
+- `src/parsers/gemini.ts` is now behind upstream storage: it only scans `session-*.json` files and ignores the current JSONL format documented in the official repo.
+- The parser also leaves `cwd` empty even though `projects.json` plus `projectHash` can recover more project context than an empty string.
+- The parser’s message-shape assumptions still match older local JSON examples, so it is not universally wrong; it is version-skewed.
+- This is a high-risk assistant-message coverage bug because current installs can store `gemini` assistant turns in files the parser never opens.
+
+## Sources
+
+- Gemini storage/config code: https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/config/storage.ts (accessed 2026-04-15)
+- Gemini chat recording service: https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts (accessed 2026-04-15)
+- Gemini chat recording types: https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingTypes.ts (accessed 2026-04-15)
+- Observed local legacy session: `~/.gemini/tmp/73a653feba8da3ab78a2b1507f0e46a718a8c5820242bd4b84df046d4ae52e8c/chats/session-2026-02-18T20-41-3d0ca2eb.json` (accessed 2026-04-15)
+- Observed local project map: `~/.gemini/projects.json` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/05-opencode.md
+++ b/docs/parser-documentation/message-schema/05-opencode.md
@@ -1,0 +1,50 @@
+# OpenCode Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: Current OpenCode persistence is SQLite-first, with `session`, `message`, and `part` tables in `opencode.db`.
+- Documented fact: OpenCode still supports migration from legacy JSON storage under `storage/project`, `storage/session`, `storage/message`, `storage/part`, and related directories.
+- Observed example: The local `opencode.db` had `session`, `message`, `part`, `session_share`, `todo`, and related tables.
+- Observed example: `message.data` rows stored structured JSON with fields like `role`, `time`, `agent`, `model`, `variant`, and summary metadata.
+- Observed example: `part.data` rows stored structured JSON with `type` values such as `text`, `tool`, `step-start`, and `step-finish`.
+
+## Assistant Messages
+
+- Documented fact: Assistant message rows use `role: "assistant"` in `message.data`.
+- Documented fact: Assistant turns are completed by associated `part` rows, not by the message row alone.
+- Documented fact: Official assistant-part types include `text`, `tool`, `reasoning`, `step-start`, `step-finish`, `snapshot`, `patch`, `agent`, `retry`, `compaction`, and `subtask`.
+- Observed example: Sampled local assistant parts included `step-start`, `text`, `tool`, and `step-finish`.
+
+## User Messages
+
+- Documented fact: User message rows use `role: "user"` and can include summary metadata plus text/file parts.
+- Documented fact: User messages can carry structured diff summaries in `summary.diffs`.
+
+## Ordering, Boundaries, And Compaction
+
+- Documented fact: Messages are ordered by `time_created`, and parts are ordered by `message_id` plus creation/id order.
+- Documented fact: Compaction is first-class in the schema: assistant messages can be marked as summary messages, and `compaction` parts exist.
+- Documented fact: Session-level summary stats also live on the `session` row as additions/deletions/files/diffs.
+- Inference: Assistant message boundaries are “message row + ordered part rows,” not one row = one readable turn.
+
+## Direct Access
+
+- Session schema: `sqlite3 ~/.local/share/opencode/opencode.db '.schema session' '.schema message' '.schema part'`
+- Message rows: `sqlite3 ~/.local/share/opencode/opencode.db 'SELECT id, session_id, data FROM message WHERE session_id = ... ORDER BY time_created'`
+- Part rows: `sqlite3 ~/.local/share/opencode/opencode.db 'SELECT message_id, data FROM part WHERE session_id = ... ORDER BY time_created'`
+
+## Parser Comparison
+
+- `src/parsers/opencode.ts` correctly knows OpenCode has both SQLite and legacy JSON storage.
+- The parser flattens only `text` parts into conversation messages, so assistant step boundaries, reasoning parts, tool parts, patch parts, and compaction parts are all omitted from recent conversation.
+- The registry points users at `~/.local/share/opencode/storage/`, but the current primary store on this machine is `~/.local/share/opencode/opencode.db`. A handoff pointer should prefer the DB path when it exists.
+
+## Sources
+
+- OpenCode session SQL schema: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/session.sql.ts (accessed 2026-04-15)
+- OpenCode message schema: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/message-v2.ts (accessed 2026-04-15)
+- OpenCode session logic: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/index.ts (accessed 2026-04-15)
+- OpenCode compaction logic: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/compaction.ts (accessed 2026-04-15)
+- Observed local DB: `~/.local/share/opencode/opencode.db` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/06-droid.md
+++ b/docs/parser-documentation/message-schema/06-droid.md
@@ -1,0 +1,49 @@
+# Droid Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Observed example: Sampled local Droid sessions were stored as JSONL under `~/.factory/sessions/<workspace-slug>/<session-id>.jsonl`, with companion `*.settings.json` files.
+- Observed example: Sampled persisted line types included `session_start`, `message`, `compaction_state`, and `todo_state`.
+- Documented fact: Factory’s `droid exec --output-format stream-json` emits JSONL runtime events such as `system`, `message`, `tool_call`, `tool_result`, and `completion`.
+- Documented fact: Factory hooks expose `transcript_path` values ending in `.jsonl`, plus `session_id` and `cwd`.
+
+## Assistant Messages
+
+- Observed example: Persisted assistant turns appeared as `type: "message"` with `message.role: "assistant"`.
+- Observed example: Assistant content used Anthropic-style blocks; sampled assistant blocks included `tool_use` followed by later `text`.
+- Documented fact: Runtime `stream-json` assistant message events flatten to fields like `role`, `id`, `text`, `timestamp`, and `session_id`.
+- Inference: Factory exposes at least two schemas that matter here: a persisted session log and a runtime exec event stream. They are related but not identical.
+
+## User Messages
+
+- Observed example: Human user turns are persisted as `message.role: "user"` with text blocks.
+- Observed example: Tool results are also persisted as `message.role: "user"` lines whose blocks are `tool_result`.
+- Documented fact: Runtime `stream-json` emits separate `tool_result` events rather than embedding them in user messages.
+
+## Ordering, Boundaries, And Compaction
+
+- Observed example: Persisted JSONL file order is chronological, and message events also include per-event timestamps.
+- Observed example: `compaction_state` carried summary text outside the regular user/assistant message flow.
+- Observed example: `todo_state` carried pending/in-progress task state outside the message stream.
+- Documented fact: Hook docs expose `PreCompact` and `SessionStart` sources including `compact`.
+
+## Direct Access
+
+- Persisted session log: `jq -c . ~/.factory/sessions/<workspace>/<session>.jsonl`
+- Companion settings: `cat ~/.factory/sessions/<workspace>/<session>.settings.json`
+- Runtime stream reference: see `droid exec --output-format stream-json`
+
+## Parser Comparison
+
+- `src/parsers/droid.ts` aligns well with the observed persisted JSONL plus `.settings.json` model.
+- The parser correctly extracts `compaction_state`, `todo_state`, settings-based token usage, and Anthropic-style assistant/user blocks.
+- The main risk is conceptual, not structural: Factory’s public `stream-json` docs describe a flatter runtime event protocol than the persisted session log. Future handoff docs should keep those two surfaces separate.
+
+## Sources
+
+- Factory hooks reference: https://docs.factory.ai/reference/hooks-reference (accessed 2026-04-15)
+- Droid exec overview: https://docs.factory.ai/cli/droid-exec/overview (accessed 2026-04-15)
+- Observed local session log: `~/.factory/sessions/-Users-yigitkonur-.codex/0dce4686-b414-42b1-a450-4fbe53979e30.jsonl` (accessed 2026-04-15)
+- Observed local settings: `~/.factory/sessions/-Users-yigitkonur-.codex/0dce4686-b414-42b1-a450-4fbe53979e30.settings.json` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/07-cursor.md
+++ b/docs/parser-documentation/message-schema/07-cursor.md
@@ -1,0 +1,44 @@
+# Cursor Agent Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Observed example: Sampled Cursor agent transcripts lived under `~/.cursor/projects/<project-slug>/agent-transcripts/<session-id>.jsonl`.
+- Observed example: Sampled transcript lines were simple JSON objects with top-level `role` and `message`, where `message.content` was an array of blocks.
+- Observed example: In sampled files, `message.content` only contained `text` blocks.
+- Unresolved uncertainty: No first-party Cursor schema document was located that fully specifies the raw `agent-transcripts` format.
+
+## Assistant Messages
+
+- Observed example: Assistant turns use `role: "assistant"`.
+- Observed example: Sampled assistant lines exposed only text blocks; no explicit `tool_use`, `tool_result`, `usage`, or `model` fields were present in the sampled transcript.
+- Inference: Cursor may emit richer Anthropic-style payloads in some builds, but that is not guaranteed by the sampled local files.
+
+## User Messages
+
+- Observed example: User turns use `role: "user"` and text blocks under `message.content[]`.
+- Inference: Human/user boundaries are easy to recover from sampled transcripts because the records are already role-tagged and text-only.
+
+## Ordering, Boundaries, And Compaction
+
+- Observed example: JSONL line order is the only clear ordering signal in sampled transcripts; the sampled lines lacked explicit top-level timestamps.
+- Unresolved uncertainty: Public community feedback indicates Cursor’s exported JSONL may not always fully preserve tool-use information, which means transcript completeness is tool/version-dependent.
+- Unresolved uncertainty: No explicit compaction marker or summary record was observed in local transcripts.
+
+## Direct Access
+
+- Transcript path: `find ~/.cursor/projects -path '*/agent-transcripts/*.jsonl'`
+- Inspect a transcript: `jq -c . ~/.cursor/projects/<slug>/agent-transcripts/<session>.jsonl`
+
+## Parser Comparison
+
+- `src/parsers/cursor.ts` assumes the transcript may contain Anthropic-compatible tool blocks plus assistant `usage`/`model` passthrough fields, and it runs `extractAnthropicToolData(...)` over every line.
+- The sampled local transcripts did not expose those richer blocks, so current tool-activity and assistant-token coverage is uncertain and may be overstated for some Cursor sessions.
+- This directly affects assistant-message inclusion and recent-message trimming because the parser may infer structure that the raw transcript did not actually preserve.
+
+## Sources
+
+- Cursor community thread: https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311 (accessed 2026-04-15)
+- Cursor community thread: https://forum.cursor.com/t/jsonl-format-should-fully-record-the-tool-use-information/154777 (accessed 2026-04-15)
+- Observed local transcript: `~/.cursor/projects/Users-yigitkonur-dev-test-cli-continues/agent-transcripts/16f31a93-4d65-4b9d-bad9-bb082f4aa56e.jsonl` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/08-amp.md
+++ b/docs/parser-documentation/message-schema/08-amp.md
@@ -1,0 +1,43 @@
+# Amp Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: Amp’s plugin API defines `ThreadID = \`T-\${string}\`` and a `ThreadMessage` union of `ThreadUserMessage`, `ThreadAssistantMessage`, and `ThreadInfoMessage`.
+- Documented fact: User thread messages contain `(text | tool_result)[]` content blocks; assistant thread messages contain `(text | thinking | tool_use)[]` content blocks.
+- Observed example: Local thread files were stored as JSON under `~/.local/share/amp/threads/T-....json`.
+- Observed example: A sampled thread JSON had top-level keys including `id`, `created`, `messages`, `env`, `meta`, `agentMode`, and `nextMessageId`.
+
+## Assistant Messages
+
+- Documented fact: Assistant messages use `role: "assistant"` with block types `text`, `thinking`, and `tool_use`.
+- Unresolved uncertainty: I did not find a local thread sample with both user and assistant messages populated, so the assistant block mix is documented from Amp’s plugin API rather than from a local on-disk example.
+
+## User Messages
+
+- Documented fact: User messages use `role: "user"` with block types `text` and `tool_result`.
+- Observed example: A sampled local message object exposed fields like `role`, `messageId`, `content`, `userState`, `agentMode`, and `meta`.
+
+## Ordering, Boundaries, And Timestamps
+
+- Documented fact: Each message has a thread-unique numeric ID in the plugin API.
+- Observed example: Local thread JSON clearly stores an ordered `messages[]` array.
+- Observed example: Sampled local thread JSON did not show per-message timestamps; the parser’s use of the thread-level `created` timestamp as fallback is therefore understandable but lossy.
+- Unresolved uncertainty: No explicit compaction or summary record was found in the plugin API or the local thread samples reviewed here.
+
+## Direct Access
+
+- List threads: `find ~/.local/share/amp/threads -name 'T-*.json'`
+- Inspect a thread: `jq . ~/.local/share/amp/threads/T-....json`
+
+## Parser Comparison
+
+- `src/parsers/amp.ts` is directionally right about thread JSON storage.
+- The parser is too narrow about content blocks: it only extracts `type: "text"` and ignores official `thinking`, `tool_use`, and `tool_result` block types documented by Amp itself.
+- That means assistant-message reconstruction is incomplete today, especially for agent/tool-heavy turns.
+
+## Sources
+
+- Amp plugin API: https://ampcode.com/manual/plugin-api (accessed 2026-04-15)
+- Observed local thread file: `~/.local/share/amp/threads/T-019cc922-3fd6-706b-9950-e56ccf39e65a.json` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/09-kiro.md
+++ b/docs/parser-documentation/message-schema/09-kiro.md
@@ -1,0 +1,48 @@
+# Kiro Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: Kiro CLI automatically saves chat sessions on every turn.
+- Documented fact: Sessions are stored per directory, can be listed/resumed by UUID session ID, and can be exported/imported as JSON files via `/chat save` and `/chat load`.
+- Documented fact: The Kiro docs describe the active session store as a database-backed concept but do not publish the on-disk internal schema.
+- Unresolved uncertainty: I did not find a first-party public document that confirms the internal `workspace-sessions/*.json` layout currently assumed by `src/parsers/kiro.ts`.
+- Observed example: No local Kiro session artifacts were present on this machine for direct inspection.
+
+## Assistant Messages
+
+- Inference: Kiro clearly persists assistant turns because it can resume, list, save, and reload chat sessions.
+- Unresolved uncertainty: The exact raw assistant-message object shape is not publicly documented in the sources reviewed for this audit.
+- Inference: The parser’s assumed `history[]` entries with `message.role` and `message.content` may reflect a real app build, but that assumption is not independently validated here.
+
+## User Messages
+
+- Documented fact: Kiro resumes and exports full conversations, so user turns are definitely persisted.
+- Unresolved uncertainty: The exact raw user-message JSON shape is likewise undocumented in the public sources reviewed here.
+
+## Ordering, Boundaries, And Compaction
+
+- Documented fact: Kiro sessions are scoped per directory and have UUID session IDs.
+- Documented fact: The most recently updated sessions appear first when listed.
+- Unresolved uncertainty: No public source in this audit exposed a compaction marker, summary record, or raw turn-order file format.
+
+## Direct Access
+
+- Officially documented operations:
+- `kiro-cli chat --list-sessions`
+- `kiro-cli chat --resume`
+- `kiro-cli chat --resume-id <SESSION_ID>`
+- `/chat save <FILE_PATH>` to write a JSON export
+- `/chat load <FILE_PATH>` to read a JSON export
+
+## Parser Comparison
+
+- `src/parsers/kiro.ts` assumes a concrete internal file layout: `~/Library/Application Support/Kiro/workspace-sessions/<workspace>/<session>.json` with fields like `sessionId`, `workspacePath`, `selectedModel`, and `history[]`.
+- The public Kiro docs used here do not validate that internal shape. They validate session behavior, UUIDs, per-directory scope, and JSON export/import only.
+- That means the current parser may be correct for a specific desktop build, but its assistant-message and ordering assumptions remain externally unverified.
+
+## Sources
+
+- Kiro chat docs: https://kiro.dev/docs/cli/chat/ (accessed 2026-04-15)
+- Kiro CLI command reference: https://kiro.dev/docs/cli/reference/cli-commands/ (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/10-crush.md
+++ b/docs/parser-documentation/message-schema/10-crush.md
@@ -1,0 +1,46 @@
+# Crush Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: Crush persists sessions in SQLite.
+- Documented fact: The official migration/schema defines `sessions`, `messages`, and `files` tables.
+- Documented fact: The `messages` table stores `role`, `parts`, `model`, timestamps, and related metadata.
+- Documented fact: The query layer orders messages by `created_at ASC` for per-session replay.
+- Observed example: On this machine, `~/.crush/crush.db` currently exists but is empty, so there was no local populated session example to inspect.
+
+## Assistant Messages
+
+- Documented fact: Assistant turns are stored as rows in `messages` with `role = 'assistant'`.
+- Documented fact: Message content lives in the `parts` JSON column rather than in scalar text columns.
+- Inference: Assistant-message reconstruction requires parsing `parts`, not just reading one `assistant_response` column.
+
+## User Messages
+
+- Documented fact: User turns are rows in `messages` with `role = 'user'`.
+- Documented fact: The official SQL layer also exposes helpers like `ListUserMessagesBySession`.
+
+## Ordering, Boundaries, And Summaries
+
+- Documented fact: Message order is `created_at ASC`.
+- Documented fact: The schema includes richer session-level metadata than the current parser uses, including prompt/completion token counts and, in the SQL layer, summary/todo-related fields.
+- Unresolved uncertainty: I did not find a first-party public example of the exact `parts` JSON payload for a current populated database in this audit.
+
+## Direct Access
+
+- Inspect schema: `sqlite3 ~/.crush/crush.db '.schema sessions' '.schema messages'`
+- List messages for a session: `sqlite3 ~/.crush/crush.db 'SELECT role, parts, created_at FROM messages WHERE session_id = ... ORDER BY created_at ASC'`
+
+## Parser Comparison
+
+- `src/parsers/crush.ts` is directionally aligned with the official schema: it expects SQLite, session rows, message rows, and a `parts` JSON column.
+- The parser only extracts plain text from `parts` and ignores other official fields such as `provider`, `finished_at`, and broader session metadata.
+- Because the local DB was empty, current parser assumptions about the exact `parts` payload remain code-backed rather than locally observed.
+
+## Sources
+
+- Crush initial migration: https://github.com/charmbracelet/crush/blob/main/internal/db/migrations/20250424200609_initial.sql (accessed 2026-04-15)
+- Crush session queries: https://github.com/charmbracelet/crush/blob/main/internal/db/sql/sessions.sql (accessed 2026-04-15)
+- Crush message queries: https://github.com/charmbracelet/crush/blob/main/internal/db/sql/messages.sql (accessed 2026-04-15)
+- Observed local DB path: `~/.crush/crush.db` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/11-cline.md
+++ b/docs/parser-documentation/message-schema/11-cline.md
@@ -1,0 +1,48 @@
+# Cline Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: Cline stores per-task UI history in `ui_messages.json` inside its globalStorage task directory.
+- Documented fact: The official code reads and writes `ui_messages.json` through `getSavedClineMessages(...)` and `saveClineMessages(...)`.
+- Documented fact: Other task files exist too, including `api_conversation_history.json`, but `ui_messages.json` is the persisted UI message stream.
+
+## Assistant Messages
+
+- Documented fact: Cline UI messages are not simple `role/content` objects; they are `ClineMessage` entries with `type`, `say`/`ask`, `text`, `partial`, and timestamps.
+- Observed example from current local parser logic: assistant-visible entries come from `type: "say"` with:
+- `say: "text"` and `partial: true` for streaming assistant text chunks
+- `say: "completion_result"` for completed assistant output
+- `say: "reasoning"` for assistant reasoning text
+- Inference: Assistant turns may be spread across multiple adjacent partial chunks before a final non-partial completion.
+
+## User Messages
+
+- Observed example from current local parser logic: user turns come from:
+- `say: "user_feedback"`
+- some non-partial `say: "text"` entries that represent user input
+- Inference: Role reconstruction is semantic, not explicit in the raw file.
+
+## Ordering, Boundaries, And Partial Chunks
+
+- Documented fact: `ui_messages.json` is an array, so array order is the primary chronological model.
+- Documented fact: Every message has a `ts` timestamp.
+- Documented fact: The official task code updates partial messages in place and saves the array back to disk.
+- Inference: Recent-conversation extraction must deduplicate/merge consecutive assistant partial chunks to avoid replaying stale intermediate text.
+
+## Direct Access
+
+- Cline task dir: look under VS Code/Cursor globalStorage for `.../tasks/<task-id>/ui_messages.json`
+- Inspect raw UI messages: `jq . <task-dir>/ui_messages.json`
+
+## Parser Comparison
+
+- `src/parsers/cline.ts` matches the official storage file (`ui_messages.json`) and correctly deduplicates consecutive assistant partial text chunks.
+- The parser intentionally produces no tool summaries because official Cline tool-level detail lives outside `ui_messages.json`, notably in `api_conversation_history.json` and other task metadata.
+- That means the parser’s conversation extraction is plausible, but its tool/activity view is knowingly incomplete if only `ui_messages.json` is consulted.
+
+## Sources
+
+- Cline disk storage code: https://github.com/cline/cline/blob/main/src/core/storage/disk.ts (accessed 2026-04-15)
+- Observed local parser assumptions: `src/parsers/cline.ts` in this repo, read 2026-04-15

--- a/docs/parser-documentation/message-schema/12-roo-code.md
+++ b/docs/parser-documentation/message-schema/12-roo-code.md
@@ -1,0 +1,44 @@
+# Roo Code Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: Roo Code stores task UI history in `ui_messages.json` and reads/writes it through `readTaskMessages(...)` and `saveTaskMessages(...)`.
+- Documented fact: The task file lives in the extension’s globalStorage task directory.
+- Documented fact: First-party issue reports show that Roo task directories can also contain `*.lock` files and can temporarily lack `ui_messages.json` after crashes.
+
+## Assistant Messages
+
+- Inference: Roo inherits the same `ClineMessage` model used by Cline-family extensions, so assistant turns are semantic `say` messages rather than explicit `role: "assistant"` records.
+- Documented fact: Roo task code still refers to these as “Cline messages.”
+- Inference: Assistant streaming chunks, final completions, and reasoning are represented the same way as in Cline’s `ui_messages.json`.
+
+## User Messages
+
+- Inference: User turns are likewise encoded via `ClineMessage` entries rather than a normalized user-role JSON object.
+- This is consistent with Roo’s direct reuse of `readTaskMessages(...)`/`saveTaskMessages(...)` and the parser sharing implemented in `src/parsers/cline.ts`.
+
+## Ordering, Boundaries, And Failure Modes
+
+- Documented fact: `ui_messages.json` is a JSON array updated over time.
+- Documented fact: Crash scenarios can leave lock files behind or leave a task directory with lock files but no `ui_messages.json`.
+- Inference: Session discovery cannot assume every valid task directory has a readable message file.
+
+## Direct Access
+
+- Local task dir examples from first-party issue reporting:
+- `~/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/tasks/<task-id>/ui_messages.json`
+- same directory may contain `*.lock`
+
+## Parser Comparison
+
+- `src/parsers/cline.ts` is the correct code path for Roo Code because Roo persists the same `ui_messages.json` task stream.
+- The current parser will silently miss crash-recovery edge cases where a Roo task directory exists but `ui_messages.json` does not, exactly the failure mode described in Roo issue #6022.
+- Tool-call coverage is limited for the same reason as Cline: `ui_messages.json` is a UI stream, not the full tool history.
+
+## Sources
+
+- Roo task persistence code: https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/taskMessages.ts (accessed 2026-04-15)
+- Roo task logic: https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task/Task.ts (accessed 2026-04-15)
+- Roo storage failure issue: https://github.com/RooCodeInc/Roo-Code/issues/6022 (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/13-kilo-code.md
+++ b/docs/parser-documentation/message-schema/13-kilo-code.md
@@ -1,0 +1,47 @@
+# Kilo Code Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: First-party Kilo issue reports explicitly reference `ui_messages.json` and `ui_messages.json.lock` under `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/<task-id>/`.
+- Documented fact: That same issue describes large `ui_messages.json` files and stale lock-file behavior in real Kilo task directories.
+- Documented fact: The official `Kilo-Org/kilocode` repository also contains a newer persistence layer built around `kilo.db` plus OpenCode-style `session/message/part` storage and JSON-to-SQLite migration code.
+- Unresolved uncertainty: This repo-level evidence suggests either a product split or an ongoing migration. The parser in `continues` currently targets the legacy extension-style `ui_messages.json` path only.
+
+## Assistant Messages
+
+- Inference: For the legacy extension path backed by `ui_messages.json`, Kilo appears to share the Cline/Roo message model and assistant-chunk semantics.
+- Documented fact: First-party issue reporting about `ui_messages.json` confirms that this file is the active UI task history in at least some Kilo builds.
+- Documented fact: In the newer `kilo.db` code path, assistant messages are fully structured session/message/part records with explicit assistant roles, tool parts, reasoning parts, and compaction parts.
+
+## User Messages
+
+- Inference: User-turn encoding depends on which Kilo storage generation is in use.
+- Legacy extension path likely mirrors Roo/Cline-style `ui_messages.json`.
+- Newer repo-level persistence mirrors OpenCode-style `message.data.role: "user"` plus structured parts.
+
+## Ordering, Boundaries, And Migration Risk
+
+- Documented fact: The issue-backed extension path uses task directories and lock files around `ui_messages.json`.
+- Documented fact: The newer repo code uses `kilo.db` and OpenCode-style session/message/part ordering.
+- Inference: Message-boundary and assistant-coverage logic for Kilo cannot safely assume one stable upstream schema today.
+
+## Direct Access
+
+- Legacy extension path: inspect `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/<task-id>/ui_messages.json`
+- Newer repo-backed path, if present: inspect the Kilo database path described by the upstream code (`kilo.db`)
+
+## Parser Comparison
+
+- `src/parsers/cline.ts` likely matches legacy extension installs that still use `ui_messages.json`.
+- The parser has no coverage for the newer `kilo.db`/OpenCode-style persistence exposed in the current official repository.
+- This makes Kilo Code one of the highest schema-drift risks in the supported tool list: the current parser may be “right for the old product channel, wrong for the current core codebase.”
+
+## Sources
+
+- Kilo storage issue: https://github.com/Kilo-Org/kilocode/issues/3706 (accessed 2026-04-15)
+- Kilo DB code: https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/storage/db.ts (accessed 2026-04-15)
+- Kilo JSON migration code: https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/storage/json-migration.ts (accessed 2026-04-15)
+- Kilo session/message schema: https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/session/index.ts (accessed 2026-04-15)
+- Kilo message schema: https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/session/message-v2.ts (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/14-antigravity.md
+++ b/docs/parser-documentation/message-schema/14-antigravity.md
@@ -1,0 +1,42 @@
+# Antigravity Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Observed example: The local Antigravity install stores conversation-like artifacts under `~/.gemini/antigravity/conversations/*.pb`.
+- Observed example: Sampled `.pb` files are binary, not JSON or JSONL; `file` reported generic binary data and a hex dump showed no JSON framing.
+- Observed example: `~/.gemini/antigravity/code_tracker/` primarily contained active-file snapshots and related artifacts, not line-delimited conversation logs.
+- Observed example: Additional directories existed under `.gemini/antigravity/`, including `brain/`, `daemon/`, `browser_recordings/`, and `code_tracker/`.
+- Unresolved uncertainty: I did not locate a first-party public schema for the protobuf conversation files during this audit.
+
+## Assistant Messages
+
+- Unresolved uncertainty: The exact assistant-message representation inside `conversations/*.pb` is not publicly documented in the evidence reviewed here.
+- Inference: Assistant turns almost certainly exist in the protobuf conversation files, but the current parser does not read that format.
+
+## User Messages
+
+- Unresolved uncertainty: Same as assistant messages; the current protobuf wire shape is not publicly documented in the sources reviewed here.
+
+## Ordering, Boundaries, And Related Artifacts
+
+- Observed example: The existence of per-conversation `.pb` files suggests one conversation artifact per session or thread.
+- Observed example: `code_tracker/active/...` looks like file-tracking/storage support, not the canonical message transcript.
+- Inference: The current parser’s assumption of `{type, content, timestamp}` JSON lines under `code_tracker/` is likely based on an older or different Antigravity storage surface than the one currently installed.
+
+## Direct Access
+
+- Conversation artifacts: `find ~/.gemini/antigravity/conversations -name '*.pb'`
+- Supporting artifacts: `find ~/.gemini/antigravity -maxdepth 2 -type d`
+
+## Parser Comparison
+
+- `src/parsers/antigravity.ts` currently assumes `.json`/`.jsonl` conversation logs under `.gemini/antigravity/code_tracker/` and parses lines into `{type, timestamp, content}`.
+- The local install contradicts that assumption: the only clearly conversation-scoped artifacts I found were binary `.pb` files under `.gemini/antigravity/conversations/`.
+- This is a high-confidence, high-severity mismatch. On current local evidence, the parser is likely outdated and may not parse real Antigravity sessions at all.
+
+## Sources
+
+- Observed local conversation file: `~/.gemini/antigravity/conversations/b88b0608-c1e9-4029-a7ac-f932303fef5f.pb` (accessed 2026-04-15)
+- Observed local directories: `~/.gemini/antigravity/` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/15-kimi.md
+++ b/docs/parser-documentation/message-schema/15-kimi.md
@@ -1,0 +1,50 @@
+# Kimi CLI Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: Official Kimi CLI code organizes sessions under `~/.kimi/sessions/<workdir-hash>/<session-id>/`.
+- Documented fact: Current session directories are expected to contain `context.jsonl`, `wire.jsonl`, and `state.json`.
+- Documented fact: The official code treats `metadata.json` as legacy and migrates its fields into `state.json`.
+- Documented fact: `wire.jsonl` begins with a metadata header line and then stores structured timestamped wire-message records.
+- Documented fact: `context.jsonl` is still the file the official session object treats as “message history.”
+- Observed example: Sampled local Kimi session directories contained `context.jsonl` and `wire.jsonl`, but the sampled `context.jsonl` files were empty.
+- Observed example: Sampled `wire.jsonl` files started with `{"type":"metadata","protocol_version":"1.3"}` followed by timestamped `TurnBegin` records.
+
+## Assistant Messages
+
+- Documented fact: The official session code reads `context.jsonl` as JSON lines containing at least a `role` field, and treats roles not starting with `_` as conversational.
+- Unresolved uncertainty: The official snippets reviewed here did not expose the full current assistant-message JSON shape inside `context.jsonl`.
+- Inference: The parser’s assumed `assistant` role plus `content`, `tool_calls`, and `_usage` lines may be correct for some builds, but that exact shape was not independently confirmed from upstream code in this audit.
+
+## User Messages
+
+- Documented fact: User messages are also stored in `context.jsonl`; the official code checks line JSON for `role`.
+- Observed example: The sampled local `wire.jsonl` `TurnBegin` payload clearly contains `user_input`, so usable user chronology may exist even when `context.jsonl` is empty.
+
+## Ordering, Boundaries, And State
+
+- Documented fact: `wire.jsonl` is append-only and timestamped.
+- Documented fact: `state.json` now carries session title/archive/approval/todo state; `metadata.json` is legacy.
+- Inference: Full Kimi reconstruction may require both `context.jsonl` and `wire.jsonl`, especially when context files are empty or partially written.
+
+## Direct Access
+
+- Session directories: `find ~/.kimi/sessions -maxdepth 3 -type f`
+- Wire log preview: `head -n 20 ~/.kimi/sessions/<hash>/<session>/wire.jsonl`
+- Context log preview: `head -n 20 ~/.kimi/sessions/<hash>/<session>/context.jsonl`
+
+## Parser Comparison
+
+- `src/parsers/kimi.ts` is only partially aligned with current upstream code.
+- It correctly targets `~/.kimi/sessions/<hash>/<session>/context.jsonl`, but it still looks for legacy `metadata.json` and ignores current `state.json`.
+- It ignores `wire.jsonl`, even though sampled local sessions had chronology there while `context.jsonl` was empty.
+- This makes Kimi a high-risk assistant-message coverage problem: the parser can return little or no conversation even when the session directory still contains recoverable wire history.
+
+## Sources
+
+- Kimi session model: https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/session.py (accessed 2026-04-15)
+- Kimi session state: https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/session_state.py (accessed 2026-04-15)
+- Kimi wire file format: https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/wire/file.py (accessed 2026-04-15)
+- Observed local wire log: `~/.kimi/sessions/ac0c330c0ce4a33a0bd36cfa7edc03d5/52f9d645-ac68-42db-8e80-e6b20bc51435/wire.jsonl` (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/16-qwen-code.md
+++ b/docs/parser-documentation/message-schema/16-qwen-code.md
@@ -1,0 +1,45 @@
+# Qwen Code Message Schema
+
+Access date: 2026-04-15
+
+## Raw Schema
+
+- Documented fact: The official `QwenLM/qwen-code` code writes JSONL chat files under `~/.qwen/tmp/<project_id>/chats/`.
+- Documented fact: Each JSONL line is a tree-structured `ChatRecord` with `uuid`, `parentUuid`, `sessionId`, `timestamp`, `type`, `cwd`, `version`, and optional `gitBranch`.
+- Documented fact: Current record types are `user`, `assistant`, `tool_result`, and `system`.
+- Documented fact: `system` records can represent `chat_compression`, slash-command replay, UI telemetry, and `@`-command replay.
+
+## Assistant Messages
+
+- Documented fact: Assistant turns are `type: "assistant"`.
+- Documented fact: Assistant records carry `message` in raw API `Content` form, plus optional `model`, `usageMetadata`, `contextWindowSize`, and `toolCallResult`.
+- Documented fact: Assistant content can therefore contain text, function-call parts, function-response-related context, and thought parts via the raw model content object.
+
+## User Messages
+
+- Documented fact: User turns are `type: "user"` and store `message: createUserContent(...)`.
+- Documented fact: Tool results are not folded into assistant messages; they are separate `type: "tool_result"` records whose `message` is also stored as user-shaped content for model replay.
+
+## Ordering, Boundaries, And Compaction
+
+- Documented fact: Qwen stores a tree, not a plain linear log. Effective history is reconstructed by following `parentUuid`.
+- Documented fact: Chat compression is explicit through `system` records with subtype `chat_compression` and payload `compressedHistory`.
+- Documented fact: Session loading aggregates records along the parent chain and merges message/tool metadata as needed.
+- Inference: Any parser that only scans file order without reconstructing the main branch risks wrong recent-message tails after rewinds/checkpoints/branching.
+
+## Direct Access
+
+- Chat files: `find ~/.qwen/tmp -path '*/chats/*.jsonl'`
+- Inspect one record: `jq -c . ~/.qwen/tmp/<project>/chats/<session>.jsonl | head`
+
+## Parser Comparison
+
+- `src/parsers/qwen-code.ts` gets one major thing right: it reconstructs a main path via `parentUuid`.
+- It appears to be using an outdated storage-path assumption, though. The parser looks under `~/.qwen/projects/*/chats/`, while the current official code documents `~/.qwen/tmp/<project_id>/chats/`.
+- The parser also simplifies the official record model. Current upstream storage includes `system` records and richer `toolCallResult`/metadata fields that the parser does not fully preserve.
+- This is a high-severity session-discovery risk even if the message-shape logic is directionally close.
+
+## Sources
+
+- Qwen chat recording service: https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/services/chatRecordingService.ts (accessed 2026-04-15)
+- Qwen session service: https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/services/sessionService.ts (accessed 2026-04-15)

--- a/docs/parser-documentation/message-schema/99-open-questions.md
+++ b/docs/parser-documentation/message-schema/99-open-questions.md
@@ -1,0 +1,20 @@
+# Open Questions
+
+Access date: 2026-04-15
+
+## High Priority
+
+- Kiro internal store: the public Kiro docs confirm per-directory auto-saved sessions, UUID session IDs, JSON export/import, and resume behavior, but not the internal `workspace-sessions/*.json` schema assumed by `src/parsers/kiro.ts`. A live install or first-party desktop code would close this gap.
+- Antigravity protobuf schema: current local installs store binary `.pb` files under `.gemini/antigravity/conversations/`, but I did not find a first-party schema for those files. The current JSONL parser is almost certainly stale.
+- Cursor transcript completeness: sampled local `agent-transcripts/*.jsonl` files were text-only, while the parser expects optional Anthropic tool/usage passthrough. A larger sample set or first-party schema doc is needed to know when tool-use blocks are actually present.
+
+## Medium Priority
+
+- Kilo Code product split: first-party issue evidence confirms legacy extension task storage in `ui_messages.json`, while the official repo contains a newer `kilo.db`/OpenCode-style persistence layer. It is still unclear which channel(s) `continues` should prioritize.
+- Kimi current history source: official code still treats `context.jsonl` as the history file, but sampled local sessions had empty `context.jsonl` files and useful `wire.jsonl` chronology. This may be a bug, a migration edge case, or a workflow-specific behavior.
+- Copilot per-session `session.db`: some local session-state directories had `session.db` but no `events.jsonl`. GitHub’s public docs emphasize `events.jsonl` plus the global `session-store.db`, but do not explain the per-session `session.db` variant.
+
+## Lower Priority
+
+- Claude compact-summary semantics: raw `isCompactSummary` records are real, but more evidence would help separate auto-compact summaries from manual `/compact` flows in downstream handoff logic.
+- Amp on-disk assistant examples: the official plugin API documents assistant block types, but I did not find a populated local thread file with both user and assistant turns to validate the exact persisted JSON shape.

--- a/docs/parser-documentation/prompts/2026-04-15-cto-session-schema-audit.md
+++ b/docs/parser-documentation/prompts/2026-04-15-cto-session-schema-audit.md
@@ -1,0 +1,95 @@
+# CTO Session Schema Audit
+
+## Context Block
+
+This mission exists because the handoff quality in `continues` is constrained by inconsistent parser behavior and insufficient technical orientation at session start. The product works, but the extraction layer is uneven: verbosity is currently expressed through four presets in `src/config/verbosity.ts`, the shared markdown renderer in `src/utils/markdown.ts` does not begin with a deep-access technical pointer block, tool activity is grouped and normalized in ways that can hide exact function names, and message trimming/extraction varies across parsers in `src/parsers/*.ts`. The CTO flagged a schema-accuracy concern without providing a concrete failing example. Treat that as a high-signal warning, not an empty complaint. The real task is to independently verify the upstream session-storage realities of every supported coding agent so the parser redesign can be driven by evidence instead of guesswork.
+
+What happened before: the current codebase already reverse-engineers and normalizes sessions from many tools, but it optimizes for a readable handoff rather than a navigable technical briefing. The resulting handoff is useful for continuity, but weaker than it should be for deep follow-up work. A future redesign is expected to move toward two clear modes, default and full, while also exposing raw-storage orientation: where the session lives, what the record shape looks like, how assistant messages appear, how tool calls are encoded, and how an agent can retrieve deeper slices of evidence on demand. This mission is the evidence-gathering phase for that redesign.
+
+What you need to know right now: the canonical tool list is defined in `src/types/tool-names.ts`; adapter-level behavior and storage-path expectations live in `src/parsers/registry.ts`; the current verbosity model lives in `src/config/verbosity.ts`; the handoff shape lives in `src/utils/markdown.ts`; tool summarization lives in `src/utils/tool-summarizer.ts`; and individual parser assumptions live in `src/parsers/*.ts`. You are not validating only the current implementation. You are validating reality outside the repo and then comparing that reality to the implementation. The product currently supports Claude, Codex, Copilot, Gemini, OpenCode, Droid, Cursor, Amp, Kiro, Crush, Cline, Roo Code, Kilo Code, Antigravity, Kimi, and Qwen Code.
+
+Start with these files:
+
+- `src/types/tool-names.ts` to confirm the full tool surface that must be researched.
+- `src/parsers/registry.ts` to understand the current storage-path, binary, and adapter assumptions per tool.
+- `src/config/verbosity.ts` to see the current preset model that research should help simplify.
+- `src/utils/markdown.ts` to understand what the current handoff includes and what it does not.
+- `src/parsers/<tool>.ts` for each tool you study, to compare current assumptions against external evidence.
+
+After reading the local code, your mental model should be: this is a cross-tool session-handoff system whose next quality jump depends on authoritative schema knowledge, direct-access recipes, and better handoff orientation. Your job is to produce that authority.
+
+## Mission Objective
+
+Produce evidence-backed parser documentation for the assigned context across all supported tools so the team can redesign session initiation, verbosity reduction, assistant-message inclusion, and tool-call fidelity on top of verified storage schemas instead of parser folklore.
+
+Hard constraints:
+
+- Do not rely on existing parser assumptions as truth.
+- Prefer official documentation, first-party repos, release notes, and real observed examples over commentary.
+- Explicitly label every uncertain claim as inference or unresolved.
+- Write only inside your assigned context folder under `docs/parser-documentation/`.
+- Preserve exact upstream tool/function names when documenting tool-call behavior.
+
+Known risks and tradeoffs:
+
+- Some tools have sparse public schema documentation, so you may need to combine official sources, issue trackers, and real-world examples.
+- A polished summary without retrieval mechanics is insufficient; this work must expose how deeper inspection would actually happen.
+- A broad but shallow catalog is less valuable than fewer, high-confidence documents. Use the document ceiling as permission for depth, not as a quota.
+
+Priority signal: source accuracy beats speed, and retrieval usefulness beats stylistic polish.
+
+You own this mission end-to-end. Explore freely, trust your judgment, adapt your approach as you learn more. The destination is fixed; the path is yours.
+
+## Research & Tool Guidance
+
+This is a high-ambiguity, externally dependent mission. Frame before acting: state your interpretation of the schema-audit objective, list plausible failure modes in the current product, and revise that framing if evidence contradicts it. Investigate each tool’s current storage path, override env vars, file or database format, session-id conventions, message representation, assistant-message representation, tool-call representation, and any publicly observable examples. Extract what matters for downstream parser design: top-level object or line structure, where tool results live, how edits/writes/deletes are encoded, whether the data source is append-only, and how a later agent could directly retrieve slices of deeper detail.
+
+Search broadly at first, then narrow to authoritative sources. Use as many search angles as needed; there is no minimum and no arbitrary limit. You may create up to 100 markdown documents across the full research wave if the evidence justifies it, but that is a ceiling, not a target.
+
+For each tool document, extract:
+
+- authoritative storage location details
+- format details: JSONL, JSON, YAML, SQLite, or mixed
+- assistant-message structure
+- tool-call structure with exact tool names preserved
+- session-id and message-index semantics where available
+- direct-access recipes: file reads, JSON filters, SQL queries, or traversal tips
+- gaps between reality and the current parser assumptions
+- concrete recommendations for what a handoff “technical pointer block” should expose at the top
+
+## Definition Of Done
+
+- A markdown document exists in the assigned context folder for every supported tool relevant to this repo’s canonical tool list, unless you provide evidence that documentation is impossible for a specific tool.
+- Every tool document distinguishes documented fact, observed example, inference, and unresolved uncertainty.
+- Every tool document includes a direct-access section explaining how deeper data could be retrieved from the raw source.
+- Every tool document includes at least one comparison point against the current local parser or registry assumptions.
+- Every source-sensitive claim includes a concrete source link and access date.
+- An overview file exists in the assigned context folder summarizing the strongest findings, the highest-risk parser mismatches, and the most valuable redesign implications for `continues`.
+
+You must achieve 100% of every criterion above before reporting completion.
+Partial completion = not complete. Do not report back until every item is fully satisfied.
+If you believe a criterion is impossible to meet, report that finding with evidence — do not silently skip it.
+
+## Verification Requirements
+
+Before reporting completion, verify that every expected document exists in the assigned folder, confirm that every document includes the required evidence sections, and demonstrate the file list you created. In your handback, include the exact file paths written and a concise evidence summary for the hardest-to-verify tools.
+
+## Failure Protocol
+
+If you cannot complete this mission, report:
+
+1. what you attempted
+2. what you discovered
+3. why completion was blocked
+4. what you would investigate next
+
+Never silently skip a tool, a document, or a verification step.
+
+## Handback Format
+
+When you complete this mission, respond with:
+
+1. Summary
+2. Changes
+3. Evidence
+4. Observations

--- a/docs/parser-documentation/prompts/2026-04-15-default-full-handoff-redesign.md
+++ b/docs/parser-documentation/prompts/2026-04-15-default-full-handoff-redesign.md
@@ -1,0 +1,113 @@
+# Default/Full Handoff Redesign
+
+## Context Block
+
+This mission exists because the schema-audit research for `continues` is now complete enough to support a real redesign of the handoff layer. The current product works, but the handoff still starts with a generic summary instead of navigational raw-storage guidance, the top-level verbosity contract is still exposed as `minimal | standard | verbose | full`, exact upstream tool/function names are normalized away too early, and recent-message extraction is not consistently grounded in raw storage truth. The research set in `docs/parser-documentation/` established that several parsers are materially stale or variant-sensitive, especially `gemini`, `kiro`, `antigravity`, `qwen-code`, `crush`, `amp`, `kilo-code`, and parts of `cursor`.
+
+What happened before: a multi-context research wave produced evidence-backed docs for storage format, message schema, tool-call fidelity, direct-access recipes, and handoff-pointer design across all 16 canonical tools. A later adversarial internet verification pass found that some local conclusions were too strong. In particular:
+
+- Gemini is clearly JSONL-first upstream now.
+- Kiro is clearly not just the old JSON path; current docs split normal CLI SQLite storage from ACP `.json` + `.jsonl` sessions.
+- Antigravity remains under-documented and should stay confidence-graded.
+- Amp and Droid storage-path claims need to be downgraded where first-party docs are weaker or point elsewhere.
+- `default | full` is a promising simplification, but not necessarily the only public axis; comparable CLIs often separate human-readable views from machine/inspection outputs.
+
+The master synthesis is in `docs/parser-documentation/00-overview.md`, the prioritized work list is in `docs/parser-documentation/01-parser-redesign-backlog.md`, and the unresolved issues are in `docs/parser-documentation/99-open-questions.md`. You are not starting from vague product intuition. You are starting from a research package that already says what is wrong and what the next contract should be, plus an adversarial pass that says where that package overreached.
+
+What you need to know right now: the current user-facing contract is shaped in `src/config/verbosity.ts` and surfaced in `src/cli.ts`; the current handoff markdown structure is in `src/utils/markdown.ts`; tool summarization is in `src/utils/tool-summarizer.ts`; parser-specific extraction lives in `src/parsers/*.ts`; and adapter metadata lives in `src/parsers/registry.ts`. The redesign goal is not cosmetic. It is to make handoffs navigable, technically grounded, and honest about raw fidelity.
+
+Start with these files:
+
+- `docs/parser-documentation/00-overview.md` for the integrated findings
+- `docs/parser-documentation/01-parser-redesign-backlog.md` for implementation order
+- `docs/parser-documentation/99-open-questions.md` for unresolved blockers that must be surfaced rather than ignored
+- `src/config/verbosity.ts` for the current preset model
+- `src/utils/markdown.ts` for the current handoff structure
+- `src/utils/tool-summarizer.ts` for current fidelity loss points
+- `src/parsers/registry.ts` and the highest-risk parsers for current backend assumptions
+
+After reading this context, your mental model should be: the next version of `continues` needs earlier raw-storage orientation, better raw-schema fidelity, and explicit confidence/variant handling for tools with storage drift. It may still end up with `default | full`, but that should be implemented as a careful human-facing simplification rather than a dogmatic one-dimensional output model.
+
+## Mission Objective
+
+Implement the first production-ready version of the handoff redesign so `continues` simplifies its human-facing detail model, adds concise backend-aware technical guidance near the top of the handoff, preserves more exact tool/message fidelity, and remains honest about parser confidence where upstream storage reality is uncertain.
+
+Hard constraints:
+
+- Do not keep the current four-preset model as the primary user-facing contract.
+- Do not remove the ability to render rich detail internally if it is still useful.
+- Do not present stale storage assumptions as canonical truth.
+- Do not assume `default | full` is the only possible public abstraction if the implementation clearly benefits from a separate machine/inspection axis.
+- Preserve backward safety where practical, but prioritize correctness and navigational value over compatibility theater.
+- Any unresolved tool/backend uncertainty must be surfaced explicitly in the product output or code comments, not buried.
+
+Known risks and tradeoffs:
+
+- Some parser families may need incremental adaptation rather than full correction in one pass.
+- A perfect raw-fidelity model for every tool may not be achievable immediately, but the handoff can still improve materially if confidence and variants are handled correctly.
+- The most dangerous failure is pretending the parser knows more than it actually knows.
+
+Priority signal: correctness of the new contract beats minimal diff size, and navigational usefulness beats legacy wording continuity.
+
+You own this mission end-to-end. Explore freely, trust your judgment, adapt your approach as you learn more. The destination is fixed; the path is yours.
+
+## Research & Tool Guidance
+
+This is a high-ambiguity, unfamiliar-codebase mission with external evidence already gathered. Before changing code, explicitly state your interpretation of the redesign scope, list the highest-risk parser/backend mismatches that affect the implementation, and explain what you will solve now versus what you will surface as deferred uncertainty. Use the research docs as evidence, not decoration.
+
+Trace the full handoff pipeline from CLI flags through config selection, parser extraction, markdown generation, and resume launching. Use the research package to define:
+
+- what the simplified default human-facing view must contain
+- what the deeper/debug/full view must add
+- how the pointer block should be built per tool/backend family
+- where exact upstream tool names should survive
+- how confidence/variant warnings should be surfaced
+
+Extract what matters from the research docs:
+
+- highest-risk parser mismatches
+- pointer block fields
+- tool families that need variant-aware handling
+- retrieval recipes that are safe enough to expose
+- places where the adversarial verification says the local research was too strong
+
+Use as many local code reads and tests as needed. There is no minimum and no arbitrary cap. Thoroughness is expected.
+
+## Definition Of Done
+
+- The CLI replaces the four-preset user-facing contract with a simpler human-facing detail model, and any deeper machine/inspection surface is explicit rather than accidental.
+- Generated handoff markdown includes concise technical guidance near the top before or alongside the main summary, without burying the human-readable continuation context.
+- The pointer block includes raw-source orientation, backend format, session handle, and at least one quick-inspect recipe when a reliable raw source exists.
+- The implementation surfaces parser-confidence or backend-variant warnings for tools where the research package identified unresolved drift.
+- At least one existing parser path preserves more exact upstream tool/function naming than the current summarized-only output.
+- Tests covering the new top-level mode contract and pointer-block rendering pass.
+- `pnpm run check` exits successfully.
+- If parser changes touch fixtures or parser behavior, `pnpm test` exits successfully.
+
+You must achieve 100% of every criterion above before reporting completion.
+Partial completion = not complete. Do not report back until every item is fully satisfied.
+If you believe a criterion is impossible to meet, report that finding with evidence — do not silently skip it.
+
+## Verification Requirements
+
+Before reporting completion, verify the CLI-facing mode contract, show sample rendered markdown proving the pointer block is first, run the relevant tests, and include command output demonstrating the DoD criteria.
+
+## Failure Protocol
+
+If you cannot complete this mission, report:
+
+1. what you attempted
+2. what you discovered
+3. why completion was blocked
+4. what you would try next
+
+Never silently skip a parser, a mode contract change, or a verification step.
+
+## Handback Format
+
+When you complete this mission, respond with:
+
+1. Summary
+2. Changes
+3. Evidence
+4. Observations

--- a/docs/parser-documentation/prompts/2026-04-15-final-schema-closure-pad.md
+++ b/docs/parser-documentation/prompts/2026-04-15-final-schema-closure-pad.md
@@ -1,0 +1,89 @@
+# Final Schema Closure Verification Pad
+
+Repository: `/Users/yigitkonur/dev/cli-continues`
+
+This is the final deep research pass intended to reduce the unresolved set as far as current first-party evidence allows. Treat both the original local research and the first adversarial wave as useful but incomplete. Your job is to close the remaining gaps, not to restate already-settled claims.
+
+## Read First
+
+Read these local files before researching:
+
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/00-overview.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/01-parser-redesign-backlog.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/99-open-questions.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/prompts/2026-04-15-default-full-handoff-redesign.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/prompts/2026-04-15-sessionr-codex-implementer.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/prompts/2026-04-15-internet-adversarial-verification-pad.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/research/high-risk-schema-family-b-adversarial-verification/00-master-summary.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/research/high-risk-schema-family-b-adversarial-verification/docs/01-seven-tool-adversarial-verification.md`
+
+## Goal
+
+Reduce the remaining uncertainty set by finding:
+
+- stronger first-party confirmations
+- stronger first-party contradictions
+- GitHub-native repo/issue/discussion context
+- any current release-note or changelog evidence that shifts confidence
+
+Use discussion-style reasoning in your own process: argue both sides where evidence conflicts, then conclude with a confidence level.
+
+## What Is Already Strong Enough
+
+Do not spend much time re-proving these:
+
+- Gemini is JSONL-first upstream now
+- Kiro normal CLI storage is SQLite-backed under `~/.kiro/`
+- Kiro ACP sessions persist as `.json` + `.jsonl`
+- Cursor transcript fidelity loss around tool outputs is real
+- Copilot per-session files are the complete record and `session-store.db` is a subset/index
+- Crush is project-local `.crush/crush.db`
+- `sessionr --new --async` is too weak for deterministic new-session-ID recovery even if not publicly “known broken”
+
+## Remaining Closure Targets
+
+### Domain A: Antigravity, Amp, Droid
+
+Still unclear:
+
+- Antigravity canonical session store
+- whether `code_tracker` is transcript data or auxiliary tracking only
+- whether public `History` / `workspaceStorage` reports indicate a different store
+- whether Amp has a first-party local transcript path/schema at all
+- whether Droid should anchor on `projects/.../*.jsonl`, `sessions/...`, or a versioned mix
+
+### Domain B: Kilo Code, Qwen Code, Kiro detailed schema
+
+Still unclear:
+
+- whether Kilo’s extension-side `ui_messages.json` and shared-core/DB-backed storage should both be treated as current product surfaces
+- whether Qwen’s `projects/` vs `tmp/` wording is just stale commentary or a real versioned split
+- whether Kiro’s exact SQLite DB/schema for normal CLI chat is visible in first-party repo/docs
+
+### Domain C: Design contract and machine/inspection surface
+
+Still unclear:
+
+- whether `default | full` should remain the leading implementation direction
+- whether a separate machine/inspection axis is strongly supported by first-party patterns
+- whether pointer blocks should lead, or just appear early and stay concise
+
+### Domain D: sessionr + outbound prompt debugging contract
+
+Still unclear:
+
+- whether there is stronger repo/issue evidence about `sessionr` async/job behavior
+- whether structured machine-readable prompt-debug output is better supported than raw plain text
+- whether same-tool debug rejection should remain a hard error or become a “show native resume command” path
+
+## Required Output Style
+
+For each domain, produce:
+
+1. Summary
+2. New confirmations beyond the first wave
+3. New contradictions beyond the first wave
+4. Still unresolved after this final pass
+5. URLs
+
+Do not edit repo files yourself. Return evidence only.

--- a/docs/parser-documentation/prompts/2026-04-15-internet-adversarial-verification-pad.md
+++ b/docs/parser-documentation/prompts/2026-04-15-internet-adversarial-verification-pad.md
@@ -1,0 +1,117 @@
+# Internet Adversarial Verification Pad
+
+Repository: `/Users/yigitkonur/dev/cli-continues`
+
+This pad is for external verification agents. Treat the current local implementation and research package as **suspect**. The job is to challenge it, find counter-evidence, and prove where the reasoning is weak, stale, or incomplete.
+
+## Current Local Implementation Under Review
+
+### Code changes
+
+- `src/cli.ts`
+- `src/commands/resume-cmd.ts`
+- `src/utils/resume.ts`
+- `src/__tests__/resume-debug-prompt.test.ts`
+- `src/__tests__/resume-command-debug.test.ts`
+- `README.md`
+
+### What changed
+
+The current implementation added a `--debug-prompt` flag to `continues resume`. In cross-tool mode, it:
+
+- still extracts context
+- still writes `.continues-handoff.md`
+- prints the exact prompt that would be sent to the target tool
+- exits without launching the target CLI
+
+It also rejects `--debug-prompt` for same-tool/native resume.
+
+### Current local evidence
+
+- targeted tests for `--debug-prompt` pass
+- full `pnpm test` passes
+- `pnpm build` passes
+- repo-wide `pnpm run check` still fails because of a pre-existing unrelated Biome backlog
+- a live CLI smoke test printed the exact handoff prompt in plain text
+
+## Current Research Package Under Review
+
+Start here:
+
+- `docs/parser-documentation/00-overview.md`
+- `docs/parser-documentation/99-open-questions.md`
+- `docs/parser-documentation/storage-format/00-overview.md`
+- `docs/parser-documentation/message-schema/00-overview.md`
+- `docs/parser-documentation/tool-call-map/00-overview.md`
+- `docs/parser-documentation/access-recipes/00-overview.md`
+- `docs/parser-documentation/handoff-pointers/00-overview.md`
+- `docs/parser-documentation/prompts/2026-04-15-default-full-handoff-redesign.md`
+- `docs/parser-documentation/prompts/2026-04-15-sessionr-codex-implementer.md`
+
+### Core claims the repo currently believes
+
+1. The current user-facing `minimal | standard | verbose | full` model should eventually become `default | full`.
+2. Handoffs should start with a technical pointer block before the summary/conversation body.
+3. Exact upstream tool/function names are currently normalized away too aggressively.
+4. Assistant-message reconstruction must be tool-specific.
+5. The highest-risk backend drift is around `gemini`, `kiro`, `antigravity`, `qwen-code`, `crush`, `amp`, `kilo-code`, and `cursor`.
+6. `sessionr` is a viable path for handing the implementation brief to a Codex session, but its `--async` path appears broken on this machine.
+
+## Explicit Doubt Vectors
+
+Attack these aggressively:
+
+### Doubt vector A: schema drift claims may be wrong
+
+Look for current first-party docs, release notes, repo code, or issue tracker evidence that contradicts the repo’s conclusions about:
+
+- Gemini JSON vs JSONL
+- Kiro JSON vs SQLite
+- Antigravity `code_tracker` vs conversations protobuf/tracker JSON
+- Qwen runtime roots and env vars
+- Crush DB path defaults
+- Amp thread storage
+- Kilo Code backend family
+- Cursor transcript completeness
+
+### Doubt vector B: the redesign direction may be overstated
+
+Look for evidence that:
+
+- four presets are still justified
+- `default | full` is too simplistic
+- a pointer block could be unsafe, misleading, or too backend-fragile
+- preserving exact tool names could hurt clarity more than it helps
+
+### Doubt vector C: the `--debug-prompt` implementation may be flawed
+
+Look for evidence and arguments that:
+
+- writing the handoff file before printing may be the wrong behavior
+- same-tool rejection is the wrong constraint
+- prompt emission should be machine-readable instead of plain text
+- there are safer or more standard ways to expose the outbound prompt
+
+### Doubt vector D: the `sessionr` orchestration path may be wrong
+
+Look for current docs, issues, or repo evidence about:
+
+- the correct sync vs async contract
+- whether `--async` is known-broken or environment-specific
+- the best way to recover created session IDs
+- whether nested Codex environments distort `sessionr` output
+
+## What A Good Verification Response Contains
+
+- challenge the repo’s claims, do not merely restate them
+- give first-party URLs wherever possible
+- separate:
+  - contradicted
+  - supported
+  - still unresolved
+- include counter-arguments, not only confirmations
+- use a discussion style when useful: “the claim looks plausible because X, but may be wrong because Y”
+
+## Access Date
+
+All local files above were current on 2026-04-15.

--- a/docs/parser-documentation/prompts/2026-04-15-live-storage-capture-validation.md
+++ b/docs/parser-documentation/prompts/2026-04-15-live-storage-capture-validation.md
@@ -1,0 +1,99 @@
+# Live Storage Capture Validation
+
+## Context Block
+
+This mission exists because the schema-audit research package for `continues` found several tools whose current parser assumptions are still too uncertain to treat as settled. The strongest unresolved tools are `kiro`, `antigravity`, `cursor`, `amp`, `droid`, and `kilo-code`, with additional format-version uncertainty around `gemini` and `qwen-code`. The current docs in `docs/parser-documentation/` already separate fact from inference, but the next step requires direct local captures from fresh or active installs.
+
+What happened before: a broad research pass gathered first-party documentation, repo evidence, issue/forum statements, and local observations where available. That was enough to identify likely drift and define redesign direction, but not enough to declare canonical raw storage for every uncertain tool. This mission is the validation pass that turns likely drift into verified local evidence.
+
+What you need to know right now: the unresolved questions are consolidated in `docs/parser-documentation/99-open-questions.md`. Tool-specific open questions also live in each context folder’s `99-open-questions.md`. The parser assumptions to compare against are in `src/parsers/*.ts` and `src/parsers/registry.ts`.
+
+Start with these files:
+
+- `docs/parser-documentation/99-open-questions.md`
+- `docs/parser-documentation/storage-format/99-open-questions.md`
+- `docs/parser-documentation/message-schema/99-open-questions.md`
+- `docs/parser-documentation/tool-call-map/99-open-questions.md`
+- `src/parsers/registry.ts`
+- the parser files for the tools you validate
+
+After reading this context, your mental model should be: this is not generic exploratory research. It is a targeted local-evidence mission designed to confirm or correct the most uncertain parser assumptions still blocking the redesign.
+
+## Mission Objective
+
+Collect and document live local storage captures for the highest-uncertainty tools so the remaining parser/backend questions in `continues` are resolved with direct evidence rather than inference.
+
+Hard constraints:
+
+- Do not modify any source session stores.
+- Do not infer a canonical store when direct capture contradicts current assumptions.
+- Capture enough lifecycle variation to reveal storage behavior changes, not just a static file tree.
+- Clearly separate observed local evidence from any upstream or documented evidence you cite.
+
+Known risks and tradeoffs:
+
+- Some tools may not be installed or may not have active sessions available.
+- Even partial captures are useful if they conclusively disprove a current parser assumption.
+- The mission can fail usefully if it returns structured evidence of missing local prerequisites.
+
+Priority signal: direct local evidence beats elegance, and disproving a stale assumption is as valuable as confirming a correct one.
+
+You own this mission end-to-end. Explore freely, trust your judgment, adapt your approach as you learn more. The destination is fixed; the path is yours.
+
+## Research & Tool Guidance
+
+Frame the problem before acting: state which uncertain tools you can validate on this machine, which ones you cannot, and what evidence would count as decisive for each. For each tool you can validate, inspect the raw storage tree after meaningful lifecycle moments:
+
+1. first prompt
+2. first assistant response
+3. first tool call
+4. resume
+5. compact/rewind if supported
+6. archive/export if supported
+
+For each capture, extract:
+
+- raw file tree
+- primary transcript or DB path
+- sidecar or auxiliary artifacts
+- session ID location
+- assistant-message carrier
+- tool-call carrier
+- whether the current parser assumption in this repo is correct, partially correct, or wrong
+
+Use as many local inspections as needed. No minimum. Depth is expected where the tool is available.
+
+## Definition Of Done
+
+- Every tool you were able to validate has a documented local capture record with lifecycle-specific observations.
+- Every validated tool includes an explicit comparison against the current parser/registry assumption.
+- Every tool you could not validate has an evidence-backed explanation of why validation was not possible.
+- The final output clearly identifies which parser assumptions are now proven correct, proven wrong, or still unresolved.
+
+You must achieve 100% of every criterion above before reporting completion.
+Partial completion = not complete. Do not report back until every item is fully satisfied.
+If you believe a criterion is impossible to meet, report that finding with evidence — do not silently skip it.
+
+## Verification Requirements
+
+Before reporting completion, show the validated tool list, the unavailable-tool list, and the key local paths or DB artifacts observed for each successful capture.
+
+## Failure Protocol
+
+If you cannot complete this mission, report:
+
+1. what you attempted
+2. what you discovered
+3. why completion was blocked
+4. what you would try next
+
+Never silently skip a validation target or a parser-comparison step.
+
+## Handback Format
+
+When you complete this mission, respond with:
+
+1. Summary
+2. Changes
+3. Evidence
+4. Observations

--- a/docs/parser-documentation/prompts/2026-04-15-sessionr-codex-implementer.md
+++ b/docs/parser-documentation/prompts/2026-04-15-sessionr-codex-implementer.md
@@ -1,0 +1,136 @@
+# Continues Implementer Mission
+
+Repository: `/Users/yigitkonur/dev/cli-continues`
+
+You are implementing the next production-quality upgrade to `continues`.
+
+This mission is grounded in a completed schema-audit research package plus an adversarial internet verification pass. Do not treat the current parser behavior or the earlier local research package as canonical truth. Use the research docs as your evidence base, then give extra weight to places where the internet verification found overconfidence.
+
+## Context
+
+`continues` already works as a cross-tool session-handoff CLI, but its extraction and handoff model is now known to have three systemic problems:
+
+1. the user-facing verbosity contract is too fragmented
+2. the handoff starts with a readable summary instead of a technical pointer block
+3. parser output often normalizes away exact schema truth, especially around raw tool names, assistant-message reconstruction, and backend variants
+
+The research package is complete and verified. Start with:
+
+- `docs/parser-documentation/00-overview.md`
+- `docs/parser-documentation/01-parser-redesign-backlog.md`
+- `docs/parser-documentation/99-open-questions.md`
+- `docs/parser-documentation/storage-format/00-overview.md`
+- `docs/parser-documentation/message-schema/00-overview.md`
+- `docs/parser-documentation/tool-call-map/00-overview.md`
+- `docs/parser-documentation/access-recipes/00-overview.md`
+- `docs/parser-documentation/handoff-pointers/00-overview.md`
+- `docs/parser-documentation/prompts/2026-04-15-default-full-handoff-redesign.md`
+- `docs/parser-documentation/prompts/2026-04-15-internet-adversarial-verification-pad.md`
+
+Critical code anchors:
+
+- `src/cli.ts`
+- `src/config/verbosity.ts`
+- `src/utils/markdown.ts`
+- `src/utils/resume.ts`
+- `src/utils/tool-summarizer.ts`
+- `src/parsers/registry.ts`
+- highest-risk parsers: `src/parsers/gemini.ts`, `src/parsers/kiro.ts`, `src/parsers/antigravity.ts`, `src/parsers/qwen-code.ts`, `src/parsers/crush.ts`, `src/parsers/amp.ts`, `src/parsers/cline.ts`, `src/parsers/cursor.ts`
+
+Current verified local status:
+
+- the research package exists and is complete
+- a new `--debug-prompt` flag now exists on `continues resume` and prints the exact handoff prompt instead of launching the target tool
+- targeted tests for `--debug-prompt` pass
+
+Current externally verified corrections:
+
+- Gemini should be treated as JSONL-first upstream, not JSON-first.
+- Kiro should be treated as a split surface: normal CLI SQLite under `~/.kiro/`, ACP sessions under `~/.kiro/sessions/cli/`.
+- Antigravity remains unresolved and confidence-graded.
+- Amp and Droid storage-path conclusions need to be treated as weaker than the earlier local research implied.
+- `default | full` is a useful design direction, but likely not the only public axis; keep room for a separate machine/inspection surface.
+- `sessionr --new --async` should not be trusted for deterministic session-ID recovery without extra safeguards.
+
+## Mission Objective
+
+Implement the first production-ready handoff redesign so `continues` simplifies the human-facing detail contract, adds concise backend-aware technical guidance near the top of handoffs, preserves more exact raw fidelity, and remains explicit about parser confidence where research found backend drift.
+
+## Hard Constraints
+
+- Do not ask the user questions.
+- Do not keep the current four preset names as the primary user-facing contract.
+- Do not bury backend uncertainty behind confident wording.
+- Do not strip out rich internal detail if it is still useful; simplify the surface, not the capability.
+- Do not assume `default | full` is the only public abstraction if a separate machine/inspection output path makes the product more robust.
+- Keep changes atomic and verifiable.
+
+## Required Protocol
+
+Follow this protocol exactly while working:
+
+<protocol>
+Before planning, check relevant skills and available agent types. Use all relevant skills, enable multiple if useful, and delegate clearly scoped sub-tasks to the best-fit agents. Re-check both whenever the task changes materially.
+
+**Planning**
+Audit what is done, planned, missing, assumed, and unverified with at least 5 thoughts. Then keep a live written task list:
+* Max 20 tasks, max 8 sub-actions each
+* One active task at a time
+* Long, explicit, outcome-first task names
+* Format: `Task N: [full result] → [1]action → [2]action (Done when: [verifiable outcome])`
+* Refresh the list after every completion, discovery, or blocker
+* Every 5 completions, compress finished items into a one-line summary
+
+**Execution**
+* Early stopping is failure. Do not stop with unfinished tasks, weak assumptions, or unverified fixes.
+* Work in semantically complete micro-tasks. Keep changes and commits atomic; never batch unrelated work.
+* At each real decision point, generate 5 options internally, score them, research if needed, choose the highest-confidence path, and continue. Surface only: `Decision point: [one line]. Choosing [option] because [one line].`
+* Do not ask the user unless the decision is irreversible and cannot be resolved from files, `.env`, relevant skills, suitable agents, or external evidence. Exhaust serious alternatives before escalating.
+* For time-sensitive facts, use research-powerpack `web_search` first, then `scrape_links` on the best sources. Prefer official docs, changelogs, release notes, and first-party issue trackers. Cite sources when claims may age.
+* If config or secrets are missing, check `.env` first. If still missing, use safe runnable placeholders with clear `[TEMP]` comments stating what to replace, where, and how to get the real value.
+* Verify the exact behavior changed before marking anything done. Chain actions to conclusion; do not stop to narrate half-finished progress.
+* If blocked, record the blocker clearly, exhaust multiple alternatives, research externally, and continue with any unblocked work.
+
+**Handoff**
+Finish with:
+
+| Item | File | What to do |
+|---|---|---|
+| ... | ... | ... |
+</protocol>
+
+## Implementation Priority
+
+1. User-facing contract:
+   move from `minimal | standard | verbose | full` toward `default | full`
+
+2. Handoff structure:
+   add a top-of-document technical pointer block before summary and recent conversation
+
+3. Raw fidelity:
+   preserve more exact upstream tool/function naming and expose raw-inspection affordances
+
+4. Variant/confidence handling:
+   surface backend drift or completeness warnings for tools with unresolved uncertainty
+
+5. Parser risk slice:
+   if scope allows, fix the highest-confidence parser mismatch that materially improves production behavior
+
+## Verification Requirements
+
+Before claiming completion, you must provide:
+
+- targeted tests proving the new mode contract and pointer-block rendering
+- `pnpm run check` output
+- `pnpm test` output if parser behavior or fixtures changed
+- concrete rendered-output evidence that the pointer block is first in the handoff
+
+## Finish Format
+
+Respond with:
+
+1. Summary
+2. Changes
+3. Evidence
+4. Observations
+5. Handoff table

--- a/docs/parser-documentation/prompts/2026-04-15-sessionr-codex-launcher.md
+++ b/docs/parser-documentation/prompts/2026-04-15-sessionr-codex-launcher.md
@@ -1,0 +1,15 @@
+# Sessionr Codex Launcher
+
+Read `docs/parser-documentation/prompts/2026-04-15-sessionr-codex-implementer.md` and prepare to execute it.
+
+For this first response only:
+
+- do not edit files
+- do not run destructive commands
+- do not ask the user questions
+
+Reply in exactly 3 lines:
+
+1. `IMPLEMENTER_READY`
+2. `SESSION_ID: <your visible session id or UNKNOWN>`
+3. `FIRST_TASK: <the first full task title you will execute>`

--- a/docs/parser-documentation/storage-format/00-overview.md
+++ b/docs/parser-documentation/storage-format/00-overview.md
@@ -1,0 +1,64 @@
+# Storage Format Overview
+
+Accessed: 2026-04-15
+
+This folder compares `continues` storage assumptions against upstream evidence for every canonical tool in `src/types/tool-names.ts`.
+
+## Highest-Risk Mismatches
+
+| Tool | Current `continues` assumption | Upstream evidence | Risk |
+| --- | --- | --- | --- |
+| Gemini | `src/parsers/gemini.ts` expects monolithic `.json` session files under `~/.gemini/tmp/*/chats/` and legacy `~/.gemini/sessions/*.json`. | Current `google-gemini/gemini-cli` writes JSONL append logs under `~/.gemini/tmp/<project-id>/chats/`, with metadata lines, `$set` updates, and `$rewindTo` records. | Very high |
+| Qwen Code | Registry advertises `QWEN_HOME`; parser scans `~/.qwen/projects/*/chats/*.jsonl`. | Current `QwenLM/qwen-code` uses `QWEN_RUNTIME_DIR` as the runtime-root override. Session storage is built under `runtimeBaseDir/projects/<sanitized-cwd>/chats/`. | High |
+| Kiro | Registry/parser target macOS app-support JSON files in `~/Library/Application Support/Kiro/workspace-sessions/`. | Current first-party Kiro CLI docs describe a local SQLite session database under `~/.kiro/`, UUID session IDs, and autosave-on-every-turn. Public IDE docs do not document `workspace-sessions`. | Very high |
+| Crush | Registry/parser assume `~/.crush/crush.db`. | Current `charmbracelet/crush` defaults session DBs to project-local `.crush/crush.db`; global XDG paths are for config/cache/data JSON, not the per-workspace session DB. | Very high |
+| Amp | Registry/parser assume `~/.local/share/amp/threads/*.json` via `XDG_DATA_HOME`. | Official Amp docs and an official public thread show settings under `~/.config/amp`, local `history.jsonl`, `session.json`, and `threads/`; only secrets are documented under `~/.local/share/amp/secrets.json`. | Very high |
+| Kilo Code | Registry/parser treat VS Code `globalStorage/.../tasks/ui_messages.json` as the live store. | Current `Kilo-Org/kilocode` codebase uses XDG data storage and a SQLite DB (`kilo.db`); VS Code `tasks/` now appears in legacy-migration code, not the current runtime path. | Very high |
+| Antigravity | Registry/parser treat `~/.gemini/antigravity/code_tracker/` JSON/JSONL files as the session source of truth. | Third-party sync tooling built specifically for Antigravity says user-visible conversation history lives in `conversations/*.pb`, while `code_tracker/` is machine-local and excluded from sync. | Very high |
+| Copilot | Registry/parser model only `~/.copilot/session-state/`. | First-party docs add `COPILOT_HOME` / `--config-dir`, `session-store.db`, incremental writes, and reindex behavior. | Medium |
+
+## Lower-Risk But Important Gaps
+
+- Claude: the registry/path assumption is broadly correct, but `continues` does not account for `tool-results/`, `file-history/`, or session-persistence disable switches.
+- Codex: rollout discovery is mostly correct, but the registry collapses several distinct stores into one label: date-partitioned rollout JSONL files, global `history.jsonl`, logs, and SQLite-backed state.
+- OpenCode: parser behavior is closer to reality than the registry text. The registry points at legacy `storage/`, but current OpenCode storage is primarily SQLite (`opencode.db`) with JSON only as a migration/fallback layer.
+- Cursor: transcript discovery is directionally correct, but official/community evidence suggests transcript files are not the whole story; IDE-side state can still determine whether history appears in the UI.
+- Roo Code: task-folder parsing is still relevant, but the parser ignores `history_item.json`, `_index.json`, and the extension’s `customStoragePath` override.
+
+## Redesign Implications
+
+1. Stop treating registry `storagePath` as canonical truth.
+   It is often only a help string, and for several tools it now points at legacy or incomplete storage roots.
+
+2. Separate “session transcript store” from “auxiliary state”.
+   Codex, Copilot, Claude, Amp, and Cursor all have meaningful side stores outside the primary transcript file.
+
+3. Distinguish append logs from mutable stores.
+   Gemini, Codex, Kimi, and likely Amp use append-oriented logs; OpenCode, Crush, Kilo, Kiro CLI, and Copilot’s session store include mutable database/index state.
+
+4. Record env-var and CLI overrides explicitly.
+   Missing or stale override support is a recurring failure mode: `COPILOT_HOME`, `QWEN_RUNTIME_DIR`, `OPENCODE_DB`, `KIMI_SHARE_DIR`, and the various “disable persistence” switches are parser-relevant.
+
+5. Treat legacy formats as legacy.
+   Gemini `.json`, OpenCode file storage, Kilo VS Code task folders, and older Kimi metadata files should be documented as migration/fallback paths, not default reality.
+
+## Suggested Pointer Block Fields
+
+Every future handoff pointer block should expose:
+
+- `storage_root`
+- `session_locator`
+- `session_id_source`
+- `primary_format`
+- `append_or_mutable`
+- `env_or_flag_overrides`
+- `auxiliary_state_paths`
+- `direct_access_recipe`
+- `confidence`
+
+## Coverage Notes
+
+- Strongest evidence: Codex, Gemini, OpenCode, Crush, Kimi, Qwen Code, Copilot.
+- Most uncertain: Factory Droid, Cursor full-fidelity recovery, Kiro IDE specifically, Antigravity, Amp per-thread file schema.
+- See `99-open-questions.md` for unresolved items that still matter for parser redesign.
+

--- a/docs/parser-documentation/storage-format/01-claude.md
+++ b/docs/parser-documentation/storage-format/01-claude.md
@@ -1,0 +1,49 @@
+# Claude Code
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Default storage root: `~/.claude/`
+- Env-var override: `CLAUDE_CONFIG_DIR` relocates the global `~/.claude` root.
+- Session transcript path: `projects/<project>/<session>.jsonl`
+- Spillover paths:
+  - `projects/<project>/<session>/tool-results/` for large tool outputs
+  - `file-history/<session>/` for edit checkpoints
+  - `history.jsonl` for prompt-history entries
+- Storage format: plaintext JSONL transcripts plus sidecar directories/files.
+- Session-ID location: the `<session>` filename segment is the canonical session identifier; transcript lines also carry `sessionId`.
+- Persistence controls:
+  - `CLAUDE_CODE_SKIP_PROMPT_HISTORY`
+  - `--no-session-persistence`
+  - Agent SDK `persistSession: false`
+
+## Observed Example
+
+- The official Anthropic issue tracker shows `CLAUDE_CONFIG_DIR` moving the global `.claude` tree while project-local `.claude/settings.local.json` can still be created in a workspace.
+
+## Inference
+
+- The transcript file is append-oriented rather than rewritten wholesale because Anthropic documents it as a full JSONL conversation transcript and separately spills large outputs into `tool-results/`.
+
+## Unresolved Uncertainty
+
+- Anthropic’s public docs do not spell out line-level transcript schemas or the exact threshold that moves a tool result from the main JSONL file into `tool-results/`.
+
+## Comparison Against `continues`
+
+- Registry: `src/parsers/registry.ts` is directionally correct on `~/.claude/projects/` and `CLAUDE_CONFIG_DIR`.
+- Parser: `src/parsers/claude.ts` correctly scans UUID-named `.jsonl` transcripts and falls back to the filename for session ID.
+- Gap: `continues` does not model `tool-results/`, `file-history/`, or persistence-disable switches, so “full session recovery” is incomplete even when the main transcript parses.
+
+## Direct Access Recipe
+
+- Read transcript head: `~/.claude/projects/<project>/<session>.jsonl`
+- Inspect large tool outputs: `~/.claude/projects/<project>/<session>/tool-results/`
+- Inspect edit rollback state: `~/.claude/file-history/<session>/`
+
+## Sources
+
+- Official docs: https://code.claude.com/docs/en/claude-directory
+- Official issue: https://github.com/anthropics/claude-code/issues/3833
+

--- a/docs/parser-documentation/storage-format/02-codex.md
+++ b/docs/parser-documentation/storage-format/02-codex.md
@@ -1,0 +1,57 @@
+# Codex CLI
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Default root: `CODEX_HOME`, defaulting to `~/.codex`
+- Session rollout path:
+  - `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDTHH-MM-SS-<thread-id>.jsonl`
+- Archived rollout path:
+  - `~/.codex/archived-sessions/...`
+- Global message history path:
+  - `~/.codex/history.jsonl`
+- Other local state:
+  - `~/.codex/log/`
+  - SQLite-backed state under `sqlite_home`
+  - `~/.codex/auth.json` when file-based auth is enabled
+- Formats:
+  - Rollouts: JSONL
+  - Message history: append-only JSONL
+  - State DB: SQLite
+- Session-ID location:
+  - Rollout filename embeds the thread ID
+  - The first `SessionMeta` line also carries the canonical thread/session ID
+- Append/update behavior:
+  - New rollouts are created lazily
+  - Resumed sessions reopen the rollout file in append mode
+  - `history.jsonl` is append-only, capped by `history.max_bytes`, and compacted by dropping oldest records when needed
+
+## Observed Example
+
+- OpenAI’s rollout recorder example path uses a concrete file like `~/.codex/sessions/rollout-2025-05-07T17-24-21-...jsonl`, while current code now date-partitions rollouts under year/month/day directories before writing the same filename pattern.
+
+## Inference
+
+- The date-partitioned filesystem rollout plus SQLite repair/listing means Codex’s operational source of truth is mixed: rollouts remain the resume substrate, while SQLite accelerates listing/search.
+
+## Comparison Against `continues`
+
+- Registry: `src/parsers/registry.ts` is directionally correct about `~/.codex/sessions/` and `CODEX_HOME`, but it compresses multiple stores into one help string.
+- Parser: `src/parsers/codex.ts` correctly looks for `rollout-*.jsonl` recursively and derives the session ID from the filename.
+- Gaps:
+  - No documentation in `continues` about date partitioning.
+  - No modeling of `history.jsonl`, archived sessions, logs, or SQLite-backed state.
+
+## Direct Access Recipe
+
+- Rollout transcript: `~/.codex/sessions/YYYY/MM/DD/rollout-...jsonl`
+- Global prompt history: `~/.codex/history.jsonl`
+- SQLite state root: value of `sqlite_home` in config
+
+## Sources
+
+- Official docs: https://developers.openai.com/codex/config-reference
+- Official docs: https://developers.openai.com/codex/config-advanced
+- Official repo code: https://github.com/openai/codex
+

--- a/docs/parser-documentation/storage-format/03-copilot.md
+++ b/docs/parser-documentation/storage-format/03-copilot.md
@@ -1,0 +1,51 @@
+# GitHub Copilot CLI
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Default config root: `~/.copilot`
+- Overrides:
+  - `COPILOT_HOME`
+  - `--config-dir` takes precedence over `COPILOT_HOME`
+- Session history root: `~/.copilot/session-state/`
+- Per-session layout: `session-state/<session-id>/`
+- Exact documented file inside each session directory: `events.jsonl`
+- Additional documented contents: workspace artifacts such as plans, checkpoints, and tracked files
+- Secondary store: `~/.copilot/session-store.db`
+- Formats:
+  - Session files: JSONL
+  - Session store: SQLite
+- Session-ID location:
+  - Directory name
+  - Also surfaced via `/session`, `--resume SESSION-ID`, and at interactive exit
+- Append/update behavior:
+  - Session data is written incrementally, periodically during the session, and when the session ends
+  - `session-store.db` can be rebuilt from the history files via `/chronicle reindex`
+
+## Inference
+
+- `session-store.db` is an index/cache layer, not the authoritative resume substrate, because GitHub explicitly documents rebuilding it from `session-state/`.
+
+## Unresolved Uncertainty
+
+- First-party docs confirm `events.jsonl`, but they do not publicly document `workspace.yaml`; that filename remains a local parser assumption.
+
+## Comparison Against `continues`
+
+- Registry: `src/parsers/registry.ts` captures `~/.copilot/session-state/` but omits `COPILOT_HOME`, `--config-dir`, and `session-store.db`.
+- Parser: `src/parsers/copilot.ts` expects `workspace.yaml` and `events.jsonl`.
+- Gap: parser behavior may still work for current installs, but only `events.jsonl` is externally documented; the parser also ignores the SQLite session store and reindex semantics.
+
+## Direct Access Recipe
+
+- Session event log: `~/.copilot/session-state/<session-id>/events.jsonl`
+- Session index/search DB: `~/.copilot/session-store.db`
+- Rebuild index after filesystem-only restore: `/chronicle reindex`
+
+## Sources
+
+- Official docs: https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+- Official docs: https://docs.github.com/en/copilot/how-tos/copilot-cli/chronicle
+- Official docs: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference
+

--- a/docs/parser-documentation/storage-format/04-gemini.md
+++ b/docs/parser-documentation/storage-format/04-gemini.md
@@ -1,0 +1,52 @@
+# Gemini CLI
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Home-dir override: `GEMINI_CLI_HOME`
+- Global root: `${GEMINI_CLI_HOME:-$HOME}/.gemini`
+- Session/chat root:
+  - `~/.gemini/tmp/<project-id>/chats/`
+- Related stores:
+  - `~/.gemini/projects.json`
+  - `~/.gemini/history/<project-id>/`
+  - `~/.gemini/settings.json`
+- Current session file format: JSONL append log
+- Filename behavior:
+  - Main sessions: `session-<timestamp>-<session-id-prefix>.jsonl`
+  - Subagents: `<session-id>.jsonl`
+- Session-ID location:
+  - Metadata records carry `sessionId`
+  - The filename alone is not the full authoritative source for main sessions
+- Record types observed in first-party code:
+  - initial partial metadata record
+  - message records with `id`
+  - metadata updates via `$set`
+  - rewind markers via `$rewindTo`
+- Append/update behavior:
+  - Gemini appends records with `appendFileSync`
+  - Metadata changes are appended as `$set` records, not rewritten in place
+  - Rewinds are appended as `$rewindTo` markers
+  - Legacy `.json` sessions are loaded and migrated into `.jsonl`
+
+## Observed Example
+
+- The current `chatRecordingService.ts` explicitly migrates an older `.json` session into a new `.jsonl` file by appending initial metadata and then each message.
+
+## Comparison Against `continues`
+
+- Registry: `src/parsers/registry.ts` is only partially correct. `~/.gemini/tmp/*/chats/` and `GEMINI_CLI_HOME` still matter, but the registry omits the JSONL migration and append-log semantics.
+- Parser: `src/parsers/gemini.ts` still treats the new format as `session-*.json` plus legacy `~/.gemini/sessions/*.json`.
+- Risk: very high. The parser is now aimed at a superseded container format, so session discovery can silently miss the current transcript store.
+
+## Direct Access Recipe
+
+- Read raw chat log: `~/.gemini/tmp/<project-id>/chats/*.jsonl`
+- Inspect project registry: `~/.gemini/projects.json`
+- Inspect metadata updates: grep JSONL lines for `$set` or `$rewindTo`
+
+## Sources
+
+- Official repo code: https://github.com/google-gemini/gemini-cli
+

--- a/docs/parser-documentation/storage-format/05-opencode.md
+++ b/docs/parser-documentation/storage-format/05-opencode.md
@@ -1,0 +1,54 @@
+# OpenCode
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Data root: XDG data directory for `opencode`, typically `~/.local/share/opencode`
+- Root override inputs:
+  - `XDG_DATA_HOME` influences the default data root
+  - `OPENCODE_DB` overrides the SQLite DB path itself
+- Default DB path:
+  - `opencode.db`
+  - Channel variants may produce `opencode-<channel>.db`
+- Format: SQLite for current storage
+- Current tables relevant to sessions:
+  - `session`
+  - `message`
+  - `part`
+  - `project`
+- Session-ID location: `session.id`
+- Message linkage:
+  - `message.session_id`
+  - `part.message_id`
+  - `part.session_id`
+- Append/update behavior:
+  - current runtime is DB-first
+  - DB uses WAL mode and normal synchronous mode
+  - rows are inserted/updated in place
+
+## Observed Example
+
+- The OpenCode repo still ships migration code for the older file store:
+  - `storage/session/<project>/<session>.json`
+  - `storage/message/<session-id>/*.json`
+  - `storage/part/<message-id>/*.json`
+- That older layout is now migration/fallback material, not the primary store.
+
+## Comparison Against `continues`
+
+- Registry: `src/parsers/registry.ts` points users at `~/.local/share/opencode/storage/`, which is now legacy-biased.
+- Parser: `src/parsers/opencode.ts` is better than the registry text because it tries SQLite first and only falls back to JSON.
+- Gap: the registry omits `opencode.db` and `OPENCODE_DB`, so a user following help text would look in the wrong place for current installs.
+
+## Direct Access Recipe
+
+- Current sessions DB: `~/.local/share/opencode/opencode.db`
+- Example query:
+  - `sqlite3 ~/.local/share/opencode/opencode.db "select id,title,time_created,time_updated from session order by time_updated desc;"`
+- Legacy fallback:
+  - `~/.local/share/opencode/storage/session/...`
+
+## Sources
+
+- Official repo code: https://github.com/opencode-ai/opencode

--- a/docs/parser-documentation/storage-format/06-droid.md
+++ b/docs/parser-documentation/storage-format/06-droid.md
@@ -1,0 +1,61 @@
+# Factory Droid
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Officially documented local settings roots:
+  - `~/.factory/settings.json`
+  - `~/.factory/settings.local.json`
+  - `<project>/.factory/settings.local.json`
+- Officially documented session behavior:
+  - `droid exec -s <id>` / `--session-id <id>` resumes an existing session
+  - `cloudSessionSync` can mirror CLI sessions to Factory web or keep them local only
+- Officially documented env/config items:
+  - `FACTORY_API_KEY`
+- No first-party storage-root env var was found for session transcripts.
+- Officially documented related local storage:
+  - `~/.factory/droids/`
+  - `~/.factory/logs/`
+
+## Observed Example
+
+- Third-party tooling that parses current Droid usage expects a session tree under `~/.factory/sessions/` and specifically documents `--droid-dir /path/to/.factory/sessions`.
+- That same tooling keys Droid discovery off `~/.factory/sessions/**/*.settings.json`, which is consistent with `continues` looking for companion `.settings.json` files beside session logs.
+
+## Inference
+
+- The current `continues` parser shape
+  - `~/.factory/sessions/<workspace-slug>/<id>.jsonl`
+  - sibling `<id>.settings.json`
+  is plausible, but I did not find first-party documentation that proves the transcript path or the JSONL event schema.
+- Session-ID location is only first-party documented at the CLI level today:
+  - `-s/--session-id <id>`
+  - the on-disk placement of that ID is still inferred, not documented.
+
+## Unresolved Uncertainty
+
+- Exact transcript root, format, and append/update behavior remain unverified from first-party sources.
+- I did not find a first-party schema reference for `session_start`, `todo_state`, `compaction_state`, or the sibling `.settings.json` file.
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/droid.ts` assume a concrete `.factory/sessions/...jsonl` event log model.
+- Risk: high. The resume-by-ID concept is first-party, but the local transcript layout is still only indirectly corroborated.
+
+## Direct Access Recipe
+
+- First-party confirmed:
+  - inspect `~/.factory/settings.json`
+  - check whether `cloudSessionSync` is enabled
+- Provisional local inspection path:
+  - `~/.factory/sessions/`
+  - look for `<id>.jsonl` with sibling `<id>.settings.json`
+
+## Sources
+
+- Official docs: https://docs.factory.ai/cli/configuration/settings
+- Official docs: https://docs.factory.ai/cli/configuration/cli-reference
+- Official docs: https://docs.factory.ai/cli/configuration/custom-droids
+- Official docs: https://docs.factory.ai/cli/configuration/ide-integrations
+- Third-party observed example: https://ayagmar.github.io/llm-usage-metrics/getting-started/

--- a/docs/parser-documentation/storage-format/07-cursor.md
+++ b/docs/parser-documentation/storage-format/07-cursor.md
@@ -1,0 +1,52 @@
+# Cursor
+
+Accessed: 2026-04-15
+
+## Observed Example
+
+- Official Cursor community forum posts place chat transcripts under:
+  - `~/.cursor/projects/<project-name>/agent-transcripts`
+- A later official forum bug report shows a second recovery dependency:
+  - transcript files may still exist under `.cursor/projects/.../agent-transcripts`
+  - UI recovery can still depend on Cursor-side global storage such as `state.vscdb` and `workspaceStorage`
+
+## Documented Fact
+
+- Public Cursor Help docs document sharing/export flows, but I did not find first-party storage-path documentation there.
+- No public env-var override for the local transcript root was found.
+
+## Inference
+
+- `agent-transcripts` is a real local transcript store.
+- It is probably not the only store required for perfect UI/session recovery, because Cursor staff recommend restoring both transcript-adjacent IDE state and global DB/storage files during corruption events.
+- The transcript payload is JSONL, matching both the local parser assumption and the observed filesystem references.
+- The transcript files are likely append-oriented, but that write behavior is not first-party documented.
+
+## Unresolved Uncertainty
+
+- No first-party public doc was found for:
+  - exact transcript schema
+  - append/update semantics beyond “transcripts exist on disk”
+  - whether the transcript filename or a separate DB row is the canonical session ID
+  - any env-var override for the storage root
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/cursor.ts` assume `~/.cursor/projects/*/agent-transcripts/<uuid>/<uuid>.jsonl`.
+- Confidence:
+  - `agent-transcripts` itself is well corroborated.
+  - the `<uuid>/<uuid>.jsonl` nesting and “filename equals session ID” behavior are still parser-side inferences.
+- Gap: `continues` ignores Cursor’s IDE/global-state dependencies, so it can recover transcript text without necessarily matching Cursor’s full notion of recoverable history.
+
+## Direct Access Recipe
+
+- Transcript root:
+  - `~/.cursor/projects/<project-name>/agent-transcripts/`
+- Recovery-adjacent IDE state mentioned by staff:
+  - `%APPDATA%\Cursor\User\globalStorage\state.vscdb`
+  - `%APPDATA%\Cursor\User\workspaceStorage`
+
+## Sources
+
+- Official forum: https://forum.cursor.com/t/where-are-cursor-chats-stored/77295/5
+- Official forum: https://forum.cursor.com/t/lost-all-cursor-settings-and-chat-history-for-all-projects-i-am-working-on/151081

--- a/docs/parser-documentation/storage-format/08-amp.md
+++ b/docs/parser-documentation/storage-format/08-amp.md
@@ -1,0 +1,67 @@
+# Amp
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Official configuration roots:
+  - workspace settings: nearest `.amp/settings.json` or `.amp/settings.jsonc`
+  - user settings: `~/.config/amp/settings.json` or `.jsonc`
+- Official credential/session-adjacent paths:
+  - `~/.amp/oauth/`
+  - `~/.local/share/amp/secrets.json`
+- Official thread/session behavior:
+  - thread IDs use `T-...`
+  - `amp threads continue` resumes an existing thread
+  - threads can be archived, shared, and referenced by thread ID or URL
+- Official docs confirm that local thread history exists, but they do not publish a storage-format schema for it.
+- No official storage-root env-var override for thread history was found.
+
+## Observed Example
+
+- An official public Amp thread shows a macOS local filesystem listing under `~/.config/amp` with:
+  - `history.jsonl`
+  - `session.json`
+  - `threads/`
+  - `ide/`
+  - `migration/`
+- That same thread explicitly failed to find an alternate `~/Library/Application Support/amp` tree on that machine.
+
+## Inference
+
+- Amp currently uses a mixed local layout:
+  - config in `~/.config/amp`
+  - secrets in `~/.local/share/amp`
+  - thread data likely rooted in `~/.config/amp/threads`
+- `history.jsonl` strongly suggests append-oriented history storage, but the exact per-thread file schema remains undocumented.
+
+## Unresolved Uncertainty
+
+- I did not find first-party documentation that proves:
+  - per-thread file format
+  - whether `threads/` contains one JSON file per thread
+  - whether `session.json` tracks the active thread pointer only
+  - whether any XDG env var overrides the thread-history root
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/amp.ts` assume `~/.local/share/amp/threads/*.json` via `XDG_DATA_HOME`.
+- Upstream evidence contradicts that as the default macOS reality:
+  - official docs place settings in `~/.config/amp`
+  - official thread evidence places `history.jsonl`, `session.json`, and `threads/` in `~/.config/amp`
+  - official security docs place only credentials in `~/.local/share/amp/secrets.json`
+- Risk: very high. The parser appears aimed at an outdated or partial storage model.
+
+## Direct Access Recipe
+
+- Inspect current local state:
+  - `~/.config/amp/history.jsonl`
+  - `~/.config/amp/session.json`
+  - `~/.config/amp/threads/`
+  - `~/.local/share/amp/secrets.json`
+
+## Sources
+
+- Official docs: https://ampcode.com/manual
+- Official docs: https://ampcode.com/security
+- Official public thread: https://ampcode.com/threads/T-019b10cd-e818-774c-bd65-8622bd15cf35

--- a/docs/parser-documentation/storage-format/09-kiro.md
+++ b/docs/parser-documentation/storage-format/09-kiro.md
@@ -1,0 +1,53 @@
+# Kiro
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Public Kiro IDE docs confirm that Kiro stores conversation history inside sessions and supports:
+  - session switching
+  - history viewing
+  - restore
+  - delete
+  - markdown export
+- Current first-party Kiro CLI docs describe:
+  - a local SQLite session database under `~/.kiro/`
+  - per-directory session scoping
+  - UUID session IDs
+  - autosave every conversation turn
+  - list/delete/resume behavior
+- No public env-var override was found for the Kiro CLI session database, and no public IDE storage override was found either.
+
+## Inference
+
+- Kiro’s current public storage model is clearly database-backed for the CLI.
+- It is plausible that the IDE and CLI no longer share the old JSON layout assumed by `continues`, but I did not find first-party IDE storage-path documentation to prove that.
+
+## Unresolved Uncertainty
+
+- The `continues` parser targets:
+  - `~/Library/Application Support/Kiro/workspace-sessions/`
+  - JSON files with `sessionId`, `workspacePath`, and `history[]`
+- I did not find first-party documentation for that path or schema.
+- I could not verify whether the parser is describing:
+  - a still-live private IDE store
+  - a superseded IDE store
+  - or an implementation that is now entirely obsolete
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/kiro.ts` describe a macOS app-support JSON store and label the source as “Kiro IDE”.
+- Upstream public docs: current first-party storage guidance points to `~/.kiro/` SQLite for Kiro CLI, not app-support JSON.
+- Risk: very high. The supported surface in `continues` may not match the current public Kiro product surface at all.
+
+## Direct Access Recipe
+
+- Publicly documented CLI path:
+  - inspect `~/.kiro/` and its SQLite DB
+- Parser-assumed legacy/IDE path:
+  - `~/Library/Application Support/Kiro/workspace-sessions/`
+
+## Sources
+
+- Official IDE docs: https://kiro.dev/docs/chat/
+- Official CLI docs: https://kiro.dev/docs/cli/chat/session-management/

--- a/docs/parser-documentation/storage-format/10-crush.md
+++ b/docs/parser-documentation/storage-format/10-crush.md
@@ -1,0 +1,50 @@
+# Crush
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Current default session data directory is project-local `.crush`
+- Default session DB path:
+  - `<workspace>/.crush/crush.db`
+- If Crush starts in a nested directory, it looks for the closest ancestor `.crush` before defaulting to `<workingDir>/.crush`
+- Session-DB root override:
+  - no env-var override for the live project session DB was found
+  - the effective root comes from `data.dir` / default `.crush` resolution
+- Current session storage format: SQLite
+- Relevant tables from first-party migrations:
+  - `sessions`
+  - `messages`
+  - `files`
+- Session-ID location:
+  - `sessions.id`
+  - regular sessions are UUIDs
+  - helper/task sessions can also use derived IDs like `title-<parent>` or tool-call IDs
+- Append/update behavior:
+  - sessions/messages/files mutate in place via SQL
+  - update triggers maintain `updated_at`
+  - insert/delete triggers maintain `message_count`
+
+## Documented But Separate Global Paths
+
+- `CRUSH_GLOBAL_CONFIG`
+- `CRUSH_CACHE_DIR`
+- `CRUSH_GLOBAL_DATA`
+- `XDG_DATA_HOME` affects global data/config JSON paths, not the default per-project session DB path
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/crush.ts` assume `~/.crush/crush.db`.
+- Upstream code says the live default is workspace-local `.crush/crush.db`.
+- Risk: very high. `continues` is currently pointed at the wrong default root for real Crush session databases.
+
+## Direct Access Recipe
+
+- Current project DB:
+  - `<repo>/.crush/crush.db`
+- Example query:
+  - `sqlite3 .crush/crush.db "select id,title,message_count,created_at,updated_at from sessions order by updated_at desc;"`
+
+## Sources
+
+- Official repo code: https://github.com/charmbracelet/crush

--- a/docs/parser-documentation/storage-format/11-cline.md
+++ b/docs/parser-documentation/storage-format/11-cline.md
@@ -1,0 +1,58 @@
+# Cline
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Official troubleshooting docs still document extension storage under host `globalStorage`:
+  - VS Code macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/`
+  - VS Code Windows: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\`
+  - VS Code Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/`
+  - JetBrains equivalents use the same extension ID under JetBrains `globalStorage`
+- Documented task data layout:
+  - `state/taskHistory.json`
+  - `tasks/<task-id>/api_conversation_history.json`
+  - `tasks/<task-id>/ui_messages.json`
+  - `tasks/<task-id>/task_metadata.json`
+- Session/task ID location: the `<task-id>` directory name
+- Recovery behavior:
+  - `taskHistory.json` is only an index
+  - reconstruction scans `tasks/`
+- No env-var override for the task storage root was found in the public docs; the effective root comes from the host IDE `globalStorage` path.
+- Append/update behavior:
+  - `ui_messages.json` and `api_conversation_history.json` are task-local JSON files
+  - `taskHistory.json` is rewritten as an index
+  - recovery rebuilds the index from task folders
+
+## Observed Example
+
+- Current Cline repo migration code says VS Code global state and secrets are being exported to shared file-backed stores in `~/.cline/data/`.
+- The same code explicitly says task data is not yet shared there:
+  - task history still lives at `{globalStorageFsPath}/state/taskHistory.json`
+  - task folders still live at `{globalStorageFsPath}/tasks/`
+
+## Inference
+
+- For conversation recovery specifically, the old `globalStorage/.../tasks/` structure is still authoritative today, even though other state is migrating into `~/.cline/data/`.
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/cline.ts` are still substantially aligned for VS Code task discovery.
+- Gaps:
+  - parser is VS Code-centric and does not surface the documented JetBrains path
+  - parser reads only `ui_messages.json`
+  - parser ignores `api_conversation_history.json`, `task_metadata.json`, and `state/taskHistory.json`
+
+## Direct Access Recipe
+
+- Task folders:
+  - `<globalStorage>/tasks/<task-id>/ui_messages.json`
+  - `<globalStorage>/tasks/<task-id>/api_conversation_history.json`
+  - `<globalStorage>/tasks/<task-id>/task_metadata.json`
+- History index:
+  - `<globalStorage>/state/taskHistory.json`
+
+## Sources
+
+- Official docs: https://docs.cline.bot/troubleshooting/task-history-recovery
+- Official repo code: https://github.com/cline/cline

--- a/docs/parser-documentation/storage-format/12-roo-code.md
+++ b/docs/parser-documentation/storage-format/12-roo-code.md
@@ -1,0 +1,47 @@
+# Roo Code
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Roo still stores task messages as JSON files inside `tasks/<task-id>/`:
+  - `ui_messages.json`
+  - `history_item.json`
+  - other task files such as metadata remain task-local
+- Roo maintains a task index:
+  - `tasks/_index.json`
+- Session/task ID location:
+  - directory name `<task-id>`
+  - mirrored inside `history_item.json`
+- Append/update behavior:
+  - per-task files are rewritten atomically
+  - `_index.json` is debounced and rewritten as a cache/index
+  - cross-process consistency is handled with locked writes and reconciliation
+- No env-var override for the storage base path was found; the documented override is the extension-level `customStoragePath` setting.
+
+## Observed Example
+
+- Current Roo code supports a `customStoragePath` override. If set and writable, Roo uses that path instead of the default VS Code global storage root.
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/cline.ts` assume a fixed VS Code path under `rooveterinaryinc.roo-cline/tasks/`.
+- What still matches:
+  - `ui_messages.json` in per-task directories is still real
+- Gaps:
+  - parser ignores `history_item.json` and `_index.json`
+  - parser ignores `customStoragePath`
+  - parser does not account for today’s stronger task-history/index model
+
+## Direct Access Recipe
+
+- Default or custom storage base:
+  - `<storage-base>/tasks/`
+- Inspect:
+  - `<storage-base>/tasks/<task-id>/ui_messages.json`
+  - `<storage-base>/tasks/<task-id>/history_item.json`
+  - `<storage-base>/tasks/_index.json`
+
+## Sources
+
+- Official repo code: https://github.com/RooCodeInc/Roo-Code

--- a/docs/parser-documentation/storage-format/13-kilo-code.md
+++ b/docs/parser-documentation/storage-format/13-kilo-code.md
@@ -1,0 +1,52 @@
+# Kilo Code
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Current runtime data root is XDG data for app `kilo`, typically:
+  - `~/.local/share/kilo`
+- Current DB path:
+  - `~/.local/share/kilo/kilo.db`
+- DB override:
+  - `KILO_DB`
+- Current storage format: SQLite
+- Current schema lineage is Opencode-derived and session-centric, not VS Code `ui_messages.json`-centric.
+- Session-ID location:
+  - current runtime sessions live in the SQLite `session` table
+  - legacy migrated sessions originate from old VS Code task IDs
+- Append/update behavior:
+  - current runtime updates happen through mutable SQLite rows
+  - the old VS Code task files are legacy import inputs
+
+## Observed Example
+
+- The Kilo repo still contains VS Code legacy-migration code that reads:
+  - `context.globalStorageUri/tasks/<task-id>/api_conversation_history.json`
+- That code exists specifically to import legacy task folders into the current session model.
+
+## Inference
+
+- The fixed VS Code `tasks/` layout assumed by `continues` is now a migration source, not the primary live store.
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/cline.ts` still treat Kilo like a Cline-family VS Code extension with:
+  - `.../globalStorage/kilocode.kilo-code/tasks/`
+  - `ui_messages.json`
+- Upstream code shows a different present-day reality:
+  - XDG data root
+  - SQLite `kilo.db`
+  - legacy task folders only for migration/import
+- Risk: very high. Current Kilo support in `continues` is aimed at historical storage, not the current runtime.
+
+## Direct Access Recipe
+
+- Current DB:
+  - `~/.local/share/kilo/kilo.db`
+- Legacy migration source, if present:
+  - `<vscode-globalStorage>/tasks/<task-id>/api_conversation_history.json`
+
+## Sources
+
+- Official repo code: https://github.com/Kilo-Org/kilocode

--- a/docs/parser-documentation/storage-format/14-antigravity.md
+++ b/docs/parser-documentation/storage-format/14-antigravity.md
@@ -1,0 +1,57 @@
+# Antigravity
+
+Accessed: 2026-04-15
+
+## Observed Example
+
+- Third-party sync tooling built specifically for Antigravity documents the local root as:
+  - `~/.gemini/antigravity/`
+- The same tooling says user-visible chat history is in:
+  - `conversations/*.pb`
+- It also explicitly lists these Antigravity-local paths:
+  - `brain/`
+  - `knowledge/`
+  - `browser_recordings/`
+  - `code_tracker/`
+  - `implicit/`
+  - `google_accounts.json`
+  - `oauth_creds.json`
+  - `user_settings.pb`
+- No env-var override for the Antigravity storage root was surfaced in the available evidence.
+
+## Inference
+
+- `conversations/*.pb` is likely the current user-facing conversation store.
+- `code_tracker/` appears machine-local and auxiliary, not the main syncable history substrate, because the sync extension excludes it by default while syncing `conversations/*.pb`.
+- Absolute workspace path matters for conversation visibility across machines.
+
+## Unresolved Uncertainty
+
+- I did not find first-party Antigravity storage documentation.
+- I did not verify:
+  - the protobuf schema for `conversations/*.pb`
+  - the exact role of `code_tracker/`
+  - the canonical on-disk session ID location
+  - append/update behavior for protobuf conversation files
+  - whether `code_tracker/` is still a recoverable coding-session source or merely local telemetry/index data
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/antigravity.ts` assume `~/.gemini/antigravity/code_tracker/` contains JSON or JSONL session files with `type`, `content`, and `timestamp`.
+- External evidence points elsewhere:
+  - synced conversation history appears protobuf-backed in `conversations/*.pb`
+  - `code_tracker/` is excluded from sync
+- Risk: very high. The current parser may be aimed at an auxiliary store rather than the product’s primary conversation history.
+
+## Direct Access Recipe
+
+- Inspect root:
+  - `~/.gemini/antigravity/`
+- Compare:
+  - `conversations/*.pb`
+  - `code_tracker/`
+  - `browser_recordings/`
+
+## Sources
+
+- Third-party extension evidence: https://marketplace.visualstudio.com/items?itemName=mrd9999.antigravity-sync

--- a/docs/parser-documentation/storage-format/15-kimi.md
+++ b/docs/parser-documentation/storage-format/15-kimi.md
@@ -1,0 +1,61 @@
+# Kimi CLI
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Share/session root:
+  - `KIMI_SHARE_DIR`, default `~/.kimi`
+- Global metadata file:
+  - `~/.kimi/kimi.json`
+- Session directory layout:
+  - `~/.kimi/sessions/<workdir-hash-or-kaos_hash>/<session-id>/`
+- Per-session files:
+  - `context.jsonl`
+  - `wire.jsonl`
+  - `state.json`
+  - `subagents/`
+- Legacy file:
+  - `metadata.json` is migrated into `state.json`
+- Session-ID location:
+  - directory name `<session-id>`
+  - created as a UUID by default
+- Resume/list behavior:
+  - sessions are tracked per working directory
+  - `--continue` resumes the latest session in the current working directory
+  - `--session` / `--resume` resume a specific session ID
+- Export behavior:
+  - `kimi export` zips the full session directory, including `context.jsonl`, `wire.jsonl`, `state.json`, and logs
+
+## Append/Update Behavior
+
+- `context.jsonl` is the persisted message-history log
+- `wire.jsonl` is a second JSONL log for wire-format records
+- `state.json` is mutable session state and is rewritten as session settings change
+- Session directories are created eagerly per session
+
+## Comparison Against `continues`
+
+- Registry/parser: `src/parsers/registry.ts` and `src/parsers/kimi.ts` are broadly correct about `~/.kimi/sessions/` and the hashed-per-workdir session structure.
+- Gaps:
+  - registry omits `KIMI_SHARE_DIR`
+  - parser focuses on `context.jsonl` and mostly ignores `wire.jsonl` and `state.json`
+  - parser still mentions optional `metadata.json`, which is now a legacy migration input
+
+## Direct Access Recipe
+
+- Global map of workdirs to last sessions:
+  - `~/.kimi/kimi.json`
+- Session root:
+  - `~/.kimi/sessions/<hash>/<session-id>/`
+- Inspect:
+  - `context.jsonl`
+  - `wire.jsonl`
+  - `state.json`
+
+## Sources
+
+- Official docs: https://www.kimi.com/code/docs/en/kimi-cli/guides/sessions.html
+- Official docs: https://moonshotai.github.io/kimi-cli/en/reference/kimi-command.html
+- Official repo code: https://github.com/MoonshotAI/kimi-cli
+

--- a/docs/parser-documentation/storage-format/16-qwen-code.md
+++ b/docs/parser-documentation/storage-format/16-qwen-code.md
@@ -1,0 +1,55 @@
+# Qwen Code
+
+Accessed: 2026-04-15
+
+## Documented Fact
+
+- Default global root: `~/.qwen`
+- Actual runtime-root override:
+  - `QWEN_RUNTIME_DIR`
+- Current session/chat root:
+  - `<runtime-base>/projects/<sanitized-cwd>/chats/`
+- Related runtime roots:
+  - `<runtime-base>/tmp/<project-hash>/`
+  - `<runtime-base>/history/<project-hash>/`
+  - `<runtime-base>/debug/`
+- Session file format: JSONL
+- Filename behavior:
+  - current recording service writes `<session-id>.jsonl`
+- Session-ID location:
+  - filename
+  - each record also carries `sessionId`
+- Record behavior:
+  - each record carries `uuid`, `parentUuid`, `sessionId`, `timestamp`, `type`, `cwd`, and related payload fields
+- Append/update behavior:
+  - each record is appended immediately with `jsonl.writeLineSync`
+  - conversation files are created once and then extended line-by-line
+
+## Observed Example
+
+- The current Qwen session service explicitly documents session files as JSONL and lists them from `getProjectDir()/chats`, not from a `QWEN_HOME` override root.
+
+## Comparison Against `continues`
+
+- Registry: `src/parsers/registry.ts` advertises `QWEN_HOME`.
+- Parser: `src/parsers/qwen-code.ts` also uses `QWEN_HOME`.
+- Upstream repo search found `QWEN_RUNTIME_DIR` but did not surface a live `QWEN_HOME` storage override.
+- What still matches:
+  - default root under `~/.qwen`
+  - session files under `projects/<sanitized-cwd>/chats/*.jsonl`
+- Risk: high because the env-var override currently documented by `continues` appears stale.
+
+## Direct Access Recipe
+
+- Session chat files:
+  - `~/.qwen/projects/<sanitized-cwd>/chats/*.jsonl`
+- Runtime override:
+  - inspect `QWEN_RUNTIME_DIR`
+- Related non-session runtime data:
+  - `~/.qwen/tmp/<project-hash>/`
+  - `~/.qwen/history/<project-hash>/`
+
+## Sources
+
+- Official repo code: https://github.com/QwenLM/qwen-code
+

--- a/docs/parser-documentation/storage-format/99-open-questions.md
+++ b/docs/parser-documentation/storage-format/99-open-questions.md
@@ -1,0 +1,46 @@
+# Open Questions
+
+Accessed: 2026-04-15
+
+## Highest Priority
+
+1. Factory Droid
+   We still do not have first-party proof that live session transcripts are stored in `~/.factory/sessions/<workspace>/<id>.jsonl` with sibling `.settings.json` files. The current parser may be right, but the evidence is still indirect.
+
+2. Cursor
+   How much session fidelity lives only in `agent-transcripts`, and how much depends on Cursor IDE state such as `state.vscdb` or workspace storage? `continues` currently parses only transcripts.
+
+3. Kiro
+   Is `continues` supposed to support Kiro IDE, Kiro CLI, or both? The public docs now point to Kiro CLI SQLite in `~/.kiro/`, while the current parser targets a macOS app-support JSON layout that I could not verify publicly.
+
+4. Antigravity
+   Which store should count as the canonical “session” source for parser work:
+   - `conversations/*.pb`
+   - `code_tracker/`
+   - or both?
+
+5. Amp
+   What is the exact on-disk schema inside `~/.config/amp/threads/`?
+   Current evidence shows the directory exists, but not whether its members are JSON, JSONL, or another structure.
+
+## Medium Priority
+
+6. Copilot CLI
+   Is `workspace.yaml` still a stable and supported filename, or should `continues` stop depending on it and derive metadata from `events.jsonl` plus `session-store.db`?
+
+7. Claude Code
+   What exact thresholds or rules move tool outputs into `tool-results/` versus leaving them inline in the main transcript JSONL?
+
+8. Cursor Session ID
+   Is the transcript filename always the canonical session ID, or is that only a convenient local parser heuristic?
+
+## Suggested Follow-Up Research
+
+- Run live captures for Droid, Amp, Cursor, Kiro, and Antigravity on fresh installs.
+- Record exact file trees after:
+  - first prompt
+  - tool call
+  - resume
+  - delete/archive
+  - export/share
+- Compare those live captures to the parser assumptions before redesigning the registry/help text.

--- a/docs/parser-documentation/tool-call-map/00-overview.md
+++ b/docs/parser-documentation/tool-call-map/00-overview.md
@@ -1,0 +1,64 @@
+# Tool Call Map Overview
+
+This folder documents how each canonical tool actually records tool activity, and where `continues` currently loses fidelity.
+
+## Highest-risk fidelity losses
+
+- `gemini`: current upstream code writes JSONL session logs with metadata updates, rewinds, `toolCalls`, `thoughts`, and token snapshots, but `src/parsers/gemini.ts` only handles legacy `.json` conversation objects. This is a version-skew risk, not just a formatting difference.
+- `qwen-code`: current upstream code says chat logs live under `~/.qwen/tmp/<project>/chats/`, while `src/parsers/qwen-code.ts` looks under `~/.qwen/projects/*/chats/`. If the repo code reflects released behavior, `continues` will miss sessions entirely.
+- `kiro`: official Kiro CLI docs say sessions are auto-saved in SQLite under `~/.kiro/`, but `src/parsers/kiro.ts` only looks for JSON files under `~/Library/Application Support/Kiro/workspace-sessions/`. This looks like a backend mismatch.
+- `cursor`: first-party Cursor staff state JSONL transcripts include tool inputs but intentionally omit tool outputs. `src/parsers/cursor.ts` currently reuses the Anthropic `tool_use`/`tool_result` extractor, which can overstate what raw Cursor transcripts really preserve.
+- `opencode`: raw OpenCode storage is much richer than the current parser output. The local SQLite database stores exact tool names, inputs, outputs, statuses, attachments, and per-part timing, while `src/parsers/opencode.ts` reduces this to a session-level edit summary.
+- `crush`: upstream schema stores structured `tool_call` and `tool_result` parts, but `src/parsers/crush.ts` only extracts plain text from `messages.parts`, losing exact tool names, arguments, result metadata, and error state.
+- `kilo-code`: first-party evidence conflicts. Kilo issue traffic still references `ui_messages.json` under VS Code globalStorage, but the current official repo also ships `kilocode_change` modifications on top of an OpenCode-style session backend. `src/parsers/cline.ts` assumes only the older `ui_messages.json` family.
+- `antigravity`: no public session schema documentation was found, and the local `code_tracker` contents on this machine look like prefixed file snapshots rather than conversation logs. `src/parsers/antigravity.ts` should be treated as highly provisional.
+
+## Cross-cutting redesign implications
+
+- Preserve exact upstream tool names. `src/types/tool-names.ts` and `src/utils/tool-summarizer.ts` currently collapse many names into generic buckets like shell/read/write/edit/search/fetch/task/mcp. That is useful for summaries, but it is not a faithful schema map.
+- Preserve argument/result placement separately. Several tools do not put arguments and results in the same place:
+  - Claude/Droid: assistant `tool_use`, user `tool_result`, with Claude Code also adding a top-level `toolUseResult`.
+  - Codex: `function_call` or `custom_tool_call`, then later `function_call_output` or `custom_tool_call_output`, joined by `call_id`.
+  - Qwen Code: assistant `functionCall` parts, plus `functionResponse` parts or separate `tool_result` records with `toolCallResult`.
+  - OpenCode: `tool` parts embed both exact tool name and structured state.
+- Stop assuming every tool preserves write/edit/delete equally. Some tools have rich diff objects (`claude`, `gemini`, `qwen-code`, `opencode`); some intentionally omit outputs (`cursor`); some only keep UI snapshots (`cline`, `roo-code`, at least part of `kilo-code` evidence).
+- Introduce a top-of-handoff technical pointer block. The current `src/utils/markdown.ts` shows source/session path/cwd, but schema-sensitive tools need quick raw-access hints like:
+  - exact file or DB path
+  - record type names
+  - where arguments live
+  - where results live
+  - whether outputs are omitted by design
+  - the one-liner to inspect raw tool records
+- Separate “raw fidelity” from “summary readability.” `SummaryCollector` is fine for a compact handoff, but the redesign should keep a raw tool-call appendix or machine-readable pointer so exact upstream names and result carriers are never lost.
+
+## Most important parser-specific consequences
+
+- `src/parsers/claude.ts`, `src/parsers/droid.ts`, and `src/parsers/cursor.ts` all rely on `extractAnthropicToolData()`. That helper ignores Claude Code’s extra `toolUseResult` metadata and assumes `tool_result` blocks are always present when outputs matter.
+- `src/parsers/codex.ts` handles the common `function_call` and `custom_tool_call` paths, but it does not currently map newer persisted response types like `local_shell_call`, `tool_search_call`, or `tool_search_output`.
+- `src/parsers/copilot.ts` only inspects `events.jsonl`, even though GitHub documents both per-session files and a separate `~/.copilot/session-store.db`.
+- `src/parsers/opencode.ts` and `src/parsers/crush.ts` both under-read SQLite-backed stores.
+- `src/parsers/cline.ts` assumes `cline`, `roo-code`, and `kilo-code` all share the same `ui_messages.json` storage story. That is safe only if Kilo has not fully moved to the newer OpenCode-style backend.
+
+## Source handling standard used here
+
+- `Documented fact`: official docs, official repositories, or first-party issue/forum statements.
+- `Observed example`: local raw session data inspected on this machine on 2026-04-15.
+- `Inference`: a conclusion drawn by comparing documented/observed evidence.
+- `Unresolved uncertainty`: a gap that still needs direct upstream confirmation.
+
+## Access date
+
+- All external sources in this folder were accessed on 2026-04-15.
+
+## Sources
+
+- Accessed 2026-04-15: https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview
+- Accessed 2026-04-15: https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs
+- Accessed 2026-04-15: https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+- Accessed 2026-04-15: https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts
+- Accessed 2026-04-15: https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/session/message-v2.ts
+- Accessed 2026-04-15: https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311
+- Accessed 2026-04-15: https://kiro.dev/docs/cli/chat/session-management/
+- Accessed 2026-04-15: https://github.com/charmbracelet/crush/blob/main/internal/message/content.go
+- Accessed 2026-04-15: https://github.com/MoonshotAI/kimi-cli/blob/main/packages/kosong/src/kosong/message.py
+- Accessed 2026-04-15: https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/services/chatRecordingService.ts

--- a/docs/parser-documentation/tool-call-map/01-claude.md
+++ b/docs/parser-documentation/tool-call-map/01-claude.md
@@ -1,0 +1,59 @@
+# Claude Code
+
+## Raw storage
+
+- Documented fact:
+  - Anthropic documents `tool_use` and `tool_result` as content-block types in the Messages API. For client-side tools, Claude emits `tool_use` and the client sends back `tool_result`.
+  - A first-party Claude Code issue confirms session JSONL files under `~/.claude/projects/` and shows that oversized `*.jsonl` session files can block startup.
+- Observed example:
+  - Local sessions live under paths like `~/.claude/projects/<project-slug>/<session-uuid>.jsonl`.
+  - Assistant records are top-level JSON objects with `type: "assistant"` and nested `message.content[]` blocks.
+- Inference:
+  - Claude Code session files are Anthropic-style JSONL plus Claude Code-specific top-level metadata.
+- Unresolved uncertainty:
+  - Anthropic does not publish a first-party Claude Code session-file schema reference for every top-level key added by the CLI.
+
+## Tool-call encoding
+
+- Documented fact:
+  - `tool_use` blocks live inside assistant `message.content[]`.
+  - `tool_result` blocks are returned in user messages.
+- Observed example:
+  - A local `Read` call appears as an assistant block: `{ "type": "tool_use", "id": "...", "name": "Read", "input": { "file_path": "..." }, "caller": { "type": "direct" } }`.
+  - The matching result appears in a user message block: `{ "type": "tool_result", "tool_use_id": "..." }`.
+  - Claude Code also adds a top-level `toolUseResult` object on the user event. For reads, observed keys were `type` and `file`. For edits, observed keys were `filePath`, `oldString`, `newString`, `originalFile`, `structuredPatch`, `replaceAll`, and `userModified`.
+- Inference:
+  - `toolUseResult` is the real Claude Code CLI value-add for exact edit/read fidelity; it is richer than the plain `tool_result.content` string.
+- Unresolved uncertainty:
+  - A dedicated delete tool name was not found in the inspected local samples.
+
+## Write, edit, delete, search, MCP, shell
+
+- Observed example:
+  - Shell calls use exact names like `Bash`.
+  - File reads use `Read`.
+  - File edits preserve structured patch data in `toolUseResult.structuredPatch`.
+- Inference:
+  - Delete behavior may be encoded as a particular edit/patch tool invocation rather than a separate universal `Delete` tool.
+
+## What `continues` abstracts away today
+
+- `src/parsers/claude.ts` delegates tool extraction to `extractAnthropicToolData()`.
+- `src/utils/tool-extraction.ts` reads the `tool_use` block name and the plain `tool_result.content`, but it ignores Claude Code’s top-level `toolUseResult`.
+- `src/types/tool-names.ts` collapses exact names like `Bash`, `Read`, `Edit`, `TodoWrite`, and MCP names into broad categories for summaries.
+- Result: current handoffs lose exact structured diffs, caller metadata, read-file metadata, and some file-level edit semantics that Claude Code actually records.
+
+## Direct-access recipe
+
+```bash
+rg -n '"tool_use"|"tool_result"' ~/.claude/projects -g '*.jsonl' | head
+
+sed -n '10p;11p;16p' ~/.claude/projects/<project>/<session>.jsonl \
+  | jq -c '{topType:.type,msgRole:.message.role,content:[(.message.content[]? | {type,name,id,tool_use_id,inputKeys:(.input|keys? // [])})],toolUseResultKeys:(.toolUseResult|keys? // [])}'
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview
+- Accessed 2026-04-15: https://github.com/anthropics/claude-code/issues/22365
+- Observed locally on 2026-04-15: `~/.claude/projects/.../*.jsonl`

--- a/docs/parser-documentation/tool-call-map/02-codex.md
+++ b/docs/parser-documentation/tool-call-map/02-codex.md
@@ -1,0 +1,64 @@
+# Codex CLI
+
+## Raw storage
+
+- Documented fact:
+  - OpenAI documents `CODEX_HOME` as the local Codex state root, defaulting to `~/.codex`.
+  - The official Codex repo writes rollout session files under `CODEX_HOME/sessions/YYYY/MM/DD/rollout-<timestamp>-<thread-id>.jsonl`.
+  - Every persisted JSONL line is a `RolloutLine` with `timestamp` plus a flattened `RolloutItem`.
+- Observed example:
+  - Local files exist under `~/.codex/sessions/2026/03/24/rollout-...jsonl`.
+- Inference:
+  - `history.jsonl` in the docs and rollout JSONL under `sessions/` are different persistence layers. The parser is correctly targeting rollout files, not the user-level history log.
+- Unresolved uncertainty:
+  - The exact persistence policy for every response item type depends on Codex rollout policy flags, not just the schema.
+
+## Tool-call encoding
+
+- Documented fact:
+  - Official Codex protocol types include these persisted `response_item` variants: `message`, `reasoning`, `local_shell_call`, `function_call`, `tool_search_call`, `function_call_output`, `custom_tool_call`, `custom_tool_call_output`, `tool_search_output`, `web_search_call`, `image_generation_call`, `ghost_snapshot`, `compaction`, and `other`.
+  - `RolloutItem` top-level variants are `session_meta`, `response_item`, `compacted`, `turn_context`, and `event_msg`.
+- Observed example:
+  - `function_call` stores exact tool name in `payload.name`, arguments as a JSON string in `payload.arguments`, and join key in `payload.call_id`.
+  - `function_call_output` stores the result under the matching `payload.call_id`.
+  - `custom_tool_call` is used for `apply_patch`, with the full patch in `payload.input`.
+  - `custom_tool_call_output` stores the patch result string in `payload.output`.
+- Inference:
+  - The authoritative join key is `call_id`, not message order.
+- Unresolved uncertainty:
+  - Some `function_call_output.output` bodies may be structured JSON objects rather than plain strings; local examples were string bodies.
+
+## Write, edit, delete, search, MCP, shell
+
+- Documented fact:
+  - Exact tool/function names are upstream-visible: `exec_command`, `write_stdin`, `update_plan`, `spawn_agent`, `read_mcp_resource`, `list_mcp_resources`, `custom_tool_call` with `name: "apply_patch"`, plus response-layer `local_shell_call` and `web_search_call`.
+- Observed example:
+  - Shell runs were recorded as `function_call` with `name: "exec_command"`.
+  - Patch edits were recorded as `custom_tool_call` with `name: "apply_patch"`.
+- Inference:
+  - `local_shell_call` is a schema-level shell path the current parser should understand separately from `exec_command`.
+
+## What `continues` abstracts away today
+
+- `src/parsers/codex.ts` handles `function_call`, `function_call_output`, `custom_tool_call`, `custom_tool_call_output`, and `web_search_call`.
+- It does not currently map `local_shell_call`, `tool_search_call`, or `tool_search_output`, even though those are official persisted response-item types.
+- It also buckets exact names into generic categories via `SummaryCollector` and `classifyToolName()`.
+- Result: current handoffs lose response-item type distinctions and some future-proofing around newer Codex tool/result carriers.
+
+## Direct-access recipe
+
+```bash
+rg -n '"type":"function_call"|"type":"custom_tool_call"|"type":"function_call_output"|"type":"custom_tool_call_output"' \
+  ~/.codex/sessions -g '*.jsonl' | head
+
+sed -n '12p;15p;20p;22p' ~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-...jsonl \
+  | jq -c '{type,payload:{type:.payload.type,name:.payload.name,call_id:.payload.call_id,argKeys:(.payload.arguments|fromjson?|keys? // []),hasInput:(.payload.input!=null)}}'
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://developers.openai.com/codex/config-advanced
+- Accessed 2026-04-15: https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder.rs
+- Accessed 2026-04-15: https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs
+- Accessed 2026-04-15: https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts
+- Observed locally on 2026-04-15: `~/.codex/sessions/.../rollout-*.jsonl`

--- a/docs/parser-documentation/tool-call-map/03-copilot.md
+++ b/docs/parser-documentation/tool-call-map/03-copilot.md
@@ -1,0 +1,58 @@
+# GitHub Copilot CLI
+
+## Raw storage
+
+- Documented fact:
+  - GitHub documents that every Copilot CLI session is recorded locally under `~/.copilot/session-state/`.
+  - GitHub also documents a separate `~/.copilot/session-store.db` session store used by `/chronicle`.
+  - Session data is written into a session-specific subdirectory and includes raw JSONL files.
+- Observed example:
+  - Local session directories contain combinations of `workspace.yaml`, `events.jsonl`, `vscode.metadata.json`, and `session.db`.
+  - Some local session directories had `session.db` but no `events.jsonl`.
+- Inference:
+  - `events.jsonl` is only part of the Copilot storage story.
+- Unresolved uncertainty:
+  - GitHub docs do not publish the full on-disk schema for tool results or modified-file payloads inside session-state.
+
+## Tool-call encoding
+
+- Observed example:
+  - Tool invocations appear in `events.jsonl` inside `assistant.message.data.toolRequests[]`.
+  - Each tool request preserves exact upstream keys: `toolCallId`, `name`, `arguments`, and `type`.
+  - Sample exact names observed locally: `report_intent` and `task`.
+- Documented fact:
+  - GitHub says session data contains prompts, Copilot responses, tools that were used, and details of files that were modified.
+- Inference:
+  - `events.jsonl` alone does not prove where Copilot stores tool results; richer detail may live elsewhere in the session directory or session store.
+- Unresolved uncertainty:
+  - No public first-party schema reference was found for `session.db` or the precise shape of file-modification records.
+
+## Write, edit, delete, search, MCP, shell
+
+- Observed example:
+  - Exact tool names are preserved verbatim in `toolRequests[].name`.
+  - Arguments live in `toolRequests[].arguments`.
+- Inference:
+  - Whether a request is read/write/edit/search/shell is not explicit in the event type; `continues` infers category by name matching.
+
+## What `continues` abstracts away today
+
+- `src/parsers/copilot.ts` only reads `workspace.yaml` plus `events.jsonl`.
+- The parser currently states that “Copilot doesn't provide tool results,” but GitHub’s own docs say session-state stores a complete record and a separate session store exists.
+- It ignores session directories that only have `session.db`.
+- It also collapses exact request names into generic buckets through `classifyToolName()`.
+
+## Direct-access recipe
+
+```bash
+find ~/.copilot/session-state -maxdepth 2 -type f | head -n 20
+
+jq -c '{type,toolRequests:[.data.toolRequests[]?|{toolCallId,name,argKeys:(.arguments|keys? // []),type}]}' \
+  ~/.copilot/session-state/<session-id>/events.jsonl | head
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+- Accessed 2026-04-15: https://docs.github.com/en/copilot/how-tos/copilot-cli/chronicle
+- Observed locally on 2026-04-15: `~/.copilot/session-state/...`

--- a/docs/parser-documentation/tool-call-map/04-gemini.md
+++ b/docs/parser-documentation/tool-call-map/04-gemini.md
@@ -1,0 +1,60 @@
+# Gemini CLI
+
+## Raw storage
+
+- Documented fact:
+  - The current official Gemini CLI repo writes chat recordings in `chats/` and uses JSONL records with metadata lines, `$set` metadata updates, `$rewindTo` rewind markers, and append-only message records.
+  - `ToolCallRecord` and `MessageRecord` are official persisted types in the repo.
+- Observed example:
+  - This machine still has legacy Gemini session files under `~/.gemini/tmp/<project>/chats/session-*.json`.
+  - Those local files are JSON objects with a `.messages[]` array, not JSONL append logs.
+- Inference:
+  - Gemini is in active storage migration: legacy `.json` session objects still exist in the wild, while the current repo has moved to JSONL append logs.
+- Unresolved uncertainty:
+  - Exactly which released Gemini CLI versions switched from legacy `.json` to JSONL was not verified.
+
+## Tool-call encoding
+
+- Documented fact:
+  - Official `ToolCallRecord` fields are `id`, `name`, `args`, `result`, `status`, `timestamp`, `agentId`, `displayName`, `description`, `resultDisplay`, and `renderOutputAsMarkdown`.
+  - Official `MessageRecord` type `gemini` can also carry `toolCalls`, `thoughts`, `tokens`, and `model`.
+- Observed example:
+  - Local tool calls preserve exact upstream names such as `list_directory`, `ask_user`, `run_shell_command`, `read_file`, and `write_file`.
+  - Arguments are stored under `toolCalls[].args`.
+  - Results live under `toolCalls[].result[]?.functionResponse?.response.output`.
+  - Rich write/edit output lives under `toolCalls[].resultDisplay` with keys like `fileName`, `filePath`, `fileDiff`, `originalContent`, `newContent`, `diffStat`, and `isNewFile`.
+- Inference:
+  - Gemini’s raw storage already distinguishes “just a textual result” from “file mutation with diff object,” and that distinction should survive into handoffs.
+- Unresolved uncertainty:
+  - A universal delete-only tool name was not observed in the inspected samples.
+
+## Write, edit, delete, search, MCP, shell
+
+- Observed example:
+  - Shell: `run_shell_command`
+  - Read: `read_file`
+  - Write: `write_file`
+  - Search/glob style tools: `list_directory`
+- Inference:
+  - `continues` should preserve exact tool names instead of only summary categories, because Gemini already gives them cleanly.
+
+## What `continues` abstracts away today
+
+- `src/parsers/gemini.ts` works well on the legacy `.json` format that exists locally, but it does not support the newer JSONL append-log structure from the current official repo.
+- It drops `toolCalls[].id`, `displayName`, `description`, `agentId`, and rewind/update semantics.
+- `src/types/tool-names.ts` then compresses exact names like `run_shell_command` and `write_file` into generic shell/write buckets.
+
+## Direct-access recipe
+
+```bash
+find ~/.gemini -path '*/chats/session-*.json' | head
+
+jq -c '.messages[] | select(.toolCalls!=null) | {type,id,toolCalls:[.toolCalls[]|{name,argKeys:(.args|keys? // []),status,resultDisplayType:(.resultDisplay|type),resultDisplayKeys:(if (.resultDisplay|type)=="object" then (.resultDisplay|keys) else [] end)}]}' \
+  ~/.gemini/tmp/<project>/chats/session-*.json | head
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts
+- Accessed 2026-04-15: https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingTypes.ts
+- Observed locally on 2026-04-15: `~/.gemini/tmp/.../chats/session-*.json`

--- a/docs/parser-documentation/tool-call-map/05-opencode.md
+++ b/docs/parser-documentation/tool-call-map/05-opencode.md
@@ -1,0 +1,72 @@
+# OpenCode
+
+## Raw storage
+
+- Documented fact:
+  - The current official OpenCode repo stores session data in SQLite by default at `Global.Path.data/opencode.db`.
+  - The same repo ships JSON-to-SQLite migration code from a legacy `storage/` tree containing `project/*.json`, `session/*/*.json`, `message/*/*.json`, `part/*/*.json`, `todo/*.json`, `permission/*.json`, and `session_share/*.json`.
+  - Core SQLite tables are `session`, `message`, `part`, `todo`, `session_entry`, and `permission`.
+- Observed example:
+  - Local `~/.local/share/opencode/opencode.db` contains populated `session`, `message`, and `part` tables.
+- Inference:
+  - OpenCode has already standardized on a part-oriented SQLite backend, with the legacy JSON tree retained only for migration.
+- Unresolved uncertainty:
+  - None that materially affects tool-call mapping; the schema is explicit.
+
+## Tool-call encoding
+
+- Documented fact:
+  - OpenCode stores tool activity as `part.data` rows with `type: "tool"`.
+  - `ToolPart` fields are `callID`, exact `tool` name, and `state`.
+  - `state` is a discriminated union:
+    - `pending`: `input`, `raw`
+    - `running`: `input`, optional `title`, optional `metadata`, `time.start`
+    - `completed`: `input`, `output`, `title`, `metadata`, `time.start`, `time.end`, optional `attachments`
+    - `error`: `input`, `error`, optional `metadata`, `time.start`, `time.end`
+- Observed example:
+  - Local tool-part names include `bash`, `webfetch`, `read`, `todowrite`, `grep`, and `apply_patch`.
+  - Local completed tool parts contain `state.input` JSON and `state.output` text.
+  - Local sessions also preserve `summary_additions`, `summary_deletions`, and `summary_files` in `session`.
+- Inference:
+  - OpenCode is one of the clearest upstream schemas in the entire tool list. Exact names, inputs, outputs, status, and timing are all present.
+
+## Write, edit, delete, search, MCP, shell
+
+- Documented fact:
+  - Exact tool names are stored in `part.data.tool`.
+  - The tool-state payload itself distinguishes successful completion vs error.
+- Observed example:
+  - Shell-like exact name: `bash`
+  - Fetch-like exact name: `webfetch`
+  - File read exact name: `read`
+  - Patch/edit exact name: `apply_patch`
+  - Search exact name: `grep`
+
+## What `continues` abstracts away today
+
+- `src/parsers/opencode.ts` currently reduces OpenCode tool activity to a session-level `Edit` summary derived from `summary_additions`, `summary_deletions`, and `summary_files`.
+- It does not read `part` rows of `type: "tool"` at all.
+- That means exact tool names, arguments, output/error placement, per-tool timing, and attachment metadata are all dropped even though upstream stores them cleanly.
+
+## Direct-access recipe
+
+```bash
+sqlite3 ~/.local/share/opencode/opencode.db '.schema session' '.schema message' '.schema part'
+
+sqlite3 ~/.local/share/opencode/opencode.db \
+  "select json_extract(data,'$.tool') as tool,
+          json_extract(data,'$.state.status') as status,
+          json_extract(data,'$.state.input') as input,
+          substr(json_extract(data,'$.state.output'),1,150) as output
+   from part
+   where json_extract(data,'$.type')='tool'
+   limit 10;"
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/storage/db.ts
+- Accessed 2026-04-15: https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/storage/json-migration.ts
+- Accessed 2026-04-15: https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/session/session.sql.ts
+- Accessed 2026-04-15: https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/session/message-v2.ts
+- Observed locally on 2026-04-15: `~/.local/share/opencode/opencode.db`

--- a/docs/parser-documentation/tool-call-map/06-droid.md
+++ b/docs/parser-documentation/tool-call-map/06-droid.md
@@ -1,0 +1,58 @@
+# Factory Droid
+
+## Raw storage
+
+- Documented fact:
+  - Factory documents hook lifecycle events such as `SessionStart`, `SessionEnd`, `PreToolUse`, `PostToolUse`, `PreCompact`, and `SubagentStop`.
+  - Factory documents custom droids as `subagent_type` targets for the `Task` tool.
+  - Factory does not publish a first-party session-file schema reference.
+- Observed example:
+  - Local Droid sessions live under `~/.factory/sessions/<workspace-slug>/<session-id>.jsonl`.
+  - Companion settings exist as `~/.factory/sessions/<workspace-slug>/<session-id>.settings.json`.
+- Inference:
+  - The raw event log is the authoritative source for tool-call mapping; docs mainly confirm lifecycle concepts, not file layout.
+- Unresolved uncertainty:
+  - No first-party public reference was found for every top-level JSONL event field.
+
+## Tool-call encoding
+
+- Observed example:
+  - Local Droid message events look like `{ "type": "message", "id": "...", "timestamp": "...", "message": { "role": "...", "content": [...] } }`.
+  - Assistant `message.content[]` blocks use Anthropic-style `tool_use` objects with exact names like `TodoWrite`, `Glob`, and `Read`.
+  - User reply events return matching `tool_result` blocks with `tool_use_id`.
+  - Assistant events can also carry extra top-level fields like `openaiEncryptedContent` and `openaiReasoningId`.
+- Documented fact:
+  - Factory hook examples show tool payloads as structured JSON, for example reading `.tool_input.command` in a `PreToolUse` hook.
+- Inference:
+  - Droid’s persisted message format is Anthropic-like for tool I/O, but the session envelope adds Droid/OpenAI-specific side metadata.
+
+## Write, edit, delete, search, MCP, shell
+
+- Observed example:
+  - Exact names observed locally included `TodoWrite`, `Glob`, and `Read`.
+  - Multiple `tool_use` blocks can appear in the same assistant message.
+- Inference:
+  - The same shared Anthropic extraction path used for Claude works for block pairing, but it should not discard Droid-specific top-level metadata.
+
+## What `continues` abstracts away today
+
+- `src/parsers/droid.ts` converts Droid events into the shared `extractAnthropicToolData()` helper.
+- That helper only consumes block-level `tool_use` and `tool_result` data.
+- It does not preserve Droid-specific top-level fields like `openaiEncryptedContent`, `openaiReasoningId`, or any richer future metadata outside the block array.
+- As elsewhere, exact tool names are then normalized into broad categories by `tool-names.ts`.
+
+## Direct-access recipe
+
+```bash
+rg -n '"tool_use"|"tool_result"' ~/.factory/sessions -g '*.jsonl' | head
+
+sed -n '3p;5p' ~/.factory/sessions/<workspace-slug>/<session-id>.jsonl \
+  | jq -c '{type,id,msgRole:.message.role,content:[.message.content[]|{type,name,id,tool_use_id,inputKeys:(.input|keys? // [])}],extraKeys:(keys - ["type","id","timestamp","message","parentId"])}'
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://docs.factory.ai/cli/configuration/hooks-guide
+- Accessed 2026-04-15: https://docs.factory.ai/cli/configuration/custom-droids
+- Accessed 2026-04-15: https://docs.factory.ai/guides/power-user/memory-management
+- Observed locally on 2026-04-15: `~/.factory/sessions/.../*.jsonl`

--- a/docs/parser-documentation/tool-call-map/07-cursor.md
+++ b/docs/parser-documentation/tool-call-map/07-cursor.md
@@ -1,0 +1,52 @@
+# Cursor
+
+## Raw storage
+
+- Documented fact:
+  - First-party Cursor staff refer to “the JSONL transcript files” for agent chats.
+  - In an official forum reply, Cursor staff state that these JSONL transcript files intentionally include tool call inputs but do not include tool call outputs.
+- Observed example:
+  - Local Cursor agent transcripts live under `~/.cursor/projects/<project-slug>/agent-transcripts/<session-id>.jsonl`.
+  - Sampled local transcript lines only contained `role` plus `message.content[]` text blocks.
+- Inference:
+  - Cursor transcript fidelity is intentionally asymmetric: inputs are eligible for persistence; outputs are intentionally excluded because they can be large.
+- Unresolved uncertainty:
+  - Local sampled transcripts did not include any persisted tool input blocks, so exact per-version on-disk representation still needs more examples.
+
+## Tool-call encoding
+
+- Documented fact:
+  - Cursor staff say JSONL transcript files include “tool call inputs (tool name + arguments)” but intentionally omit tool call outputs.
+  - Cursor staff recommend `postToolUse` hooks if users need full output logging.
+- Observed example:
+  - On this machine, inspected transcript lines were plain message text only.
+- Inference:
+  - The transcript backend is not Anthropic-complete. Even when tool inputs exist, tool outputs are intentionally absent.
+
+## Write, edit, delete, search, MCP, shell
+
+- Documented fact:
+  - Tool outputs are intentionally not persisted in transcript JSONL.
+- Inference:
+  - Any write/edit/delete/search/shell classification from Cursor transcripts should be treated as input-side only unless a separate hook log is consulted.
+
+## What `continues` abstracts away today
+
+- `src/parsers/cursor.ts` currently reuses `extractAnthropicToolData()`, which assumes Anthropic-style `tool_use`/`tool_result` pairing.
+- That is a poor fit for first-party Cursor guidance, because Cursor intentionally omits tool outputs from transcript JSONL.
+- Result: current summaries can only ever be partial, and they may look more complete than the raw source actually is.
+
+## Direct-access recipe
+
+```bash
+find ~/.cursor/projects -path '*/agent-transcripts/*.jsonl' | head
+
+jq -c '{role,content:[.message.content[]?|{type,name,id,inputKeys:(.input|keys? // [])}]}' \
+  ~/.cursor/projects/<project>/agent-transcripts/<session>.jsonl | head
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311
+- Accessed 2026-04-15: https://forum.cursor.com/t/jsonl-format-should-fully-record-the-tool-use-information/154777
+- Observed locally on 2026-04-15: `~/.cursor/projects/.../agent-transcripts/*.jsonl`

--- a/docs/parser-documentation/tool-call-map/08-amp.md
+++ b/docs/parser-documentation/tool-call-map/08-amp.md
@@ -1,0 +1,51 @@
+# Amp
+
+## Raw storage
+
+- Documented fact:
+  - Amp’s official manual documents threads, `amp threads continue`, handoffs, and JSON streaming modes.
+  - The manual does not document an on-disk thread/transcript file path.
+- Observed example:
+  - Local thread files exist under `~/.local/share/amp/threads/T-*.json`.
+  - Sampled thread JSON keys were `agentMode`, `created`, `env`, `id`, `messages`, `meta`, `nextMessageId`, and `v`.
+  - Sampled message content kinds were only `text`.
+- Inference:
+  - Amp’s local thread JSON, at least in the observed samples, is chat-centric and not a rich raw tool-call log.
+- Unresolved uncertainty:
+  - The official manual says threads contain messages, context, and tool calls conceptually, but no first-party on-disk schema was found for how or whether those tool calls are persisted locally.
+
+## Tool-call encoding
+
+- Observed example:
+  - No `tool_use`, `tool_result`, `toolCalls`, or non-text content parts were present in sampled local thread files.
+- Documented fact:
+  - Amp supports `--stream-json` and `--stream-json-input`, both line-oriented JSON protocols, but the manual does not connect those stream objects to the on-disk thread JSON format.
+- Inference:
+  - Tool-call fidelity may exist in runtime streams but not necessarily in the local thread file format.
+
+## Write, edit, delete, search, MCP, shell
+
+- Observed example:
+  - Sampled thread JSON did not preserve raw write/edit/delete/search/shell events as separate structured entries.
+- Inference:
+  - `continues` should not promise exact tool activity from Amp unless a richer first-party storage source is identified.
+
+## What `continues` abstracts away today
+
+- `src/parsers/amp.ts` already emits no tool summaries and only lightly uses `usageLedger` if present.
+- That conservative behavior matches the sampled local JSON better than a more aggressive parser would.
+- The main risk is not over-normalization; it is lack of a documented source of exact tool names.
+
+## Direct-access recipe
+
+```bash
+find ~/.local/share/amp/threads -type f -name '*.json' | head
+
+jq -c '{id,topKeys:(keys|sort),messageShape:(.messages[0]|keys_unsorted),contentKinds:[.messages[0].content[]?.type]}' \
+  ~/.local/share/amp/threads/T-*.json | head -n 1
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://ampcode.com/manual
+- Observed locally on 2026-04-15: `~/.local/share/amp/threads/T-*.json`

--- a/docs/parser-documentation/tool-call-map/09-kiro.md
+++ b/docs/parser-documentation/tool-call-map/09-kiro.md
@@ -1,0 +1,46 @@
+# Kiro
+
+## Raw storage
+
+- Documented fact:
+  - Official Kiro CLI docs say sessions are auto-saved on every turn in a local SQLite database under `~/.kiro/`.
+  - Sessions are per-directory, keyed by directory path, and have UUID session IDs.
+  - Kiro supports resume, interactive session picking, list, delete, save-to-file, and load-from-file commands.
+- Observed example:
+  - The parser’s expected path `~/Library/Application Support/Kiro/workspace-sessions/` does not exist on this machine.
+- Inference:
+  - The current `src/parsers/kiro.ts` is not aligned with current first-party Kiro CLI documentation.
+- Unresolved uncertainty:
+  - Whether Kiro IDE still maintains a separate JSON `workspace-sessions` store apart from Kiro CLI’s SQLite backend is not publicly documented in the sources inspected here.
+
+## Tool-call encoding
+
+- Documented fact:
+  - No first-party public session-schema reference was found for raw tool-call storage inside Kiro’s SQLite backend.
+- Observed example:
+  - No local Kiro session store was available to inspect.
+- Inference:
+  - The current parser statement “Kiro sessions have no tool call data” should be treated as unverified.
+
+## Write, edit, delete, search, MCP, shell
+
+- Unresolved uncertainty:
+  - No documented first-party evidence was found for exact persisted Kiro tool names or result placement.
+
+## What `continues` abstracts away today
+
+- `src/parsers/kiro.ts` only looks for JSON files with `sessionId`, `workspacePath`, `selectedModel`, and `history`.
+- Official docs point instead to SQLite under `~/.kiro/`.
+- This is likely a storage-backend mismatch, not just a missing field.
+
+## Direct-access recipe
+
+```bash
+find ~/.kiro -name '*.db' 2>/dev/null
+
+kiro-cli chat --list-sessions
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://kiro.dev/docs/cli/chat/session-management/

--- a/docs/parser-documentation/tool-call-map/10-crush.md
+++ b/docs/parser-documentation/tool-call-map/10-crush.md
@@ -1,0 +1,50 @@
+# Crush
+
+## Raw storage
+
+- Documented fact:
+  - The official Crush repo creates SQLite tables `sessions`, `files`, and `messages`.
+  - `messages.parts` is a JSON string storing structured content parts.
+- Observed example:
+  - Local `~/.crush/crush.db` exists on this machine but is currently zero bytes, so no live rows were available for inspection.
+- Inference:
+  - The current parser’s table names are aligned with the upstream schema, but its data extraction is not.
+- Unresolved uncertainty:
+  - No populated local Crush database was available to verify current runtime row contents.
+
+## Tool-call encoding
+
+- Documented fact:
+  - Upstream `ContentPart` types include `reasoning`, `text`, `image_url`, `binary`, `tool_call`, `tool_result`, and `finish`.
+  - Upstream `ToolCall` fields are `id`, `name`, `input`, `provider_executed`, and `finished`.
+  - Upstream `ToolResult` fields are `tool_call_id`, `name`, `content`, `data`, `mime_type`, `metadata`, and `is_error`.
+  - Upstream `MessageRole` includes `assistant`, `user`, `system`, and `tool`.
+- Inference:
+  - Crush preserves exact tool call and result structure inside `messages.parts`; it is not just plain assistant/user text.
+
+## Write, edit, delete, search, MCP, shell
+
+- Unresolved uncertainty:
+  - No populated local sample was available to enumerate current exact built-in tool names used by Crush agents.
+- Inference:
+  - Even without tool-name enumeration, the upstream `tool_call` / `tool_result` part types clearly exceed the fidelity of the current parser.
+
+## What `continues` abstracts away today
+
+- `src/parsers/crush.ts` extracts plain text from `messages.parts` and ignores structured `tool_call` / `tool_result` parts entirely.
+- That drops exact upstream names, arguments, provider-executed flags, MIME/data metadata, and error state.
+
+## Direct-access recipe
+
+```bash
+sqlite3 ~/.crush/crush.db \
+  "select role, parts from messages where parts like '%tool_call%' limit 5;"
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://github.com/charmbracelet/crush/blob/main/internal/db/migrations/20250424200609_initial.sql
+- Accessed 2026-04-15: https://github.com/charmbracelet/crush/blob/main/internal/db/models.go
+- Accessed 2026-04-15: https://github.com/charmbracelet/crush/blob/main/internal/message/content.go
+- Accessed 2026-04-15: https://github.com/charmbracelet/crush/blob/main/internal/message/message.go
+- Observed locally on 2026-04-15: `~/.crush/crush.db` exists but was empty

--- a/docs/parser-documentation/tool-call-map/11-cline.md
+++ b/docs/parser-documentation/tool-call-map/11-cline.md
@@ -1,0 +1,49 @@
+# Cline
+
+## Raw storage
+
+- Documented fact:
+  - Official Cline docs say task history lives under IDE global storage, with `state/taskHistory.json` as an index and per-task folders under `tasks/<task-id>/`.
+  - Each task folder contains `api_conversation_history.json`, `ui_messages.json`, and `task_metadata.json`.
+  - The official repo defines `ClineMessage` as the persisted `ui_messages.json` item type.
+- Observed example:
+  - No local Cline task folders were available on this machine.
+- Inference:
+  - `ui_messages.json` is a UI/event snapshot, not a faithful low-level tool transcript.
+
+## Tool-call encoding
+
+- Documented fact:
+  - `ClineMessage` fields include `ts`, `type`, `ask`, `say`, `text`, `reasoning`, `images`, `files`, `partial`, `commandCompleted`, `lastCheckpointHash`, `isCheckpointCheckedOut`, `isOperationOutsideWorkspace`, `conversationHistoryIndex`, `conversationHistoryDeletedRange`, and `modelInfo`.
+  - The official ask/say enums include generic events like `ask: "tool"` and `say: "tool"`, `command_output`, `mcp_server_request_started`, `mcp_server_response`, `codebase_search_result`, and `subtask_result`.
+  - Cline docs treat `ui_messages.json` as recoverable task history data, alongside `api_conversation_history.json`.
+- Inference:
+  - Exact upstream tool function names are not the primary thing `ui_messages.json` preserves. It preserves UI-level asks/says and snapshots.
+- Unresolved uncertainty:
+  - Without local samples, it is unclear how often `say: "tool"` carries enough detail to infer specific operations beyond the UI layer.
+
+## Write, edit, delete, search, MCP, shell
+
+- Documented fact:
+  - The schema preserves some operation-adjacent information (`files`, `commandCompleted`, `mcp_server_*`, `codebase_search_result`) but not a clean universal `name + args + result` tool schema.
+- Inference:
+  - For Cline, “exact upstream tool name” may be unavailable from `ui_messages.json` by design.
+
+## What `continues` abstracts away today
+
+- `src/parsers/cline.ts` chooses the conservative path and emits no tool summaries.
+- That is defensible because `ui_messages.json` is not a raw tool log.
+- It still leaves information on the floor, though: the parser currently ignores `files`, `reasoning`, `checkpoint`, context-condense/truncation metadata, and generic `say: "tool"` events.
+
+## Direct-access recipe
+
+```bash
+find ~/Library/'Application Support'/Code/User/globalStorage/saoudrizwan.claude-dev/tasks -name ui_messages.json 2>/dev/null
+
+jq '.[0] | keys' ~/Library/'Application Support'/Code/User/globalStorage/saoudrizwan.claude-dev/tasks/<task-id>/ui_messages.json
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://docs.cline.bot/troubleshooting/task-history-recovery
+- Accessed 2026-04-15: https://github.com/cline/cline/blob/main/src/shared/ExtensionMessage.ts

--- a/docs/parser-documentation/tool-call-map/12-roo-code.md
+++ b/docs/parser-documentation/tool-call-map/12-roo-code.md
@@ -1,0 +1,50 @@
+# Roo Code
+
+## Raw storage
+
+- Documented fact:
+  - Roo Code persists task snapshots in `ui_messages.json`.
+  - Roo issue traffic explicitly references `ui_messages.json` and `api_conversation_history.json` as exported task-history artifacts.
+  - Roo’s own packages define a Cline-style persisted message schema and save `ui_messages.json` via `taskMessages.ts`.
+- Observed example:
+  - No local Roo Code task folders were available on this machine.
+- Inference:
+  - Roo remains in the Cline-style UI snapshot family, but with explicit evidence that large `read_file` payloads can be stored inside `ui_messages.json`.
+
+## Tool-call encoding
+
+- Documented fact:
+  - Roo’s `clineMessageSchema` preserves fields like `ts`, `type`, `ask`, `say`, `text`, `images`, `partial`, `reasoning`, `conversationHistoryIndex`, and context-management metadata.
+  - Roo issue #8690 states that full `read_file` payloads were persisted into `ui_messages.json` snapshots.
+  - Roo issue #9580 confirms `ui_messages.json` and `api_conversation_history.json` are user-visible task-history artifacts.
+- Inference:
+  - Roo may preserve more file-read detail than plain Cline, but still not a normalized exact tool transcript.
+- Unresolved uncertainty:
+  - No local sample was available to verify how exact tool names are surfaced in current Roo `ui_messages.json`.
+
+## Write, edit, delete, search, MCP, shell
+
+- Documented fact:
+  - Roo persisted complete `read_file` contents in some `ui_messages.json` snapshots, which is strong evidence of file-read leakage into the UI layer.
+- Inference:
+  - That means Roo snapshots can contain tool-adjacent detail, but not necessarily a stable exact `name + args + result` record for every tool.
+
+## What `continues` abstracts away today
+
+- `src/parsers/cline.ts` handles `roo-code` exactly like `cline` and emits no tool summaries.
+- That avoids fabricating exact tool names, but it also ignores persisted read-file payloads, `say`/`ask` tool markers, and other UI-layer operation hints that Roo actually stores.
+
+## Direct-access recipe
+
+```bash
+find ~/Library/'Application Support'/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks -name ui_messages.json 2>/dev/null
+
+jq '.[0] | keys' ~/Library/'Application Support'/Code/User/globalStorage/rooveterinaryinc.roo-cline/tasks/<task-id>/ui_messages.json
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://github.com/RooCodeInc/Roo-Code/blob/main/packages/types/src/message.ts
+- Accessed 2026-04-15: https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/taskMessages.ts
+- Accessed 2026-04-15: https://github.com/RooCodeInc/Roo-Code/issues/8690
+- Accessed 2026-04-15: https://github.com/RooCodeInc/Roo-Code/issues/9580

--- a/docs/parser-documentation/tool-call-map/13-kilo-code.md
+++ b/docs/parser-documentation/tool-call-map/13-kilo-code.md
@@ -1,0 +1,53 @@
+# Kilo Code
+
+## Raw storage
+
+- Documented fact:
+  - First-party Kilo issue #3706 refers to task storage under `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks`, with `ui_messages.json` and `ui_messages.json.lock`.
+  - The current official Kilo repo also contains substantial `kilocode_change` modifications on top of an OpenCode-style session backend, including `packages/opencode/src/session/index.ts` and `packages/opencode/src/session/message-v2.ts`.
+- Observed example:
+  - No local Kilo task or session store was available on this machine.
+- Inference:
+  - First-party evidence conflicts. Kilo appears to have both legacy VS Code task snapshots and a newer OpenCode-derived session backend in play.
+- Unresolved uncertainty:
+  - Which backend is canonical for current Kilo releases was not resolved from public sources alone.
+
+## Tool-call encoding
+
+- Documented fact:
+  - The Kilo issue describes `ui_messages.json` as an actively written task-history file that can lock and grow large.
+  - The current official repo also defines an OpenCode-style `ToolPart` backend, where exact tool names live in `part.data.tool` and exact inputs/outputs live in `part.data.state`.
+- Inference:
+  - There are two plausible Kilo storage generations:
+    - legacy extension snapshots in `ui_messages.json`
+    - newer OpenCode-like SQLite/message-part storage with exact tool parts
+- Unresolved uncertainty:
+  - No first-party page was found that explicitly says whether both stores coexist or whether one superseded the other.
+
+## Write, edit, delete, search, MCP, shell
+
+- Documented fact:
+  - The OpenCode-derived Kilo code path preserves exact tool names and structured tool state.
+  - The issue-based `ui_messages.json` evidence only proves a UI snapshot file, not exact low-level tool semantics.
+- Inference:
+  - `continues` is safest if it treats Kilo as unresolved rather than assuming it is just another Cline-family `ui_messages.json` tool.
+
+## What `continues` abstracts away today
+
+- `src/parsers/cline.ts` currently handles `kilo-code` exactly like `cline` and `roo-code`.
+- If the modern Kilo backend is OpenCode-derived, that parser is pointed at the wrong storage model and will miss exact tool parts entirely.
+- If the legacy `ui_messages.json` backend is still active for some builds, exact tool names may still be unavailable there anyway.
+
+## Direct-access recipe
+
+```bash
+find ~/.config/Code/User/globalStorage/kilocode.kilo-code -maxdepth 3 -type f 2>/dev/null
+
+sqlite3 ~/.local/share/kilo*/**/*.db '.tables' 2>/dev/null
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://github.com/Kilo-Org/kilocode/issues/3706
+- Accessed 2026-04-15: https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/session/index.ts
+- Accessed 2026-04-15: https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/session/message-v2.ts

--- a/docs/parser-documentation/tool-call-map/14-antigravity.md
+++ b/docs/parser-documentation/tool-call-map/14-antigravity.md
@@ -1,0 +1,50 @@
+# Antigravity
+
+## Raw storage
+
+- Documented fact:
+  - A first-party public product announcement for Google Antigravity exists, but no first-party session-schema or code-tracker-storage reference was found.
+- Observed example:
+  - Local Antigravity files exist under `~/.gemini/antigravity/code_tracker/`.
+  - Sampled files in `code_tracker/active/...` looked like prefixed file snapshots such as `*_CLAUDE.md`, `*.tsx`, and `*.py`, not obvious conversation transcripts.
+  - Local Antigravity data also includes `browser_recordings/.../*.jpg`.
+- Inference:
+  - The local `code_tracker` on this machine appears to be a file-tracking corpus, not an obviously parseable assistant/user conversation log.
+- Unresolved uncertainty:
+  - No public first-party schema was found for Antigravity session history, transcript logs, or exact tool-call persistence.
+
+## Tool-call encoding
+
+- Observed example:
+  - No local evidence of structured `tool_use`, `tool_result`, `toolCalls`, or conversation-role JSON was found inside the sampled `code_tracker` files.
+- Inference:
+  - `src/parsers/antigravity.ts` should be treated as provisional until a canonical upstream log format is confirmed.
+- Unresolved uncertainty:
+  - Whether Antigravity stores raw chat history outside `code_tracker`, or inside other machine-local directories, remains open.
+
+## Write, edit, delete, search, MCP, shell
+
+- Unresolved uncertainty:
+  - No evidence-backed first-party schema was found for Antigravity write/edit/delete/search/shell tool logging.
+
+## What `continues` abstracts away today
+
+- `src/parsers/antigravity.ts` assumes JSON/JSONL conversation entries with `{type, content, timestamp}` inside `code_tracker`.
+- Local evidence here points the other way: sampled files look like tracked file snapshots with binary-ish prefixes.
+- This is the single weakest parser/storage match in the current product.
+
+## Direct-access recipe
+
+```bash
+find ~/.gemini/antigravity/code_tracker -type f | head -n 20
+
+find ~/.gemini/antigravity/code_tracker -type f | head -n 3 | while read f; do
+  echo "$f"
+  xxd -l 64 "$f"
+done
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://developers.googleblog.com/build-with-google-antigravity-our-new-agentic-development-platform/
+- Observed locally on 2026-04-15: `~/.gemini/antigravity/code_tracker/...`

--- a/docs/parser-documentation/tool-call-map/15-kimi.md
+++ b/docs/parser-documentation/tool-call-map/15-kimi.md
@@ -1,0 +1,59 @@
+# Kimi CLI
+
+## Raw storage
+
+- Documented fact:
+  - The official Kimi CLI repo creates sessions under `~/.kimi/sessions/<workdir-hash>/<session-id>/`.
+  - Each session directory has a `context.jsonl` history file and a `wire.jsonl` log file.
+  - `context.jsonl` is append-only and can also contain special sentinel records `_system_prompt`, `_usage`, and `_checkpoint`.
+  - `wire.jsonl` starts with a metadata line and then timestamped wire-message records.
+- Observed example:
+  - Local Kimi session directories match the `~/.kimi/sessions/<hash>/<session-id>/` pattern.
+  - On this machine, sampled `context.jsonl` files were zero bytes, while `wire.jsonl` files were non-empty and began with a metadata header plus `TurnBegin` records.
+- Inference:
+  - `wire.jsonl` is important operational state, not just an optional side log.
+- Unresolved uncertainty:
+  - The exact conditions under which Kimi flushes full history into `context.jsonl` versus only writing `wire.jsonl` were not determined from the inspected sources.
+
+## Tool-call encoding
+
+- Documented fact:
+  - Official `kosong.message.Message` fields are `role`, `content`, `tool_calls`, `tool_call_id`, and `partial`.
+  - `tool_calls[]` items use `type: "function"`, `id`, and `function.{name,arguments}`.
+  - Thought blocks are serialized as content parts with `type: "think"` and `think`; optional `encrypted` also exists.
+  - `_usage` records store `token_count`.
+- Observed example:
+  - Local `wire.jsonl` records had a metadata header and timestamped message envelopes, but no local populated `context.jsonl` sample with tool calls was available.
+- Inference:
+  - The parser’s assumption that Kimi tool calls look like OpenAI-style `tool_calls[].function.name` is supported by the official message model.
+
+## Write, edit, delete, search, MCP, shell
+
+- Documented fact:
+  - Exact tool/function names are preserved in `tool_calls[].function.name`.
+  - Tool arguments are persisted as a JSON string in `tool_calls[].function.arguments`.
+- Unresolved uncertainty:
+  - No populated local `context.jsonl` example was available to enumerate actual built-in Kimi tool names in use.
+
+## What `continues` abstracts away today
+
+- `src/parsers/kimi.ts` reads only `context.jsonl`.
+- Local evidence on this machine suggests that can miss real sessions when `context.jsonl` is empty but `wire.jsonl` is populated.
+- The parser also normalizes exact tool names and ignores `wire.jsonl` entirely.
+
+## Direct-access recipe
+
+```bash
+find ~/.kimi/sessions -name context.jsonl -o -name wire.jsonl | head -n 20
+
+sed -n '1,8p' ~/.kimi/sessions/<hash>/<session-id>/wire.jsonl \
+  | jq -c '{keys:(keys|sort),type,messageKeys:(.message|keys? // []),messageType:(.message.type? // null)}'
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/session.py
+- Accessed 2026-04-15: https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/soul/context.py
+- Accessed 2026-04-15: https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/wire/file.py
+- Accessed 2026-04-15: https://github.com/MoonshotAI/kimi-cli/blob/main/packages/kosong/src/kosong/message.py
+- Observed locally on 2026-04-15: `~/.kimi/sessions/...`

--- a/docs/parser-documentation/tool-call-map/16-qwen-code.md
+++ b/docs/parser-documentation/tool-call-map/16-qwen-code.md
@@ -1,0 +1,53 @@
+# Qwen Code
+
+## Raw storage
+
+- Documented fact:
+  - The current official Qwen Code repo writes chat records as JSONL under `~/.qwen/tmp/<project-id>/chats/`.
+  - Each persisted `ChatRecord` has `uuid`, `parentUuid`, `sessionId`, `timestamp`, `type`, `cwd`, and `version`, plus optional `message`, `usageMetadata`, `model`, `contextWindowSize`, `toolCallResult`, and `systemPayload`.
+- Observed example:
+  - No local `~/.qwen` session store existed on this machine.
+- Inference:
+  - The storage location documented in the current official repo conflicts with `src/parsers/qwen-code.ts`, which looks under `~/.qwen/projects/*/chats/`.
+- Unresolved uncertainty:
+  - No local sample was available to confirm whether released builds already use the repo-documented `~/.qwen/tmp/` location.
+
+## Tool-call encoding
+
+- Documented fact:
+  - Assistant records store raw API `Content`, whose `parts[]` can include `functionCall`.
+  - Tool results are stored either as `functionResponse` parts or as separate top-level `tool_result` records carrying `toolCallResult`.
+  - `toolCallResult` is UI-oriented metadata and can include rich `resultDisplay` information.
+  - Official export code reconstructs tool calls by matching function call IDs to function responses and `toolCallResult.callId`.
+- Inference:
+  - Qwen Code explicitly distinguishes model-visible content (`message.parts`) from UI recovery metadata (`toolCallResult`), and both matter for fidelity.
+
+## Write, edit, delete, search, MCP, shell
+
+- Documented fact:
+  - Exact tool names are preserved in `functionCall.name`.
+  - Arguments live in `functionCall.args`.
+  - Result bodies live in `functionResponse.response.output`.
+  - Rich file-operation metadata lives in `toolCallResult.resultDisplay`.
+- Inference:
+  - `continues` should keep both the raw function-call layer and the UI result-display layer for Qwen, not collapse them into a single summary string.
+
+## What `continues` abstracts away today
+
+- `src/parsers/qwen-code.ts` already understands a useful subset of the Qwen record model, but it is likely pointed at the wrong base directory.
+- It also normalizes exact tool names into generic read/write/edit/search/fetch/shell buckets and only partially exposes `toolCallResult`.
+- If the upstream path mismatch is real, none of that logic will run on current sessions anyway.
+
+## Direct-access recipe
+
+```bash
+find ~/.qwen/tmp -path '*/chats/*.jsonl' 2>/dev/null | head
+
+jq -c 'select(.type=="assistant" or .type=="tool_result") | {type,uuid,parentUuid,hasMessage:(.message!=null),hasToolCallResult:(.toolCallResult!=null)}' \
+  ~/.qwen/tmp/<project-id>/chats/<session>.jsonl | head
+```
+
+## Sources
+
+- Accessed 2026-04-15: https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/services/chatRecordingService.ts
+- Accessed 2026-04-15: https://github.com/QwenLM/qwen-code/blob/main/packages/cli/src/ui/utils/export/collect.ts

--- a/docs/parser-documentation/tool-call-map/99-open-questions.md
+++ b/docs/parser-documentation/tool-call-map/99-open-questions.md
@@ -1,0 +1,25 @@
+# Open Questions
+
+## Highest-priority follow-ups
+
+- `antigravity`: what is the canonical session/transcript store? Local `code_tracker` samples look like prefixed file snapshots, not conversation logs, and no public first-party storage schema was found.
+- `kiro`: is `continues` meant to support Kiro CLI, Kiro IDE, or both? Official docs say SQLite under `~/.kiro/`; current parser targets JSON files under `Application Support/Kiro/workspace-sessions/`.
+- `kilo-code`: which backend is canonical today?
+  - First-party issue evidence still references `ui_messages.json` under VS Code globalStorage.
+  - Current official repo also ships OpenCode-style `ToolPart` and `Session` code with `kilocode_change` customizations.
+- `cursor`: first-party staff say transcript JSONL intentionally excludes tool outputs. Do all Cursor agent-transcript builds at least persist tool inputs on disk, and if so in what exact shape?
+- `copilot`: GitHub documents a complete local session record plus `~/.copilot/session-store.db`, but the exact location of tool results and file-modification detail still needs direct schema confirmation.
+- `kimi`: when does `context.jsonl` remain empty while `wire.jsonl` is populated? Current parser likely needs a `wire.jsonl` fallback or at least a better session-discovery rule.
+
+## Redesign questions
+
+- Should `continues` carry both:
+  - a human summary grouped into read/write/edit/search/shell buckets
+  - and a raw-tool appendix preserving exact upstream names plus argument/result carriers?
+- Should storage adapters declare version families explicitly?
+  - Example: Gemini legacy `.json` vs current JSONL
+  - Example: possible Kilo legacy `ui_messages.json` vs OpenCode-style backend
+- Should the top-of-handoff pointer block include a “raw fidelity class”?
+  - `full`: exact name + args + result + diff metadata available
+  - `partial`: exact name + args only, or UI-layer summary only
+  - `opaque`: no trustworthy raw tool-call storage confirmed

--- a/docs/research/agentlytics-parser-comparison/00-master-summary.md
+++ b/docs/research/agentlytics-parser-comparison/00-master-summary.md
@@ -1,0 +1,79 @@
+# Agentlytics Parser Comparison Master Summary
+
+Access date: 2026-04-15
+
+This directory compares `cli-continues` against `f/agentlytics` across the overlapping parser surfaces and mines reusable parser patterns from adjacent agentlytics editors.
+
+## Document Index
+
+| File | Description |
+| --- | --- |
+| [claude/01-claude-comparison.md](./claude/01-claude-comparison.md) | Claude-specific comparison and mismatches |
+| [codex/01-codex-comparison.md](./codex/01-codex-comparison.md) | Codex-specific comparison and mismatches |
+| [copilot/01-copilot-comparison.md](./copilot/01-copilot-comparison.md) | Copilot-specific comparison and mismatches |
+| [cursor/01-cursor-comparison.md](./cursor/01-cursor-comparison.md) | Cursor-specific comparison and mismatches |
+| [gemini/01-gemini-comparison.md](./gemini/01-gemini-comparison.md) | Gemini-specific comparison and mismatches |
+| [kiro/01-kiro-comparison.md](./kiro/01-kiro-comparison.md) | Kiro-specific comparison and mismatches |
+| [opencode/01-opencode-comparison.md](./opencode/01-opencode-comparison.md) | OpenCode-specific comparison and mismatches |
+| [antigravity-and-adjacent/01-antigravity-comparison.md](./antigravity-and-adjacent/01-antigravity-comparison.md) | Antigravity-specific comparison and mismatches |
+| [antigravity-and-adjacent/02-adjacent-patterns-and-non-overlap-gaps.md](./antigravity-and-adjacent/02-adjacent-patterns-and-non-overlap-gaps.md) | Shared parser ideas and implications for our non-overlap tools |
+
+## Biggest Takeaways
+
+### Where `cli-continues` is ahead
+
+- Documentation discipline is stronger.
+  - Our parser-documentation set usually separates confirmed fact, inference, unresolved uncertainty, and operator guidance better than agentlytics’ code-only surface.
+- Shared rendering/verbosity architecture is stronger.
+  - `src/config/verbosity.ts`, `src/utils/tool-summarizer.ts`, and `src/utils/markdown.ts` are cleaner and more reusable than agentlytics’ adapter-local preview/truncation style.
+- Handoff-specific summarization is stronger.
+  - We generally produce better continuation context once the raw parser has enough truth.
+
+### Where agentlytics is ahead
+
+- Backend ambition is higher.
+  - Agentlytics more often uses secondary stores, migration paths, workspace DBs, or hidden local state instead of stopping at the easiest transcript surface.
+- Analytics extraction is richer.
+  - It preserves more assistant/tool/thinking surface for later analysis, especially for Claude, Codex, Cursor, and OpenCode.
+- Artifact and MCP scanning are stronger.
+  - The shared `base.js` + `index.js` pattern gives agentlytics a reusable artifact/MCP discovery layer that `continues` does not yet have.
+
+## Highest-Confidence Implementation Gaps Revealed By The Comparison
+
+- Gemini parser is still legacy-JSON-only, while our docs are already JSONL-first.
+- Codex parser likely misreads modern `token_count` by expecting top-level fields instead of current nested `payload.info.*`.
+- Copilot parser misses documented `COPILOT_HOME` / `--config-dir` handling and does not exploit native SQLite index surfaces.
+- Cursor parser code still assumes more transcript completeness than our own docs justify.
+- OpenCode parser is SQLite-first, but still under-reads SQLite by dropping non-text parts and DB-native summary/tool signals.
+- Kiro parser still targets the wrong public surface and needs an explicit CLI/ACP split.
+- Antigravity parser still centers the weakest substrate (`code_tracker`) instead of the stronger `.pb` + `brain/` + UI/index-state picture.
+- Shared artifact/MCP discovery is a reusable adjacent pattern we should likely adopt.
+
+## Confidence Map
+
+### Strongly confirmed now
+
+- Claude: our parser is stronger on session reconstruction, but still misses `toolUseResult`
+- Codex: scan `archived_sessions` and fix token-count parsing
+- Copilot: add `COPILOT_HOME` / `--config-dir` and use richer native surfaces
+- Cursor: add an explicit completeness warning and consider a confidence-graded second ingestion path
+- Gemini: move to JSONL-first with replay semantics
+- Kiro: split normal CLI SQLite from ACP JSON/JSONL
+- OpenCode: honor SQLite richness, `OPENCODE_DB`, and non-text parts
+- Antigravity: stop treating `code_tracker` as the safe canonical transcript source
+
+### Still confidence-graded
+
+- Amp local transcript schema/path
+- Droid `projects/...` vs `sessions/...` coexistence/versioning
+- Kilo extension-side legacy artifacts vs canonical live runtime
+- exact same-tool debug UX
+- exact machine-readable prompt-debug shape
+
+## Action Implication
+
+The next implementation pass should use this corpus as a parser-priority input, not just as reference reading. The highest value is not in copying agentlytics. It is in:
+
+1. fixing the high-confidence parser gaps it surfaced
+2. borrowing its shared artifact/MCP/reconstruction patterns where they fit
+3. keeping our stronger documentation discipline and confidence grading

--- a/docs/research/agentlytics-parser-comparison/antigravity-and-adjacent/01-antigravity-comparison.md
+++ b/docs/research/agentlytics-parser-comparison/antigravity-and-adjacent/01-antigravity-comparison.md
@@ -1,0 +1,187 @@
+# Antigravity parser comparison: `continues` vs `agentlytics`
+
+**Scope:** Antigravity-specific storage, message extraction, tool/activity recovery, and artifact/MCP surface comparison between this repo and `f/agentlytics`. This does not attempt to reverse-engineer the full `.pb` schema.
+**Last updated:** 2026-04-15
+
+## 1. Summary
+
+`agentlytics` has the broader Antigravity adapter today. Its `editors/antigravity.js` covers three distinct surfaces: live language-server RPC, offline SQLite-backed trajectory summaries, and project/session artifact discovery. Our parser in `src/parsers/antigravity.ts` only covers one legacy-looking surface: JSON or JSONL line logs under `~/.gemini/antigravity/code_tracker/`.
+
+The deeper problem is not just feature breadth. It is source truth. Current local evidence and our own Antigravity docs under `docs/parser-documentation/*/14-antigravity.md` show that present-day installs expose `~/.gemini/antigravity/conversations/*.pb`, `brain/`, `browser_recordings/`, and a VS Code-like app-data store with `User/globalStorage/state.vscdb`. That contradicts our parser's assumption that `code_tracker` is the primary conversation substrate, but it also means some `agentlytics` assumptions are only partly right: its SQLite path is confirmed, while its MCP config path is wrong on this machine.
+
+Net: `agentlytics` is stronger on extraction, but our repo is stronger on epistemic hygiene because our parser docs explicitly flag uncertainty, split storage/message/tool assumptions apart, and already document the possibility that `code_tracker` is auxiliary rather than canonical.
+
+## 2. Agentlytics parser surface
+
+Primary file: `f/agentlytics/editors/antigravity.js`
+
+- Live session discovery:
+  - `getChats()` calls `GetAllCascadeTrajectories` over the local Antigravity language-server RPC and maps `summary`, `createdTime`, `lastModifiedTime`, workspace folder, step count, and model IDs into chat metadata.
+  - File: `editors/antigravity.js`, around lines 624-650.
+- Live message extraction:
+  - `getSteps()` prefers `GetCascadeTrajectorySteps`, then falls back to `GetCascadeTrajectory`.
+  - `parseStep()` maps many Antigravity/Cortex step types into normalized `user`, `assistant`, and `tool` messages, including planner responses, command runs, file views, code actions, grep, directory listing, and MCP tool steps.
+  - Files: `editors/antigravity.js`, around lines 653-850.
+- Tail recovery:
+  - `getTailMessages()` uses `trajectory.generatorMetadata[].chatModel.messagePrompts` to recover conversation tail content when step lists are truncated.
+  - File: `editors/antigravity.js`, around lines 665-725.
+- Offline fallback:
+  - `readGlobalStateValue()` reads `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb`.
+  - `getOfflineChats()` looks for `antigravityUnifiedStateSync.trajectorySummaries` or `unifiedStateSync.trajectorySummaries`, then decodes nested base64/protobuf-like payloads to recover title, folder, timestamps, and bubble counts.
+  - Files: `editors/antigravity.js`, around lines 232-439.
+- Model normalization and usage:
+  - `GetUserStatus` is used both for model label normalization and for usage/quota extraction.
+  - Files: `editors/antigravity.js`, around lines 35-67 and 857-930.
+- Artifact scanning:
+  - `getArtifacts(folder)` scans `.gemini/skills`, `.gemini/rules`, `.gemini/plans`, `.gemini/workflows`, then joins per-session `brain/<session-id>/{task.md,implementation_plan.md,walkthrough.md}` artifacts back to the workspace folder.
+  - File: `editors/antigravity.js`, around lines 957-1008.
+- MCP discovery:
+  - `getMCPServers()` assumes a global config at `~/.codeium/antigravity/mcp_config.json`.
+  - File: `editors/antigravity.js`, around lines 1010-1017.
+
+Discussion:
+
+- Case for agentlytics:
+  - It matches the product’s public framing better. Google’s launch post describes Antigravity as an agentic platform spanning editor, terminal, browser, manager surface, and artifacts; the `agentlytics` adapter actually tries to read those richer surfaces instead of flattening Antigravity to plain chat text.
+- Case against agentlytics:
+  - Several parts are heuristic or environment-dependent. Live RPC requires a running Antigravity language server. The protobuf decoding is field-number inference, not a published schema. The MCP path assumption is not confirmed by first-party docs and is contradicted locally here.
+
+## 3. Our parser surface
+
+Primary file: `/Users/yigitkonur/dev/cli-continues/src/parsers/antigravity.ts`
+
+- Storage assumption:
+  - `ANTIGRAVITY_BASE_DIR` is hardcoded to `${GEMINI_CLI_HOME|$HOME}/.gemini/antigravity/code_tracker`.
+  - File: `/Users/yigitkonur/dev/cli-continues/src/parsers/antigravity.ts`, lines 13-18.
+- File discovery:
+  - `findSessionFiles()` recursively scans immediate `code_tracker` subdirectories for `*.json` and `*.jsonl`.
+  - File: `/Users/yigitkonur/dev/cli-continues/src/parsers/antigravity.ts`, lines 105-119.
+- Message assumption:
+  - Every useful line is expected to reduce to JSON with `{ type, content, timestamp }` after removing a binary prefix up to the first `{`.
+  - Files: `/Users/yigitkonur/dev/cli-continues/src/parsers/antigravity.ts`, lines 36-68.
+- Session indexing:
+  - Only `type === 'user'` or `type === 'assistant'` entries count.
+  - `cwd` is always empty.
+  - `repo` is derived from the directory name by trimming a trailing hash suffix.
+  - File: `/Users/yigitkonur/dev/cli-continues/src/parsers/antigravity.ts`, lines 138-181.
+- Context extraction:
+  - `extractAntigravityContext()` only returns recent user/assistant messages.
+  - `filesModified`, `pendingTasks`, `toolSummaries`, and `sessionNotes` are always empty.
+  - File: `/Users/yigitkonur/dev/cli-continues/src/parsers/antigravity.ts`, lines 184-234.
+- Documentation surface:
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/14-antigravity.md`
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/14-antigravity.md`
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/14-antigravity.md`
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/14-antigravity.md`
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/14-antigravity.md`
+
+Discussion:
+
+- Case for our parser:
+  - It is small, readable, streamed with `readline`, and conservative about what it emits.
+  - The docs already warn that `code_tracker` may now be auxiliary, which avoids falsely presenting the parser as high-confidence.
+- Case against our parser:
+  - On current local evidence it likely misses real Antigravity sessions entirely, because current conversations are `.pb` files under `~/.gemini/antigravity/conversations/`, not JSON/JSONL transcripts under `code_tracker/`.
+
+## 4. Where agentlytics is stronger
+
+- It treats Antigravity as a multi-surface product, not just a chat log.
+  - Evidence: `editors/antigravity.js` covers live RPC, offline summary cache, artifacts, MCP, and usage.
+- It recovers tool and planner activity.
+  - Our parser emits no tool activity at all; `agentlytics` maps planner responses, tool executions, commands, file views, code actions, grep, list-directory, and MCP steps.
+- It recovers workspace folder identity far better.
+  - Live chats use `summary.workspaces[0].workspaceFolderAbsoluteUri`.
+  - Offline chats derive folder hints from decoded summary payloads.
+  - Our parser sets `cwd: ''` and derives `repo` from hashed directory names.
+- It has a credible offline fallback that is confirmed locally.
+  - Local machine confirmation:
+    - `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb` exists and is a SQLite database.
+    - Querying `ItemTable` shows the exact key `antigravityUnifiedStateSync.trajectorySummaries`.
+- It maps Antigravity’s artifact-centric workflow better.
+  - Google’s launch post explicitly says agents produce artifacts like task lists, implementation plans, screenshots, and browser recordings.
+  - `agentlytics` surfaces `brain/` task docs and scans workspace `.gemini/*` artifacts; our parser ignores all of that.
+
+## 5. Where our parser/docs are stronger
+
+- Our docs separate storage, message schema, tool-call map, access recipes, and handoff pointers into independent documents.
+  - `agentlytics` keeps Antigravity logic in one large adapter file, which is operationally effective but less auditable.
+- Our docs are more explicit about uncertainty.
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/14-antigravity.md`
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/14-antigravity.md`
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/14-antigravity.md`
+  - These already state that `conversations/*.pb` appears primary and `code_tracker` appears auxiliary.
+- Our shared handoff architecture is more disciplined than `agentlytics`’ per-editor flattening.
+  - `/Users/yigitkonur/dev/cli-continues/src/utils/tool-summarizer.ts` centralizes category-aware summaries and file tracking.
+  - `/Users/yigitkonur/dev/cli-continues/src/utils/markdown.ts` centralizes rendering order and section caps.
+  - `/Users/yigitkonur/dev/cli-continues/src/config/verbosity.ts` gives a typed, preset-driven verbosity layer.
+  - `agentlytics` instead embeds truncation, preview, and message-format choices directly inside each editor adapter.
+- Our parser does not currently overclaim live support.
+  - `agentlytics`’ best Antigravity path requires a running editor and local language server. That is powerful, but also operationally brittle.
+
+## 6. Confirmed mismatches
+
+- Confirmed mismatch: our parser’s canonical storage assumption is wrong for the current local install.
+  - Our code:
+    - `/Users/yigitkonur/dev/cli-continues/src/parsers/antigravity.ts`, lines 13-18 and 105-119
+  - Local evidence:
+    - `~/.gemini/antigravity/conversations/*.pb` exists in bulk.
+    - Sample `file` output identifies a `.pb` conversation artifact as binary data.
+    - `~/.gemini/antigravity/code_tracker/active/...` contains hashed file snapshots like `*_CLAUDE.md`, `*.tsx`, and `*.json`, not session transcripts.
+  - Verdict:
+    - `code_tracker` is not the safe default primary transcript source.
+
+- Confirmed mismatch: `agentlytics`’ Antigravity MCP path is wrong on this machine.
+  - Agentlytics code:
+    - `f/agentlytics/editors/antigravity.js`, lines 1010-1017, assumes `~/.codeium/antigravity/mcp_config.json`.
+  - Local evidence:
+    - `~/.codeium/antigravity/` does not exist here.
+    - `~/.gemini/antigravity/mcp_config.json` does exist.
+  - Verdict:
+    - The current `agentlytics` MCP path should be treated as unverified product knowledge, not canonical truth.
+
+- Confirmed mismatch: our parser’s message model is materially narrower than Antigravity’s public product shape.
+  - Our code:
+    - `/Users/yigitkonur/dev/cli-continues/src/parsers/antigravity.ts`, lines 184-234, always returns empty tool summaries, pending tasks, files modified, and session notes.
+  - First-party product evidence:
+    - Google’s launch post says Antigravity agents plan, execute, and verify across editor, terminal, and browser, then communicate via artifacts such as task lists, implementation plans, screenshots, and browser recordings.
+  - Verdict:
+    - Even if our parser found the right transcript surface, its normalization target is still underspecified for Antigravity.
+
+- Confirmed match in favor of agentlytics: the offline SQLite surface is real.
+  - Agentlytics code:
+    - `f/agentlytics/editors/antigravity.js`, lines 232-439.
+  - Local evidence:
+    - `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb` exists.
+    - SQLite `ItemTable` contains `antigravityUnifiedStateSync.trajectorySummaries`.
+  - Verdict:
+    - This is a legitimate local evidence source, even if the protobuf field mapping remains heuristic.
+
+## 7. Still unresolved
+
+- Unresolved: the canonical schema for `~/.gemini/antigravity/conversations/*.pb`.
+  - First-party public docs reviewed here do not publish the protobuf shape.
+- Unresolved: whether `code_tracker` still contains recoverable conversation/session material in some Antigravity builds, or only auxiliary code-tracking artifacts.
+  - Our fixtures and parser imply a legacy or internal variant still exists somewhere.
+- Unresolved: whether `agentlytics`’ protobuf field mapping for offline summaries is stable across Antigravity versions.
+  - The key exists locally, but field-number interpretation was inferred from bytes, not documented upstream.
+- Unresolved: live RPC path verification for Antigravity in this environment.
+  - No Antigravity language-server process was observed during this audit, so `GetAllCascadeTrajectories` / `GetCascadeTrajectorySteps` were not directly exercised here.
+
+## 8. URLs
+
+- `f/agentlytics` Antigravity adapter:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/antigravity.js
+- `f/agentlytics` shared base:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+- `f/agentlytics` editor registry:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+- Google Antigravity launch post:
+  - https://developers.googleblog.com/build-with-google-antigravity-our-new-agentic-development-platform/
+- Google Antigravity docs home:
+  - https://antigravity.google/docs/home
+- Google Antigravity browser docs:
+  - https://antigravity.google/docs/browser
+- Google Gemini CLI tracker service:
+  - https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/trackerService.ts
+- Google Gemini CLI storage paths:
+  - https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/config/storage.ts

--- a/docs/research/agentlytics-parser-comparison/antigravity-and-adjacent/02-adjacent-patterns-and-non-overlap-gaps.md
+++ b/docs/research/agentlytics-parser-comparison/antigravity-and-adjacent/02-adjacent-patterns-and-non-overlap-gaps.md
@@ -1,0 +1,194 @@
+# Adjacent patterns from agentlytics and implications for non-overlap tools
+
+**Scope:** Reusable parser, normalization, artifact, MCP, and summarization patterns from `f/agentlytics` shared/editor layers, with implications for `amp`, `droid`, `crush`, `kilo-code`, `qwen-code`, `cline`, and `roo-code` in this repo.
+**Last updated:** 2026-04-15
+
+## 1. Summary
+
+The main reusable value in `agentlytics` is not its UI or cache DB. It is its willingness to normalize across heterogeneous storage backends by introducing editor-local reconstruction logic before aggregation. The strongest adjacent patterns are:
+
+- reconstructing patch/event logs into durable session state
+- supporting dual-format or dual-backend migrations instead of forcing one canonical store
+- scanning workspace artifacts and MCP configs as first-class context
+- recovering truncated conversation tails from secondary metadata
+- accepting editor-specific tool/result blocks, then projecting them into a shallow common shape
+
+This repo already has a better shared rendering stack than `agentlytics` in `/Users/yigitkonur/dev/cli-continues/src/utils/tool-summarizer.ts`, `/Users/yigitkonur/dev/cli-continues/src/utils/markdown.ts`, and `/Users/yigitkonur/dev/cli-continues/src/config/verbosity.ts`. The gap is not presentation. The gap is backend ambition. Several of our non-overlap tools still parse only the easiest visible transcript while leaving adjacent artifacts, config, or migrated storage formats on the floor.
+
+## 2. Reusable agentlytics shared-layer patterns
+
+### Pattern: reconstruction before normalization
+
+- `f/agentlytics/editors/vscode.js` reconstructs Copilot session state from JSONL patches where `kind: 0` is init and `kind: 1` is path-based patch application.
+- This is stronger than treating JSONL as one-message-per-line text, because it acknowledges that some tools persist state deltas rather than append-only chats.
+- Reusable lesson:
+  - when a source is patch/event based, build a tiny reconstructor first, then reuse the same downstream normalization flow.
+
+### Pattern: multi-source session recovery
+
+- `f/agentlytics/editors/goose.js` reads both SQLite sessions and legacy JSONL sessions.
+- `f/agentlytics/editors/antigravity.js` merges live RPC chats with offline `state.vscdb` trajectory summaries.
+- Reusable lesson:
+  - a parser should support primary plus fallback backends where upstream tools are clearly migrating.
+  - this is especially relevant when local docs or issues already show “old path still in the wild, new path in repo code”.
+
+### Pattern: secondary metadata to repair incomplete message streams
+
+- `f/agentlytics/editors/antigravity.js` and `f/agentlytics/editors/windsurf.js` use `generatorMetadata[].chatModel.messagePrompts` to recover tails missing from step lists.
+- Reusable lesson:
+  - if the obvious event stream is truncated, look for compacted context, prompt history, or step metadata before concluding that chronology is unavailable.
+
+### Pattern: artifact scanning as parser-adjacent, not UI-only
+
+- `f/agentlytics/editors/base.js` defines `scanArtifacts(folder, { files, dirs })`.
+- `f/agentlytics/editors/index.js` aggregates editor-specific artifacts plus shared files like `AGENTS.md`, `.mcp.json`, `plan.md`, `progress.md`, `TODO.md`, `ARCHITECTURE.md`, and `PLANNING.md`.
+- Reusable lesson:
+  - artifacts should be treated as part of session context extraction, even if the core transcript format lacks explicit tool metadata.
+
+### Pattern: MCP config normalization
+
+- `f/agentlytics/editors/base.js` normalizes multiple MCP config shapes and can even query server tool lists.
+- `f/agentlytics/editors/index.js` also scans project-level configs across several editors.
+- Reusable lesson:
+  - MCP visibility should be a shared capability, not reimplemented per parser.
+
+### Pattern: editor-local structural flattening
+
+- `f/agentlytics/editors/zed.js`, `commandcode.js`, and `goose.js` each understand their tool block structures, but they all emit a shallow common shape with `role`, `content`, optional `_toolCalls`, and optional `_model`.
+- Reusable lesson:
+  - preserve editor-specific richness as long as needed, then flatten late.
+
+## 3. Implications for our non-overlap tools (`amp`, `droid`, `crush`, `kilo-code`, `qwen-code`, `cline`, `roo-code`)
+
+### `amp`
+
+- Current local state:
+  - `/Users/yigitkonur/dev/cli-continues/src/parsers/amp.ts` extracts messages and some notes, but it leaves `toolSummaries` empty.
+  - Our own docs already flag storage uncertainty around the local JSON thread store.
+- Adjacent implication:
+  - adopt the “primary plus secondary evidence” pattern.
+  - If Amp has thread web pages and streamed JSON docs, parser design should keep a distinction between local thread JSON and richer runtime/event surfaces.
+
+### `droid`
+
+- Current local state:
+  - `/Users/yigitkonur/dev/cli-continues/src/parsers/droid.ts` is relatively strong already and does extract tool data.
+- Adjacent implication:
+  - Droid is the best candidate for artifact and MCP-layer upgrades.
+  - If Factory’s JSONL already includes compaction and todo state, add adjacent workspace artifact scanning rather than only message parsing.
+
+### `crush`
+
+- Current local state:
+  - `/Users/yigitkonur/dev/cli-continues/src/parsers/crush.ts` emits no files modified, pending tasks, or tool summaries.
+  - Our docs already note DB-first storage.
+- Adjacent implication:
+  - copy Goose’s “dual backend or migration-aware” mindset where applicable.
+  - if Crush’s DB contains richer message-part or tool/result tables than the current extraction uses, the parser should expose them before investing more in markdown output polish.
+
+### `kilo-code`
+
+- Current local state:
+  - Kilo is still handled in `/Users/yigitkonur/dev/cli-continues/src/parsers/cline.ts`.
+  - Our docs already say official Kilo code has moved toward `kilo.db` plus OpenCode-like session/message/part storage.
+- Adjacent implication:
+  - this is the clearest place to copy `agentlytics/editors/goose.js`.
+  - support both legacy `ui_messages.json` and newer DB-backed storage rather than forcing Kilo to remain permanently inside the Cline-family format.
+
+### `qwen-code`
+
+- Current local state:
+  - `/Users/yigitkonur/dev/cli-continues/src/parsers/qwen-code.ts` already uses `SummaryCollector` and is one of the better shared-layer citizens.
+- Adjacent implication:
+  - Qwen Code is a good target for adjacent artifact/MCP scanning because the transcript layer is already decent.
+  - The next gap is broader project context, not raw message parsing.
+
+### `cline`
+
+- Current local state:
+  - `/Users/yigitkonur/dev/cli-continues/src/parsers/cline.ts` extracts reasoning and pending tasks from `ui_messages.json`, but explicitly leaves `toolSummaries` empty.
+- Adjacent implication:
+  - use `commandcode.js` and `zed.js` as examples of block-aware tool-call flattening.
+  - If Cline-family `ui_messages.json` contains richer structured tool events in some versions, parse them into `SummaryCollector` instead of accepting “tool summaries unavailable” as a permanent limit.
+
+### `roo-code`
+
+- Current local state:
+  - Roo Code rides the same Cline-family parser and inherits the same omissions.
+- Adjacent implication:
+  - separate “same current storage family” from “same long-term parser ownership”.
+  - If Roo adds its own metadata or project artifact surface, give it an adapter boundary even if it still reuses Cline event parsing underneath.
+
+## 4. Verbosity/summarization differences
+
+`agentlytics` and this repo solve different problems.
+
+- `agentlytics` favors extraction-first analytics.
+  - It stores normalized messages, tool calls, token counts, and costs into a local cache DB in `cache.js`.
+  - It uses adapter-local previews, line limits, and block flattening to feed analytics and dashboard queries.
+- `continues` favors handoff-quality context.
+  - `/Users/yigitkonur/dev/cli-continues/src/config/verbosity.ts` defines typed caps and presets.
+  - `/Users/yigitkonur/dev/cli-continues/src/utils/tool-summarizer.ts` centralizes tool sample limits and formatting.
+  - `/Users/yigitkonur/dev/cli-continues/src/utils/markdown.ts` centralizes markdown layout and category-aware rendering.
+
+Practical difference:
+
+- `agentlytics` is better at saying "what happened across many sessions and tools?"
+- `continues` is better at saying "what is the right amount of context to hand one session to another agent?"
+
+Recommended synthesis:
+
+- keep our shared verbosity system
+- borrow `agentlytics`’ deeper backend extraction
+- do not copy its adapter-local truncation style into our parsers
+
+## 5. Recommended adoptions or rejections
+
+### Adopt
+
+- Adopt reconstruction helpers for non-append-only formats.
+  - Best precedent: `f/agentlytics/editors/vscode.js`
+  - Likely targets: any parser facing JSONL patch logs or delta-based session state.
+- Adopt migration-aware dual backend support.
+  - Best precedent: `f/agentlytics/editors/goose.js`
+  - Highest-value local targets: `kilo-code`, then possibly `crush`.
+- Adopt a shared artifact scanner in `continues`.
+  - Best precedent: `f/agentlytics/editors/base.js` plus `editors/index.js`
+  - Local gap: we do not currently have a shared artifact-scanning layer for parser context.
+- Adopt shared MCP config discovery as a library utility.
+  - Best precedent: `f/agentlytics/editors/base.js`
+  - Local gap: parser docs repeatedly surface MCP uncertainty, but parser code does not have a shared MCP normalization helper.
+- Adopt secondary-metadata tail recovery where the primary event stream truncates.
+  - Best precedent: `f/agentlytics/editors/antigravity.js` and `editors/windsurf.js`
+  - Local target: any parser with compacted or summarized histories.
+
+### Reject
+
+- Reject copying `agentlytics`’ live-RPC process-scraping approach as a default shared pattern.
+  - It is powerful, but it is editor-process dependent, fragile, and not a safe baseline for `continues`.
+  - If we ever add it, it should be a confidence-graded optional backend, not the canonical parser contract.
+- Reject copying adapter-local preview/truncation rules into our parser files.
+  - We already have a better architecture for that in `/Users/yigitkonur/dev/cli-continues/src/config/verbosity.ts`, `/Users/yigitkonur/dev/cli-continues/src/utils/tool-summarizer.ts`, and `/Users/yigitkonur/dev/cli-continues/src/utils/markdown.ts`.
+- Reject assuming all adjacent tools need one monolithic analytics cache.
+  - `agentlytics/cache.js` makes sense for analytics queries. It is not obviously the right abstraction for `continues`, whose primary deliverable is per-session handoff context.
+
+## 6. URLs
+
+- Agentlytics shared base:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+- Agentlytics editor registry:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+- Agentlytics VS Code adapter:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/vscode.js
+- Agentlytics Windsurf adapter:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/windsurf.js
+- Agentlytics Zed adapter:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/zed.js
+- Agentlytics Command Code adapter:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/commandcode.js
+- Agentlytics Goose adapter:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/goose.js
+- Agentlytics Deno sandboxed entrypoint:
+  - https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- Agentlytics analytics cache:
+  - https://raw.githubusercontent.com/f/agentlytics/master/cache.js

--- a/docs/research/agentlytics-parser-comparison/claude/01-claude-comparison.md
+++ b/docs/research/agentlytics-parser-comparison/claude/01-claude-comparison.md
@@ -1,0 +1,256 @@
+# Claude Parser Comparison: `continues` vs `agentlytics`
+
+**Scope:** Claude Code only. Compares `continues` Claude parser/docs against agentlytics' Claude adapter and cache behavior, then checks both against Anthropic first-party docs/issues and current local Claude storage observations.
+**Last updated:** 2026-04-15
+**Confidence:** High — 10+ independent sources across Anthropic docs/issues, agentlytics first-party repo code, and local Claude storage
+
+## 1. Summary
+
+`continues` is materially stronger than agentlytics on Claude-specific session reconstruction. In [`src/parsers/claude.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/claude.ts), it understands Claude-only sidecars (`subagents/`, `tool-results/`), queue/task events, compacted-history cues, and token/cache accounting from assistant `usage`. Agentlytics' Claude path in `editors/claude.js`, `mod.ts`, and `cache.js` is narrower: it is optimized for chat/session analytics, not faithful session handoff or Claude-specific recovery.
+
+Agentlytics is still stronger in two places. First, it preserves raw assistant messages with inline `[thinking]` and `[tool-call: ...]` markers in a way that is useful for analytics and later SQL queries. Second, it scans Claude project artifacts (`CLAUDE.md`, `.claude/settings*.json`, `.mcp.json`, `.claude/commands`) out of the box, while our Claude parser/docs discuss those files but the parser output itself is centered on transcript reconstruction rather than artifact indexing.
+
+The largest confirmed miss on our side is that we still ignore Claude Code's top-level `toolUseResult` payload even though our docs correctly call it out. The largest confirmed miss on agentlytics' side is that it still treats `sessions-index.json` as a normal metadata source even though Anthropic docs no longer document it and current local Claude storage on this machine does not contain it at all.
+
+## 2. Agentlytics parser surface
+
+### Storage and discovery
+
+- `editors/claude.js` hardcodes `~/.claude/projects` via `os.homedir()` and does **not** honor `CLAUDE_CONFIG_DIR`.
+- It scans each project folder for `.jsonl` files and also tries to load `sessions-index.json` from each project directory.
+- `mod.ts` duplicates the same Claude scan logic for the Deno CLI path, including the `sessions-index.json` assumption.
+- Folder decoding uses `projDir.replace(/-/g, "/")`, which is heuristic and can produce an invalid path if the slugging scheme changes.
+
+### Message reconstruction
+
+- `getMessages()` in `editors/claude.js` only emits `user`, `assistant`, and `system` messages.
+- User tool-result carrier turns are collapsed into normal `role: 'user'` messages via `extractContent()`, which only keeps `text` blocks. When a Claude user turn contains only `tool_result`, agentlytics drops it.
+- Assistant turns are flattened into a single text blob by `extractAssistantContent()`.
+- `thinking` blocks become `[thinking] ...`.
+- `tool_use` blocks become `[tool-call: Name(arg1, arg2)]`, and the raw args are also kept in `_toolCalls`.
+- `tool_result` inside assistant content is handled, but current Claude local observations show the normal pattern is assistant `tool_use` followed by user `tool_result`, so this branch is rarely the critical one.
+
+### Tokens, model, and cache fields
+
+- `editors/claude.js` attaches `_model`, `_inputTokens`, `_outputTokens`, `_cacheRead`, and `_cacheWrite` from `obj.message.usage`.
+- `cache.js` persists those fields into SQLite and aggregates them for per-chat and per-model analytics.
+- `cache.js` also falls back to character-based token estimation when token fields are absent.
+
+### Artifact scanning
+
+- `editors/claude.js#getArtifacts()` scans:
+  - `CLAUDE.md`
+  - `.claude/settings.json`
+  - `.claude/settings.local.json`
+  - `.mcp.json`
+  - `.claude/commands/*`
+- It does not scan `rules/`, `skills/`, `agents/`, `agent-memory/`, or Claude sidecar session folders.
+
+### Summarization / verbosity implications
+
+- Agentlytics stores assistant text largely verbatim, with inline markers for thinking and tool calls.
+- `cache.js` truncates very long stored message content at 50,000 chars.
+- Tool-result detail is lossy by design: assistant-side `tool_result` text is capped to 500 chars in the flattened message string, and user-side Claude `tool_result` is usually lost entirely.
+
+## 3. Our parser surface
+
+### Storage and discovery
+
+- [`src/parsers/claude.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/claude.ts) discovers Claude sessions under `CLAUDE_CONFIG_DIR/projects` or `~/.claude/projects`.
+- It only accepts UUID-named `.jsonl` files and ignores debug files.
+- It does **not** depend on `sessions-index.json`.
+- The storage docs in [`docs/parser-documentation/storage-format/01-claude.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/01-claude.md) align with Anthropic's current `.claude` directory docs on transcripts, `tool-results/`, `file-history/`, and persistence-disable switches.
+
+### Message reconstruction
+
+- `extractClaudeContext()` reads the full JSONL transcript and filters to conversational `user`/`assistant` records.
+- When `separateHumanFromToolResults` is enabled, pure tool-result user carrier turns are excluded from recent conversation. This matches Anthropic's documented tool-use pattern better than agentlytics' generic user-message handling.
+- We also detect `isCompactSummary`, capture the latest compact summary, and optionally chain prior sessions when compaction cues suggest history was collapsed.
+- Queue/task parsing is Claude-aware:
+  - `queue-operation` events
+  - tagged `<task-notification>` payloads
+  - `TaskOutput` tool-result payloads
+  - subagent transcript sidecars in `<session>/subagents/agent-<taskId>.jsonl`
+
+### Tool-call capture
+
+- Claude tool extraction is delegated to [`src/utils/tool-extraction.ts`](/Users/yigitkonur/dev/cli-continues/src/utils/tool-extraction.ts).
+- That helper understands Anthropic-style `tool_use` + `tool_result` pairing and derives structured summaries for shell, read, write, edit, grep, glob, search, fetch, MCP, and task tools.
+- It is better than agentlytics at deriving file modifications and concise handoff summaries.
+- It is still incomplete for Claude Code because it ignores the top-level `toolUseResult` object Anthropic records on user tool-result lines.
+
+### Tokens, model, and cache fields
+
+- `extractSessionNotes()` aggregates model and token usage from assistant `message.usage`.
+- It sums `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens`.
+- That aligns with current local Claude transcripts and Anthropic's prompt-caching concepts, even though Anthropic's public Claude Code docs do not publish a full transcript schema reference.
+
+### Sidecars and artifacts
+
+- `continues` is materially stronger on session sidecars:
+  - `subagents/`
+  - `tool-results/`
+  - compact summaries
+  - predecessor session chaining
+- The docs are also stronger on operator guidance:
+  - [`docs/parser-documentation/access-recipes/01-claude.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/01-claude.md)
+  - [`docs/parser-documentation/handoff-pointers/01-claude.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/01-claude.md)
+- Unlike agentlytics, our Claude parser does not separately index repo instruction artifacts like `CLAUDE.md` or `.claude/commands`; that knowledge currently lives in docs, not parser output.
+
+### Summarization / verbosity implications
+
+- `continues` is intentionally summarizing, not archival:
+  - recent messages are truncated by preset
+  - tool summaries are category-aware and sampled
+  - reasoning highlights are extracted rather than preserved verbatim
+  - subagent outputs are sampled and truncated
+- This is better for handoff readability.
+- It is worse than agentlytics if the goal is raw analytics over nearly verbatim assistant traces.
+
+## 4. Where agentlytics is stronger
+
+### 4.1 Artifact indexing is more explicit
+
+Agentlytics' Claude adapter explicitly scans `CLAUDE.md`, `.claude/settings.json`, `.claude/settings.local.json`, `.mcp.json`, and `.claude/commands/*` in `editors/claude.js`. Our Claude parser/docs know those files matter, but the parser output is transcript-centric. For workspace-level Claude configuration inventory, agentlytics currently exposes more directly.
+
+### 4.2 Raw assistant flattening is better for analytics
+
+`extractAssistantContent()` in `editors/claude.js` preserves assistant thinking and tool calls as inline markers in the assistant message stream. That is crude but queryable. Our parser converts Claude activity into summarized handoff sections, which is better for continuation but weaker for later SQL-style "show me all sessions where Claude thought X and then called Bash Y" analysis.
+
+### 4.3 SQLite analytics path is broader
+
+`cache.js` persists Claude messages, models, token counts, tool names, and derived costs into a queryable cache. `continues` does not offer an equivalent cross-session analytics store for Claude.
+
+## 5. Where our parser/docs are stronger
+
+### 5.1 Claude storage assumptions are more current
+
+Our code and docs treat the JSONL transcript as canonical and avoid relying on `sessions-index.json`. That matches Anthropic's current `.claude` directory docs, which explicitly document `projects/<project>/<session>.jsonl`, `tool-results/`, and `file-history/`, but do not mention `sessions-index.json`.
+
+### 5.2 Claude session reconstruction is meaningfully deeper
+
+`continues` handles:
+
+- compact summaries and history chaining
+- user tool-result carrier filtering
+- queue operations
+- tagged task notifications
+- `TaskOutput` reconciliation
+- subagent transcript harvesting
+- sidecar `tool-results/` previews
+
+Agentlytics handles none of those Claude-only recovery paths.
+
+### 5.3 Our docs identify a real Claude fidelity gap that agentlytics also misses
+
+[`docs/parser-documentation/tool-call-map/01-claude.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/01-claude.md) correctly states that Claude Code adds a top-level `toolUseResult` object with richer structured data than plain `tool_result.content`. Agentlytics ignores that distinction entirely. Our code also still ignores it, but our documentation is at least correctly pointed at the real problem.
+
+### 5.4 Our operator guidance is much stronger
+
+The storage, schema, access-recipe, and handoff-pointer docs give a Claude-specific operational model that agentlytics does not provide:
+
+- storage layout
+- compact-summary cues
+- sidecar inspection commands
+- persistence caveats
+- session pointer guidance
+
+That is a real advantage for maintenance and future parser fixes.
+
+## 6. Confirmed mismatches
+
+### 6.1 Agentlytics assumes `sessions-index.json` is normal metadata; that is not supported by current Anthropic docs
+
+- Agentlytics reads `projects/<project>/sessions-index.json` in both `editors/claude.js` and `mod.ts`.
+- Anthropic's current `.claude` directory docs enumerate application-data paths and do not include `sessions-index.json`.
+- On this machine, `find ~/.claude/projects -maxdepth 2 -name 'sessions-index.json'` returned no matches on 2026-04-15.
+- First-party Anthropic issue `#25032` shows `sessions-index.json` can be stale enough to break `claude --resume`, which makes it a risky primary metadata source even if it exists in some versions.
+
+**Conclusion:** agentlytics' index support is defensible as backward-compatibility, but not as a current Claude storage assumption.
+
+### 6.2 Agentlytics does not honor `CLAUDE_CONFIG_DIR`
+
+- `continues` uses `CLAUDE_CONFIG_DIR` in [`src/parsers/claude.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/claude.ts).
+- Anthropic docs explicitly state that every `~/.claude` path moves under `CLAUDE_CONFIG_DIR` if set.
+- Agentlytics hardcodes `~/.claude`.
+
+**Conclusion:** this is a confirmed correctness gap in agentlytics for non-default Claude installations.
+
+### 6.3 Agentlytics loses the normal Claude `tool_result` half of the turn
+
+- Anthropic tool-use docs describe the pattern as assistant `tool_use` followed by client-supplied `tool_result`.
+- Current local Claude transcripts on this machine show `tool_result` blocks on `type: "user"` lines, not assistant lines.
+- Agentlytics' `extractContent()` only preserves `text` blocks in user messages, so a user turn that contains only `tool_result` becomes empty and is dropped.
+
+**Conclusion:** agentlytics captures the tool call name and args, but usually not the actual Claude tool result body unless it can infer it elsewhere.
+
+### 6.4 Our code still ignores Claude's top-level `toolUseResult`
+
+- Current local Claude transcripts include `toolUseResult` with structured data such as `stdout`, `stderr`, `filenames`, `durationMs`, `structuredPatch`, and related metadata.
+- [`src/utils/tool-extraction.ts`](/Users/yigitkonur/dev/cli-continues/src/utils/tool-extraction.ts) only reads `tool_result.content`.
+- Our own Claude tool-call doc explicitly says this is a gap.
+
+**Conclusion:** our docs are right, our implementation is not yet aligned.
+
+### 6.5 Our storage-format doc understates current implementation strength on `tool-results/`
+
+- [`docs/parser-documentation/storage-format/01-claude.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/01-claude.md) says `continues` does not model `tool-results/`.
+- Current code in [`src/parsers/claude.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/claude.ts) does parse `tool-results/` previews into `sessionNotes.externalToolResults`.
+
+**Conclusion:** the doc is partially stale relative to the current parser.
+
+### 6.6 Agentlytics has no Claude-side compaction or subagent awareness
+
+- Anthropic hooks docs explicitly expose `PreCompact` and `PostCompact`, including `compact_summary` and `transcript_path`.
+- Anthropic subagent docs describe concurrent/background subagents, and current local Claude storage contains `<session>/subagents/*.jsonl`.
+- `continues` has explicit compaction and subagent handling in [`src/parsers/claude.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/claude.ts).
+- Agentlytics does not inspect sidecar subagent folders or compact-summary markers.
+
+**Conclusion:** agentlytics' Claude view is shallow for resumed or delegated sessions.
+
+## 7. Still unresolved
+
+- Anthropic publicly documents the `.claude` directory layout, compaction hooks, and subagent concepts, but it still does not publish a full line-by-line Claude transcript schema. Some conclusions therefore still rely on local observation.
+- The exact spill threshold or routing rule for when Claude writes large outputs into `tool-results/` instead of keeping them inline is not documented.
+- `sessions-index.json` appears in Anthropic issues but not current docs or current local storage here. It is unclear whether it is version-gated, platform-gated, or being phased out.
+- Anthropic docs do not currently document the full shape of `toolUseResult`, even though current local transcripts clearly contain it.
+
+See [99-open-issues.md](/Users/yigitkonur/dev/cli-continues/docs/research/agentlytics-parser-comparison/claude/99-open-issues.md) for the remaining unresolved questions.
+
+## 8. URLs
+
+### Anthropic first-party
+
+- https://code.claude.com/docs/en/claude-directory
+- https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/hooks
+- https://code.claude.com/docs/en/sub-agents
+- https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview
+- https://github.com/anthropics/claude-code/issues/25032
+- https://github.com/anthropics/claude-code/issues/22365
+- https://github.com/anthropics/claude-code/issues/3833
+
+### Agentlytics first-party
+
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/claude.js
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+- https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- https://raw.githubusercontent.com/f/agentlytics/master/cache.js
+
+### Local files compared
+
+- /Users/yigitkonur/dev/cli-continues/src/parsers/claude.ts
+- /Users/yigitkonur/dev/cli-continues/src/utils/tool-extraction.ts
+- /Users/yigitkonur/dev/cli-continues/src/types/schemas.ts
+- /Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/01-claude.md
+- /Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/01-claude.md
+- /Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/01-claude.md
+- /Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/01-claude.md
+- /Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/01-claude.md
+
+### Local Claude storage observations used as evidence
+
+- `~/.claude/projects/.../*.jsonl` samples observed on 2026-04-15
+- `~/.claude/projects/.../<session>/subagents/*.jsonl` samples observed on 2026-04-15
+- `~/.claude/projects/.../<session>/tool-results/*` samples observed on 2026-04-15

--- a/docs/research/agentlytics-parser-comparison/claude/99-open-issues.md
+++ b/docs/research/agentlytics-parser-comparison/claude/99-open-issues.md
@@ -1,0 +1,71 @@
+# Open Issues For Claude Comparison
+
+**Scope:** Remaining Claude-specific questions that neither `continues` nor agentlytics can fully settle from current first-party docs alone.
+**Last updated:** 2026-04-15
+**Confidence:** Medium — grounded by current docs and local observation, but blocked by missing upstream schema documentation
+
+## Open questions
+
+### 1. Is `sessions-index.json` still live, transitional, or deprecated?
+
+**Why it matters:** agentlytics reads it as a normal metadata source, while `continues` ignores it.
+
+**What is known**
+
+- Anthropic issue `#25032` shows the file existed and could become stale enough to break `claude --resume`.
+- Current Anthropic `.claude` directory docs do not list it.
+- Current local Claude storage on this machine did not contain it on 2026-04-15.
+
+**Current best judgment**
+
+Treat `sessions-index.json` as optional legacy or transitional state, not canonical storage.
+
+### 2. What exactly determines `tool-results/` spillover?
+
+**Why it matters:** both tools need to know whether large outputs are only an optimization or are necessary for lossless recovery.
+
+**What is known**
+
+- Anthropic docs explicitly say large tool outputs can spill into `projects/<project>/<session>/tool-results/`.
+- Current local storage contains multiple such files.
+- Anthropic does not document the threshold or routing logic.
+
+**Current best judgment**
+
+A Claude parser that ignores `tool-results/` cannot claim full-fidelity session recovery.
+
+### 3. Is `toolUseResult` stable enough to parse as a real schema?
+
+**Why it matters:** this is the largest currently unparsed Claude-specific fidelity surface in `continues`, and agentlytics ignores it too.
+
+**What is known**
+
+- Current local Claude transcripts include top-level `toolUseResult` objects with structured fields like `stdout`, `stderr`, `filenames`, `durationMs`, and other tool-specific payloads.
+- Anthropic public docs do not yet document this object.
+
+**Current best judgment**
+
+The field is real and valuable, but parser support should be guarded with tolerant schema handling because upstream has not published a stable contract.
+
+### 4. How much of Claude compaction can be reconstructed from transcripts alone?
+
+**Why it matters:** `continues` chains prior sessions heuristically; agentlytics does not try.
+
+**What is known**
+
+- Anthropic hooks docs expose `PreCompact` and `PostCompact`, plus `compact_summary`.
+- Current local transcripts contain `isCompactSummary`.
+- Anthropic does not document deterministic predecessor linkage between compacted and prior sessions.
+
+**Current best judgment**
+
+Our current predecessor chaining is useful but heuristic, not guaranteed.
+
+## Sources
+
+- https://code.claude.com/docs/en/claude-directory
+- https://code.claude.com/docs/en/hooks
+- https://github.com/anthropics/claude-code/issues/25032
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/claude.js
+- /Users/yigitkonur/dev/cli-continues/src/parsers/claude.ts
+- /Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/01-claude.md

--- a/docs/research/agentlytics-parser-comparison/codex/01-codex-comparison.md
+++ b/docs/research/agentlytics-parser-comparison/codex/01-codex-comparison.md
@@ -1,0 +1,196 @@
+# Codex Parser Comparison: `continues` vs Agentlytics
+
+**Scope:** Codex-only comparison between this repo's parser/docs and Agentlytics' Codex handling, checked against first-party OpenAI Codex docs, repo code, and one first-party discussion.
+**Last updated:** 2026-04-15
+**Confidence:** High for confirmed code-path differences; Medium where rollout persistence policy may vary by Codex version or event-persistence mode.
+
+## 1. Summary
+
+`continues` and Agentlytics are both partly right and partly incomplete for modern Codex rollouts.
+
+- Agentlytics' main Node adapter at `https://raw.githubusercontent.com/f/agentlytics/master/editors/codex.js` is stronger on turn reconstruction, token deltas, and archived-session discovery.
+- `continues` is stronger on modern Codex storage documentation, prompt-hygiene filtering, `apply_patch`/file-write summarization, and on explicitly documenting what its parser still misses.
+- Agentlytics' Deno scanner at `https://raw.githubusercontent.com/f/agentlytics/master/mod.ts` appears stale for current Codex rollout files. It assumes a flat top-level chat shape that conflicts with OpenAI's current `session_meta` / `turn_context` / `event_msg` / `response_item` rollout format.
+- `continues`' parser at [/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts) has one likely schema bug: it reads `event_msg.token_count` from top-level `input_tokens` / `output_tokens`, while OpenAI's current first-party protocol nests those under `payload.info.last_token_usage` and `payload.info.total_token_usage`.
+
+## 2. Agentlytics parser surface
+
+### Main Node adapter: `editors/codex.js`
+
+Documented from `https://raw.githubusercontent.com/f/agentlytics/master/editors/codex.js` and `https://raw.githubusercontent.com/f/agentlytics/master/cache.js`:
+
+- Storage assumptions:
+  - Scans both `CODEX_HOME/sessions` and `CODEX_HOME/archived_sessions` recursively (`codex.js`, lines 11-27, 42-48).
+  - Requires first line to be `session_meta` and uses `payload.id`, `payload.cwd`, `payload.source`, `payload.originator`, `payload.cli_version`, and `payload.model_provider` (`codex.js`, lines 76-118).
+- Session discovery:
+  - Deduplicates by `composerId`, so if the same thread appears in active and archived trees it keeps the first seen file (`codex.js`, lines 11-27).
+  - Titles sessions from the first non-bootstrap user `response_item.message` (`codex.js`, lines 83-93).
+- Message reconstruction:
+  - Uses `turn_context` as turn boundaries and model source (`codex.js`, lines 150-158).
+  - Reconstructs user messages from `response_item.message(role=user)` and assistant turns from assistant messages, reasoning summaries, tool calls, and tool outputs (`codex.js`, lines 161-199, 280-320).
+  - Emits synthetic assistant content like `[thinking] ...`, `[tool-call: ...]`, and `[tool-result: ...]`.
+- Tool-call capture:
+  - Captures `function_call`, `custom_tool_call`, and `web_search_call`; captures paired outputs via `call_id`; stores normalized tool calls in `_toolCalls` and later in Agentlytics SQLite `tool_calls` (`codex.js`, lines 187-199, 298-320; `cache.js`, lines 272-290).
+- Token/model handling:
+  - Reads model from `turn_context` and token events from `event_msg.token_count.info.last_token_usage` / `total_token_usage` with delta recovery (`codex.js`, lines 204-227).
+  - Stores per-message `_model`, `_inputTokens`, `_outputTokens`, `_cacheRead` and aggregates them into analytics tables (`cache.js`, lines 293-317).
+- Audit-log / summarization implications:
+  - Stronger for analytics because it persists normalized messages, models, token totals, and tool call rows in SQLite (`cache.js`, lines 223-319).
+  - More lossy for handoff fidelity because raw rollout item types are flattened into synthetic assistant text.
+
+### Deno sandboxed scanner: `mod.ts`
+
+Documented from `https://raw.githubusercontent.com/f/agentlytics/master/mod.ts`:
+
+- It scans `sessions` and `archived_sessions`, but expects the first JSONL line to expose top-level `id`, `instructions`, `created_at`, and `cwd` (`mod.ts`, lines 438-447).
+- It counts Codex messages with `obj.type === "message" || obj.role` and looks for `obj.model` on top-level rows (`mod.ts`, lines 430-445).
+
+That shape does not match current first-party Codex rollout files, which OpenAI documents and codes as JSONL lines with top-level `type` plus nested payloads such as `session_meta`, `turn_context`, `event_msg`, `response_item`, and `compacted`. Source: OpenAI rollout recorder and protocol definitions in `codex-rs/rollout/src/recorder.rs`, `codex-rs/protocol/src/protocol.rs`, and `ResponseItem.ts`, accessed 2026-04-15.
+
+## 3. Our parser surface
+
+### Parser implementation
+
+Documented from [/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts):
+
+- Storage assumptions:
+  - Scans `CODEX_HOME/sessions` recursively only, not `archived_sessions` ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L29), [codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L36), [codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L93)).
+  - Derives session ID and created timestamp from the rollout filename, not from `session_meta.payload.id` ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L76)).
+- Session discovery:
+  - Uses `session_meta.payload.cwd` and `git.repository_url` / `git.branch` to derive repo metadata ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L103)).
+  - Uses the first `event_msg.user_message` encountered in the first 150 lines as session summary seed, with a legacy fallback for older flat `message` rows ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L45)).
+- Message reconstruction:
+  - Collects `event_msg` and `response_item` separately, then prefers `response_item` if present ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L398)).
+  - Keeps only plain user/assistant conversational text in `recentMessages`; explicitly skips system-injected user content starting with `<environment_context>`, `<permissions`, or `# AGENTS.md` ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L419)).
+  - Does not inject tool-call/result pseudo-lines into the conversation tail.
+- Tool-call capture:
+  - Joins `function_call_output` and `custom_tool_call_output` by `call_id` ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L205)).
+  - Summarizes `exec_command`, `write_stdin`, MCP reads/listing, `request_user_input`, `update_plan`, `view_image`, general MCP-like tool names, `custom_tool_call` including `apply_patch`, and `web_search_call` ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L221)).
+  - Tracks probable file writes from shell redirection and `apply_patch`, and computes diff stats for patches ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L173), [codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L293)).
+- Token/model handling:
+  - Stores only the first `turn_context.model` into `sessionNotes.model` ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L355)).
+  - Reads `token_count` from top-level `payload.input_tokens` / `payload.output_tokens` and optional top-level `reasoning_output_tokens` ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L372)).
+- Audit-log / summarization implications:
+  - Optimized for concise cross-tool handoff, not full-fidelity analytics.
+  - Balanced-tail trimming intentionally avoids long assistant-only tails but can omit older assistant activity before the last user message ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L454)).
+
+### Repo documentation surface
+
+The local Codex docs are materially broader than the implementation:
+
+- Storage docs:
+  - [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/02-codex.md)
+  - [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/02-codex.md)
+  - [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/02-codex.md)
+- Message/tool schema docs:
+  - [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/02-codex.md)
+  - [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/02-codex.md)
+
+Those docs already acknowledge several gaps the parser still has:
+
+- no `archived_sessions` scanning
+- no modeling of `compacted`
+- no handling of `local_shell_call`, `tool_search_call`, or `tool_search_output`
+- no exposure of broader `CODEX_HOME` stores like `history.jsonl`, session index, or SQLite state in the parser output
+
+## 4. Where Agentlytics is stronger
+
+- Archived-session coverage is better in `editors/codex.js` because it scans both active and archived rollout trees, which matches OpenAI's first-party rollout code constants `SESSIONS_SUBDIR` and `ARCHIVED_SESSIONS_SUBDIR`. Sources: `codex.js` lines 11-27; `codex-rs/rollout/src/lib.rs`, lines 17-18.
+- Token accounting is better in `editors/codex.js` because it follows OpenAI's current `TokenCountEvent.info.last_token_usage` / `total_token_usage` structure and computes deltas from totals when needed. Sources: `codex.js` lines 204-227; OpenAI `protocol.rs` lines 2074-2158.
+- Turn reconstruction is richer in `editors/codex.js` because it folds reasoning summaries and tool call/result previews into assistant turns. That makes its downstream analytics and SQLite cache more audit-friendly than `continues`' plain-text recent-tail handoff. Sources: `codex.js` lines 181-199, 247-257, 280-320; `cache.js` lines 241-319.
+- Session analytics are stronger in Agentlytics because `cache.js` normalizes messages, token counts, model usage, and tool calls into queryable tables, while `continues` emits handoff-oriented markdown and lightweight summaries instead. Source: `cache.js` lines 223-319.
+
+## 5. Where our parser/docs are stronger
+
+- The local docs are closer to current first-party Codex storage reality than Agentlytics' public Deno scanner. Our docs explicitly distinguish rollout JSONL, `history.jsonl`, archived sessions, and SQLite-backed state, while `mod.ts` still assumes a flat `first.id` / `first.instructions` / `first.created_at` layout. Sources: local docs listed above; `mod.ts` lines 438-447; OpenAI config docs on `CODEX_HOME`, `history.jsonl`, and `sqlite_home`, accessed 2026-04-15.
+- Prompt hygiene is stronger in `continues`. The parser filters not just `<environment_context>` but also `<permissions...>` and injected `# AGENTS.md` blocks from user-message reconstruction ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L425)). Agentlytics only filters `<user_instructions>` and `<environment_context>` (`codex.js`, lines 289-292).
+- Patch/file-write summarization is stronger in `continues`. It recognizes `apply_patch`, extracts touched files, preserves diff text, computes diff stats, and also heuristically tracks shell redirection writes ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L173), [codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L293)). Agentlytics stores generic tool args and tool names but does not compute patch diff stats.
+- The docs are more self-auditing. `/docs/parser-documentation/.../02-codex.md` repeatedly says where the implementation is incomplete instead of silently implying full coverage. Agentlytics' shipped `mod.ts` and `codex.js` do not annotate their own Codex blind spots in code.
+
+## 6. Confirmed mismatches
+
+### A. Agentlytics `mod.ts` is incompatible with current Codex rollout structure
+
+**Documented:** OpenAI's current rollout format uses `session_meta`, `turn_context`, `event_msg`, `response_item`, and `compacted` as top-level line types, with nested payloads. Sources: OpenAI `recorder.rs`; `protocol.rs`; `ResponseItem.ts`.
+
+**Observed:** `mod.ts` expects top-level `id`, `instructions`, `created_at`, `cwd`, and counts `obj.type === "message" || obj.role` for Codex (`mod.ts`, lines 430-447).
+
+**Conclusion:** `mod.ts` is stale for current Codex JSONL and should not be treated as authoritative parser behavior for modern Codex rollouts.
+
+### B. `continues` misses `archived_sessions`
+
+**Documented:** OpenAI rollout code defines both `sessions` and `archived_sessions`, and Agentlytics `codex.js` scans both. Sources: `codex-rs/rollout/src/lib.rs`, lines 17-18; `codex.js`, lines 11-27.
+
+**Observed:** [/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L29) hardcodes only `.../.codex/sessions`.
+
+**Conclusion:** This is a real discovery gap in `continues`, not just a documentation gap.
+
+### C. `continues` token parsing likely does not match current first-party `token_count`
+
+**Documented:** OpenAI's `TokenCountEvent` is `payload.info`, with `total_token_usage` and `last_token_usage`; token counts are nested there, including `reasoning_output_tokens`. Source: `protocol.rs`, lines 2074-2158.
+
+**Observed:** `continues` reads `payload.input_tokens`, `payload.output_tokens`, and top-level `reasoning_output_tokens` in `event_msg.token_count` ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L372)). The local Zod schema also encodes that flatter assumption in [/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts](/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts#L63).
+
+**Counterpoint:** The local docs mention observed Codex rollouts but do not publish a contradictory raw `token_count` sample.
+
+**Conclusion:** Until a live current rollout proves otherwise, this looks like a genuine parser/schema bug in `continues`.
+
+### D. Both implementations under-capture official response-item variants
+
+**Documented:** OpenAI's generated `ResponseItem` type includes `local_shell_call`, `tool_search_call`, `tool_search_output`, `image_generation_call`, `ghost_snapshot`, and `compaction` in addition to the classic function/custom/web-search items. Source: `ResponseItem.ts`, lines 14-18.
+
+**Observed:**
+
+- `continues` only handles `function_call`, `function_call_output`, `custom_tool_call`, `custom_tool_call_output`, and `web_search_call` as response-item tools ([codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L227), [codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L293), [codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L320)).
+- Agentlytics `codex.js` only recognizes `function_call`, `custom_tool_call`, `web_search_call`, and paired outputs (`codex.js`, lines 298-304).
+
+**Conclusion:** Both parsers lag the full first-party response-item surface, though our docs already say so explicitly.
+
+### E. Our docs are ahead of our parser on Codex protocol coverage
+
+**Documented in repo docs:** The local docs explicitly state that `continues` does not yet model `compacted`, `local_shell_call`, `tool_search_call`, or `tool_search_output`, and that `archived_sessions` / SQLite / index files exist.
+
+**Observed in code:** Those gaps are real in the parser.
+
+**Conclusion:** The repo's Codex documentation is currently more accurate than the implementation in several areas.
+
+## 7. Still unresolved
+
+- Whether current real-world Codex rollout files ever duplicate token counters at top level on `event_msg.token_count` in addition to the documented nested `info` object. First-party protocol says nested; a current raw rollout sample would close this decisively.
+- Whether every official `ResponseItem` variant in `ResponseItem.ts` is actually persisted to rollout JSONL under current persistence policy, or whether some exist in protocol but are gated by recorder policy. OpenAI's recorder policy code would need a narrower review or a live sample set.
+- Whether Agentlytics intends `mod.ts` to remain a supported Codex path or only as a lightweight fallback beside the richer Node adapter.
+
+Open issues are tracked in [99-open-issues.md](/Users/yigitkonur/dev/cli-continues/docs/research/agentlytics-parser-comparison/codex/99-open-issues.md).
+
+## 8. URLs
+
+### Local repo files
+
+- [/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts)
+- [/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts](/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts)
+- [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/02-codex.md)
+- [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/02-codex.md)
+- [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/02-codex.md)
+- [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/02-codex.md)
+- [/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/02-codex.md](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/02-codex.md)
+
+### Agentlytics
+
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/codex.js
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+- https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- https://raw.githubusercontent.com/f/agentlytics/master/cache.js
+
+### First-party OpenAI Codex evidence
+
+- https://developers.openai.com/codex/cli/features
+- https://developers.openai.com/codex/config-advanced
+- https://developers.openai.com/codex/config-reference
+- https://github.com/openai/codex/blob/main/codex-rs/rollout/src/lib.rs
+- https://github.com/openai/codex/blob/main/codex-rs/rollout/src/list.rs
+- https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder.rs
+- https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs
+- https://github.com/openai/codex/blob/main/codex-rs/state/src/extract.rs
+- https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts
+- https://github.com/openai/codex/discussions/3827

--- a/docs/research/agentlytics-parser-comparison/codex/99-open-issues.md
+++ b/docs/research/agentlytics-parser-comparison/codex/99-open-issues.md
@@ -1,0 +1,62 @@
+# Open Issues: Codex Parser Comparison
+
+**Scope:** Remaining Codex-specific uncertainties after comparing `continues` and Agentlytics against first-party OpenAI Codex evidence.
+**Last updated:** 2026-04-15
+**Confidence:** Medium
+
+## 1. Does current `event_msg.token_count` ever flatten token counters at top level?
+
+**Why it matters:** [/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts#L372) and [/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts](/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts#L63) assume `input_tokens`, `output_tokens`, and `reasoning_output_tokens` may appear directly on `payload`.
+
+**What first-party evidence says:** OpenAI's current protocol defines `TokenCountEvent` as:
+
+- `info.total_token_usage`
+- `info.last_token_usage`
+- each usage object carrying `input_tokens`, `cached_input_tokens`, `output_tokens`, `reasoning_output_tokens`, `total_tokens`
+
+Source: `https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs` (lines 2074-2158 in the 2026-04-15 read).
+
+**Competing interpretation:** A live rollout from some Codex versions might still include compatibility fields at the top level.
+
+**What would close it:** Inspect a fresh raw rollout JSONL line with `type: "event_msg"` and `payload.type: "token_count"` from a current Codex session.
+
+## 2. Which official `ResponseItem` variants are actually persisted in rollout JSONL today?
+
+**Why it matters:** Both parsers currently ignore some first-party response-item variants, but protocol presence is not identical to guaranteed persistence.
+
+**What first-party evidence says:** OpenAI's generated `ResponseItem` union includes:
+
+- `local_shell_call`
+- `tool_search_call`
+- `tool_search_output`
+- `image_generation_call`
+- `ghost_snapshot`
+- `compaction`
+
+Source: `https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts`
+
+**Competing interpretation:** The recorder's persistence policy may omit some item types depending on event-persistence mode or rollout policy.
+
+**What would close it:** Review the exact recorder policy code for `is_persisted_response_item` or sample current rollouts that exercise those paths.
+
+## 3. Is Agentlytics `mod.ts` still intended to support modern Codex, or is `editors/codex.js` the real supported path?
+
+**Why it matters:** The repo ships two materially different Codex code paths.
+
+**Observed:**
+
+- `editors/codex.js` understands `session_meta`, `turn_context`, `response_item`, and `event_msg.token_count`.
+- `mod.ts` still assumes flat top-level `id`, `instructions`, `created_at`, and `cwd`.
+
+**Inferred risk:** The Deno "sandboxed edition" may underreport or mislabel current Codex sessions even if the full Node path works.
+
+**What would close it:** Agentlytics README or release notes explicitly stating whether `mod.ts`'s Codex support is current, best-effort, or intentionally degraded.
+
+## Sources
+
+- https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs
+- https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/codex.js
+- https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- [/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts](/Users/yigitkonur/dev/cli-continues/src/parsers/codex.ts)
+- [/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts](/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts)

--- a/docs/research/agentlytics-parser-comparison/copilot/01-copilot-comparison.md
+++ b/docs/research/agentlytics-parser-comparison/copilot/01-copilot-comparison.md
@@ -1,0 +1,115 @@
+# Copilot parser/docs comparison: `continues` vs agentlytics
+
+## 1. Summary
+
+Both codebases are grounded in Copilot CLI's per-session `events.jsonl` stream under `session-state/`, and both infer extra structure from local files that GitHub does not fully specify. The main difference is emphasis: `continues` is more conservative for handoff generation and documents the native Copilot storage model more accurately, while agentlytics is stronger at session-wide analytics once a session has already been discovered.
+
+The biggest confirmed gaps are shared. Neither `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` nor `https://raw.githubusercontent.com/f/agentlytics/master/editors/copilot.js` honors documented `COPILOT_HOME` / `--config-dir` overrides, and neither uses Copilot's native `session-store.db` tables (`sessions`, `turns`, `session_files`) for discovery or fallback. Both also underuse the raw event stream by ignoring `tool.execution_*` result events even though those events are present in local `events.jsonl`.
+
+## 2. Agentlytics parser surface
+
+Agentlytics has two Copilot surfaces:
+
+- `https://raw.githubusercontent.com/f/agentlytics/master/editors/copilot.js`
+- `https://raw.githubusercontent.com/f/agentlytics/master/mod.ts`
+
+`editors/copilot.js` is the fuller parser. It reads `~/.copilot/session-state/<id>/workspace.yaml` and `events.jsonl`, skips sessions without `workspace.yaml`, skips sessions whose `user.message` + `assistant.message` count is zero, derives the session model from the first `session.shutdown`, and emits all user and assistant messages from the full event log. It also extracts tool calls from `assistant.message.data.toolRequests[]`, preserves raw tool names and parsed args, and aggregates `session.shutdown.data.modelMetrics` token totals into the first assistant message. In `cache.js`, those `_toolCalls`, `_inputTokens`, `_outputTokens`, and `_cacheRead` fields are persisted into agentlytics' own derived SQLite cache.
+
+`mod.ts` is materially weaker for Copilot. Its `scanCopilot()` scanner only counts `user.message` and `assistant.message`, does not parse messages at all, and pushes a session row for every subdirectory under `~/.copilot/session-state/` even when `workspace.yaml` or `events.jsonl` are missing. That means the Deno "sandboxed edition" can overcount empty or partial sessions that the full adapter would drop.
+
+`editors/index.js` registers the full Copilot adapter under `copilot-cli`. `editors/base.js` provides shared helpers but no Copilot-specific path resolution for `COPILOT_HOME` or `--config-dir`.
+
+## 3. Our parser surface
+
+`/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` is narrower than agentlytics' full adapter but cleaner for handoff use. It:
+
+- discovers sessions only in `~/.copilot/session-state/`
+- requires `workspace.yaml` to exist before considering a directory a session
+- computes bytes/line counts from `events.jsonl`
+- filters final sessions to `bytes > 0`
+- extracts the selected model from `session.start.data.selectedModel`
+- builds handoff context from recent `user.message` and `assistant.message` events only
+- summarizes tool usage only from `assistant.message.data.toolRequests[]`
+- records modified files only when a tool name maps to `write` or `edit` through `classifyToolName()`
+
+The surrounding docs are substantially broader than the parser:
+
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/03-copilot.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/03-copilot.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/03-copilot.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/03-copilot.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/03-copilot.md`
+
+Those docs correctly call out `session-store.db`, native raw-vs-index separation, `COPILOT_HOME`, `--config-dir`, `session.db`, `rewind-snapshots`, and the fact that `events.jsonl` is append-only and can span multiple `session.resume` segments.
+
+## 4. Where agentlytics is stronger
+
+- `https://raw.githubusercontent.com/f/agentlytics/master/editors/copilot.js` extracts session-wide token metrics from `session.shutdown.data.modelMetrics`. `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` does not expose any token or cache-read counts.
+- Agentlytics preserves raw tool names and raw parsed args in `_toolCalls`, then persists them through `https://raw.githubusercontent.com/f/agentlytics/master/cache.js`. `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` keeps raw names in samples, but it also collapses them into generic categories for file-mod tracking and drops tools in `SKIP_TOOLS`.
+- Agentlytics reads the full conversation, not just a recent window. That is better for retrospective analytics and cost accounting, even if it is noisier for handoff.
+- Agentlytics attaches a first-session-wide model and token picture from `session.shutdown`; that is useful when the goal is dashboards rather than precise replay.
+
+## 5. Where our parser/docs are stronger
+
+- The docs in `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/.../03-copilot.md` track GitHub's first-party storage docs more accurately than agentlytics does. They explicitly separate native raw storage (`session-state/<id>/events.jsonl`) from the native index (`session-store.db`), which matches GitHub's docs and the local `sessions` / `turns` / `session_files` tables.
+- Our docs explicitly mention the documented config-root overrides `COPILOT_HOME` and `--config-dir`. Agentlytics hardcodes `~/.copilot` in both `editors/copilot.js` and `mod.ts`.
+- `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` is safer than agentlytics' `mod.ts` scanner for session discovery because it requires `workspace.yaml` and excludes sessions with zero `events.jsonl` bytes.
+- Our docs correctly note that `session.db` is not the main transcript store. On this machine, sampled per-session `session.db` files mostly contain `todos` and `todo_deps`, while the global `session-store.db` holds normalized `sessions`, `turns`, and `session_files`.
+- For handoff, our truncation and recent-message focus are intentional. That loses fidelity, but it avoids flooding the downstream agent with Copilot-specific hook noise that appears in raw logs.
+
+## 6. Confirmed mismatches
+
+### Storage assumptions
+
+- GitHub documents `~/.copilot` as the default config dir, but also documents `COPILOT_HOME` and `--config-dir` overrides. Neither `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` nor `https://raw.githubusercontent.com/f/agentlytics/master/editors/copilot.js` nor `https://raw.githubusercontent.com/f/agentlytics/master/mod.ts` honors those overrides.
+- GitHub documents `session-store.db` as a native SQLite store for cross-session indexing and search. Local verification shows populated `sessions`, `turns`, and `session_files` tables. Neither parser uses it.
+- `workspace.yaml` is real and widely present locally, but GitHub's public docs only guarantee `events.jsonl` plus "workspace artifacts". So both parsers rely on a de facto file that is not yet a formally documented contract.
+
+### Session discovery
+
+- `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` only discovers directories with `workspace.yaml`, then filters out zero-byte `events.jsonl`. This is conservative and misses any future session variant that lacks either assumption.
+- `https://raw.githubusercontent.com/f/agentlytics/master/editors/copilot.js` also requires `workspace.yaml`, but then additionally drops sessions with no user/assistant messages.
+- `https://raw.githubusercontent.com/f/agentlytics/master/mod.ts` is looser than both: it emits a session row for every directory under `session-state/`, even if the session has no `workspace.yaml` and no messages. This is a real internal agentlytics mismatch between its two Copilot implementations.
+
+### Transcript completeness
+
+- Both parsers only treat `user.message` and `assistant.message` as conversational content.
+- Local Copilot logs also contain `tool.execution_start`, `tool.execution_complete`, `hook.start`, `hook.end`, `assistant.turn_start`, `assistant.turn_end`, `session.resume`, and `session.shutdown`.
+- This matters because `tool.execution_complete` contains tool results, and those results can be large and semantically important. `assistant.message.data.toolRequests[]` only describes intended tool invocations, not what actually happened.
+- Agentlytics partially compensates by embedding `[tool-call: name(keys)]` placeholders into assistant content and storing `_toolCalls`, but it still does not ingest `tool.execution_complete` outputs.
+- `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` currently states that "Copilot doesn't provide tool results," which is contradicted by local `events.jsonl` evidence showing `tool.execution_complete.data.result`.
+
+### Subset / index surfaces
+
+- Native Copilot already exposes normalized subsets: `session-store.db.sessions`, `turns`, and `session_files`.
+- Agentlytics ignores those native subsets, then creates its own derived `cache.db` message and tool-call index in `https://raw.githubusercontent.com/f/agentlytics/master/cache.js`.
+- `continues` ignores both the native SQLite index and any derived index; it works only from raw per-session files.
+- Native `session_files` is materially richer than our current file-mod tracking because it carries `file_path`, `tool_name`, and `turn_index`, whereas `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` only infers modified files from tool names classified as write/edit inside `assistant.message.data.toolRequests[]`.
+
+### Verbosity / summarization implications
+
+- Agentlytics favors completeness. It reads the full session, persists messages, and stores up to 50k characters per message in its cache. This is better for dashboards and mining, but it also preserves Copilot hook noise and synthetic tool-call placeholders inside assistant content.
+- `continues` favors handoff brevity. It only reads the recent tail, trims the final conversation window, truncates session summaries to 60 chars, and truncates tool sample argument JSON to 100 chars. That is usually better for continuation prompts, but weaker for forensic replay.
+- Agentlytics' token attribution is convenient but coarse. Because aggregate `session.shutdown.modelMetrics` totals are attached to the first assistant message, downstream analytics can easily misread session-level totals as turn-level totals.
+
+## 7. Still unresolved
+
+- Whether GitHub intends `workspace.yaml` to remain stable enough for parser contracts, or whether tooling should degrade to `events.jsonl` + `session-store.db` when it is absent.
+- Whether Copilot's public docs will eventually specify a canonical location for tool results and file modifications beyond the current high-level statement that session data includes them.
+- Whether `session.db` will stay mostly todo-oriented or gain broader transcript semantics in future Copilot versions.
+- Whether `session.resume` boundaries should be preserved in handoff output or compacted into a single logical transcript.
+
+See `99-open-issues.md` for action-oriented follow-ups.
+
+## 8. URLs
+
+- GitHub Docs, Copilot CLI config directory: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference
+- GitHub Docs, Copilot CLI chronicle concepts: https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+- GitHub Docs, Copilot CLI chronicle how-to: https://docs.github.com/en/copilot/how-tos/copilot-cli/chronicle
+- GitHub issue #2396, persisted session-state fields: https://github.com/github/copilot-cli/issues/2396
+- GitHub issue #2209, long-lived resumed sessions: https://github.com/github/copilot-cli/issues/2209
+- agentlytics full Copilot adapter: https://raw.githubusercontent.com/f/agentlytics/master/editors/copilot.js
+- agentlytics shared editor helpers: https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+- agentlytics editor registry: https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+- agentlytics Deno scanner: https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- agentlytics derived cache layer: https://raw.githubusercontent.com/f/agentlytics/master/cache.js

--- a/docs/research/agentlytics-parser-comparison/copilot/99-open-issues.md
+++ b/docs/research/agentlytics-parser-comparison/copilot/99-open-issues.md
@@ -1,0 +1,71 @@
+# Open issues for Copilot parser comparison
+
+## 1. Native path resolution
+
+Question: should `/Users/yigitkonur/dev/cli-continues/src/parsers/copilot.ts` support `COPILOT_HOME` and `--config-dir` parity with GitHub's documented config-root rules?
+
+Why it is open:
+
+- GitHub documents both overrides.
+- The current parser hardcodes `~/.copilot/session-state`.
+- Agentlytics hardcodes the same path, so external comparison does not settle the intended behavior.
+
+Likely answer:
+
+- Yes. This is a confirmed parser gap, not just a docs nicety.
+
+## 2. Discovery fallback via `session-store.db`
+
+Question: should session discovery and indexing fall back to native SQLite tables when `workspace.yaml` or `events.jsonl` is missing, partial, or too large?
+
+Why it is open:
+
+- GitHub documents `session-store.db` for cross-session indexing and search.
+- Local evidence shows populated `sessions`, `turns`, and `session_files` tables.
+- Some session directories contain `workspace.yaml` and `session.db` but no `events.jsonl`.
+
+Likely answer:
+
+- Yes for discovery and enrichment; maybe no for canonical transcript replay. The SQLite store looks like a native subset/index surface, not the full-fidelity raw log.
+
+## 3. Tool-result fidelity
+
+Question: should the parser ingest `tool.execution_complete` and hook events instead of relying only on `assistant.message.data.toolRequests[]`?
+
+Why it is open:
+
+- Local `events.jsonl` shows `tool.execution_complete.data.result`.
+- Current `continues` docs and parser still assume Copilot does not provide tool results.
+- Agentlytics also stops at `toolRequests`, so comparison does not provide a stronger alternative.
+
+Likely answer:
+
+- Yes, at least behind a verbosity gate. Tool results are present, but ingesting them blindly could bloat handoffs.
+
+## 4. File modification source of truth
+
+Question: should modified-file tracking come from native `session_files` instead of inferred write/edit tool calls?
+
+Why it is open:
+
+- Local `session-store.db.session_files` rows include `file_path`, `tool_name`, and `turn_index`.
+- Current `continues` tracking depends on `classifyToolName()` recognizing a tool as write/edit.
+- Unknown tools currently fall into `mcp`, so true file changes can be missed.
+
+Likely answer:
+
+- Yes for accuracy, with raw-event inference retained as fallback when the SQLite index is stale or absent.
+
+## 5. Resume segmentation
+
+Question: should resumed Copilot sessions remain segmented in downstream output?
+
+Why it is open:
+
+- First-party issue #2209 shows real sessions with multiple `session.resume` segments in one `events.jsonl`.
+- Neither parser models those boundaries explicitly.
+- For analytics, compaction may be fine. For replay/debugging, segment boundaries can explain odd context resets and inflated line counts.
+
+Likely answer:
+
+- Preserve them internally; decide at render time whether to compact or expose them.

--- a/docs/research/agentlytics-parser-comparison/cursor/01-cursor-comparison.md
+++ b/docs/research/agentlytics-parser-comparison/cursor/01-cursor-comparison.md
@@ -1,0 +1,214 @@
+# Cursor Parser Comparison: `cli-continues` vs `agentlytics`
+
+## 1. Summary
+
+This comparison is only about Cursor.
+
+`cli-continues` currently centers Cursor support on local `agent-transcripts` JSONL files in [`/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts). Its documentation set under:
+
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/07-cursor.md)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/07-cursor.md)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/07-cursor.md)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/07-cursor.md)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/07-cursor.md)
+
+is materially more careful than the code about transcript incompleteness, export-vs-local ambiguity, and warning needs.
+
+`agentlytics` splits Cursor into two different adapters:
+
+- `editors/cursor.js`
+- `editors/cursor-agent.js`
+
+That split is important. `editors/cursor.js` is materially stronger than `cli-continues` when undocumented local Cursor stores exist, because it reads:
+
+- `~/.cursor/chats/<workspace>/<chatId>/store.db`
+- `Cursor/User/workspaceStorage/...`
+- `Cursor/User/globalStorage/state.vscdb`
+
+and can recover tool calls, some tool results, model hints, token counts, and richer assistant content. On this machine, `~/.cursor/chats/.../store.db` does exist and contains richer data than the transcript JSONL.
+
+But `agentlytics` is also materially less conservative. It converts undocumented Cursor internals into analytics-friendly message streams without the warning layer that `cli-continues` already documents as necessary. Its `cursor-agent` adapter is especially lossy: it assumes transcript JSONL is basically text-only and does not attempt block-aware tool extraction at all.
+
+Bottom line:
+
+- For current warning quality and export/local caveat handling, `cli-continues` docs are stronger.
+- For completeness on machines where `store.db` and/or Cursor DB state exist, `agentlytics` is stronger.
+- For the current `cli-continues` implementation, there is a confirmed code/docs mismatch: the code still assumes Anthropic-style transcript completeness more strongly than the docs and first-party Cursor evidence justify.
+
+## 2. Agentlytics parser surface
+
+Relevant files:
+
+- `https://github.com/f/agentlytics/blob/master/editors/cursor.js`
+- `https://github.com/f/agentlytics/blob/master/editors/cursor-agent.js`
+- `https://github.com/f/agentlytics/blob/master/editors/index.js`
+- `https://github.com/f/agentlytics/blob/master/cache.js`
+- `https://github.com/f/agentlytics/blob/master/mod.ts`
+- `https://github.com/f/agentlytics/blob/master/editors/base.js`
+
+Observed behavior:
+
+- `editors/cursor.js` reads two undocumented Cursor storage families.
+- Source 1 is `~/.cursor/chats/<workspace>/<chatId>/store.db`.
+- Source 2 is VS Code-style Cursor app storage under `Cursor/User/workspaceStorage` plus `Cursor/User/globalStorage/state.vscdb`.
+- `editors/cursor.js` reconstructs tree/blob-backed messages from `store.db`, parses OpenAI-style `tool_calls`, preserves `_toolCalls`, and attaches `_model` when present.
+- `editors/cursor.js` also reads `toolFormerData`, `thinking`, `tokenCount`, and truncated `result` previews from composer bubbles in DB-backed state.
+- `cache.js` persists those extracted `_toolCalls`, token counts, and model names into analytics tables and aggregates them into top-tool/top-model stats.
+- `editors/cursor-agent.js` separately scans `~/.cursor/projects/*/agent-transcripts`, supports both flat and nested JSONL layout, strips wrappers like `<user_query>`, and turns transcript rows into plain `user`/`assistant` text messages.
+- `editors/cursor-agent.js` does not extract tool blocks or tool results from transcript block types. It only handles `text` blocks and synthetic `[file: ...]` references from embedded tags.
+- `mod.ts` still carries an older Cursor scanner that labels Cursor as “file-based chats only, no SQLite,” which is now narrower than `editors/cursor.js`.
+
+Local confirmation on this machine:
+
+- `~/.cursor/chats/.../store.db` exists.
+- Example exact path: `~/.cursor/chats/0607b860e9c8a921340e6e5f8fa63415/ca38930e-96e0-413f-a36f-65a7f0322657/store.db`
+- Its `meta.key='0'` payload decodes to JSON containing `agentId`, `latestRootBlobId`, `name`, `mode`, `createdAt`, `lastUsedModel`, and `currentPlanUri`.
+- Blob rows in that same DB contain richer JSON than the paired transcript file, including assistant `reasoning` content and Cursor tool-call records such as `{"type":"tool-call","toolName":"Write",...}`.
+
+Discussion:
+
+- Case for agentlytics being right: Cursor clearly has richer local state than transcript JSONL alone. The local `store.db` proves that on this machine.
+- Case against agentlytics overclaiming: none of those richer stores are publicly documented by Cursor Help docs, and the app-data database paths are missing on this machine even though Cursor still works. So `agentlytics` is reading real data, but from unstable, undocumented surfaces.
+
+## 3. Our parser surface
+
+Relevant files:
+
+- [`/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/07-cursor.md)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/07-cursor.md)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/07-cursor.md)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/07-cursor.md)
+- [`/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/07-cursor.md`](/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/07-cursor.md)
+
+Observed behavior:
+
+- The parser only scans `~/.cursor/projects/<slug>/agent-transcripts/...jsonl`.
+- It infers `cwd` from the encoded project slug.
+- It derives summary text from the first real user text block.
+- It feeds every transcript row into shared Anthropic-style extraction via `extractAnthropicToolData(...)`.
+- It also assumes `usage` and `model` passthrough fields may exist on assistant rows and aggregates them if found.
+- For recent messages, it only keeps `text` blocks and drops everything else.
+- It emits no explicit warning inside the parser output that Cursor transcript completeness may be partial.
+
+Documented behavior in this repo is more cautious than the implementation:
+
+- The docs explicitly say first-party Cursor evidence supports local `agent-transcripts` existence but not a full stable schema.
+- The docs explicitly separate local `agent-transcripts` from exported/shared transcript behavior.
+- The docs explicitly record first-party forum statements that JSONL transcript/export behavior may omit `tool_use` and is expected to omit `tool_result`.
+- The docs explicitly recommend a handoff-level completeness warning before normalized tool summaries.
+
+Local confirmation on this machine:
+
+- `~/.cursor/projects/.../agent-transcripts/*.jsonl` exists.
+- Example exact path: `~/.cursor/projects/Users-yigitkonur-dev-test-cli-continues/agent-transcripts/16f31a93-4d65-4b9d-bad9-bb082f4aa56e.jsonl`
+- The sampled transcript rows on this machine are text-only at the block level.
+- In the sampled JSONL, `.message.content[]` entries are all `{"type":"text",...}`.
+- That means the parser’s current Anthropic-style tool extraction path is not evidenced by the local sample files read for this review.
+
+Discussion:
+
+- Case for our parser being right: Cursor staff did say on 2026-04-13 that JSONL transcript files include tool call inputs, so the shared Anthropic-style path could match some newer sessions.
+- Case against our parser being right today: the current code assumes more than the local sample and more than Cursor’s export/tool-output caveats justify. The docs already admit this.
+
+## 4. Where agentlytics is stronger
+
+- It uses more than one local storage surface. `editors/cursor.js` reads `store.db`, workspace storage, and global DB state; [`/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts) only reads transcript JSONL.
+- It can recover richer message structure when `store.db` exists. On this machine, `store.db` contains assistant reasoning and tool-call objects that are not present in the paired transcript file.
+- It has a more realistic path for tool-input completeness, because `normalizeStoreMessage()` and `bubblesToMessages()` persist `_toolCalls` from internal Cursor objects rather than waiting for transcript JSONL to contain matching Anthropic blocks.
+- It captures some tool-output signal. `bubblesToMessages()` appends a truncated `[tool-result: ...]` preview from `toolFormerData.result`, while `cli-continues` currently has no alternative source for tool outputs.
+- It captures more verbosity-sensitive metadata: model hints, token counts, tool counts, file references, and thinking text.
+- It recognizes both flat and nested transcript layouts in `editors/cursor-agent.js`; `cli-continues` effectively supports both because it scans depth 2 for `.jsonl`, but its docs and implementation language still frame the nested `<uuid>/<uuid>.jsonl` pattern as the primary one.
+
+## 5. Where our parser/docs are stronger
+
+- The documentation is substantially more honest about uncertainty. The Cursor docs set in this repo repeatedly labels observed facts, inference, and unresolved uncertainty instead of flattening them into one parser story.
+- The docs explicitly compare local transcript behavior against exported/shared transcript behavior. `agentlytics` code does not make that distinction visible.
+- The docs explicitly warn that tool fidelity may be incomplete and that transcript-only summaries can look more complete than the source warrants.
+- The docs cite first-party Cursor forum posts about:
+  - transcript files living under `.cursor/projects/.../agent-transcripts`
+  - UI recovery depending on `state.vscdb` and `workspaceStorage`
+  - JSONL omitting tool outputs
+  - export still dropping command/file-edit content in March 2026
+- The current `cli-continues` scope is narrower but easier to defend from first-party public evidence. `agentlytics` is stronger operationally, but its SQLite and KV assumptions are much more reverse-engineered.
+- Warning implications are better handled here, at least in docs. This repo already identifies the need for a top-of-handoff completeness warning before normalized tool summaries. `agentlytics` converts hidden-store data into analytics without an equivalent trust banner.
+
+## 6. Confirmed mismatches
+
+### A. `cli-continues` code overstates Cursor transcript structure relative to its own docs
+
+Confirmed mismatch:
+
+- [`/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts) routes transcript rows through `extractAnthropicToolData(...)` and assumes `usage`/`model` passthroughs may meaningfully populate handoff output.
+- But this repo’s own Cursor docs say local transcript samples were text-only and that first-party Cursor statements do not support transcript completeness for tool results.
+- The first-party March 14 and March 25 forum threads say JSONL/export may still contain only text or omit agent command/file-edit data entirely.
+
+Why this matters:
+
+- Current handoff summaries can imply a normalized tool history that the raw transcript did not actually preserve.
+- This is not just a data-loss problem; it is a trust problem. The parser may make Cursor look more transcript-complete than Cursor is.
+
+### B. `agentlytics` has an internal split-brain Cursor model
+
+Confirmed mismatch:
+
+- `editors/cursor.js` treats Cursor as a multi-source hidden-state system with `store.db`, workspace DBs, and global DBs.
+- `editors/cursor-agent.js` treats Cursor agent transcripts as a separate text-oriented source.
+- `mod.ts` still describes Cursor as “file-based chats only, no SQLite.”
+
+Why this matters:
+
+- There is not one agentlytics Cursor story; there are at least three layers of it.
+- Consumers can easily misread `agentlytics` as having a single stable Cursor adapter when its own codebase shows an evolving, partially overlapping model.
+
+### C. `agentlytics cursor-agent` understates transcript richness whenever transcript blocks regain tool inputs
+
+Confirmed mismatch:
+
+- On 2026-04-13, Cursor staff said JSONL transcript files include tool call inputs but intentionally omit tool outputs.
+- `editors/cursor-agent.js` only reads `text` blocks and never inspects non-text transcript content types.
+
+Why this matters:
+
+- If Cursor has already restored `tool_use`-like blocks in some builds, `cursor-agent.js` will miss them even when they are present.
+- So agentlytics is simultaneously stronger than `cli-continues` on hidden stores and weaker than it could be on transcript blocks.
+
+### D. Export behavior remains materially less complete than local hidden-state behavior
+
+Confirmed mismatch:
+
+- Cursor Help docs on shared transcripts describe what is shareable and explicitly note what is not shared.
+- Cursor forum threads in January and March 2026 still report exported transcripts omitting command/file-edit/thinking content.
+- `agentlytics` relies on local hidden stores for richer reconstruction; `cli-continues` relies on local transcript JSONL; neither implementation should treat exported transcript behavior as equivalent to local data completeness.
+
+Why this matters:
+
+- “Transcript completeness” is not one thing in Cursor. Local hidden stores, local `agent-transcripts`, exported transcripts, and shared transcripts do not have the same fidelity.
+
+## 7. Still unresolved
+
+- Whether current local `agent-transcripts` broadly include restored tool-input blocks in April 2026, or whether Cursor staff’s April 13 statement only reflects some builds or some transcript paths.
+- Whether local `agent-transcripts` and exported transcript JSONL share the same serializer. First-party evidence currently suggests they do not behave the same, but Cursor has not published a schema or lifecycle document.
+- Whether `~/.cursor/chats/.../store.db` is a durable modern Cursor source or an implementation detail that could disappear. It exists on this machine, but it is not documented by public Cursor docs.
+- Whether the missing `Cursor/User/globalStorage/state.vscdb` and `workspaceStorage` paths on this machine mean agentlytics’ DB-backed source 2 is stale on macOS, optional, or simply absent for this install.
+- Whether `cli-continues` should add a second Cursor ingestion path for `store.db`, or whether that would violate the project’s current “publicly supportable evidence first” posture.
+
+See `99-open-issues.md` for the testable follow-ups.
+
+## 8. URLs
+
+- Cursor shared transcripts docs: https://cursor.com/help/ai-features/shared-transcripts
+- Cursor hooks docs: https://cursor.com/docs/hooks
+- Cursor forum, “Where are cursor chats stored?”: https://forum.cursor.com/t/where-are-cursor-chats-stored/77295
+- Cursor forum, “Chat history not loading after VS Code Settings Sync, possible state inconsistency”: https://forum.cursor.com/t/chat-history-not-loading-after-vs-code-settings-sync-possible-state-inconsistency/150559
+- Cursor forum, “Lost all cursor settings and chat history for all projects I am working on :-(”: https://forum.cursor.com/t/lost-all-cursor-settings-and-chat-history-for-all-projects-i-am-working-on/151081
+- Cursor forum, “.jsonl format should fully record the tool_use information”: https://forum.cursor.com/t/jsonl-format-should-fully-record-the-tool-use-information/154777
+- Cursor forum, “Accessing the Full Agent Transcript in Cursor”: https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311
+- Cursor forum, “Transcripts no longer exported in full”: https://forum.cursor.com/t/transcripts-no-longer-exported-in-full/150214
+- Cursor forum, “Exporting transcript doesn't export agent commands”: https://forum.cursor.com/t/exporting-transcript-doesnt-export-agent-commands/155837
+- agentlytics `cursor.js`: https://raw.githubusercontent.com/f/agentlytics/master/editors/cursor.js
+- agentlytics `cursor-agent.js`: https://raw.githubusercontent.com/f/agentlytics/master/editors/cursor-agent.js
+- agentlytics `base.js`: https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+- agentlytics `index.js`: https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+- agentlytics `mod.ts`: https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- agentlytics `cache.js`: https://raw.githubusercontent.com/f/agentlytics/master/cache.js

--- a/docs/research/agentlytics-parser-comparison/cursor/99-open-issues.md
+++ b/docs/research/agentlytics-parser-comparison/cursor/99-open-issues.md
@@ -1,0 +1,96 @@
+# Cursor Open Issues For This Comparison
+
+## 1. Do modern local `agent-transcripts` now include tool-input blocks consistently?
+
+Why unresolved:
+
+- Cursor staff wrote on 2026-03-14 that `.jsonl` had dropped `tool_use` and a fix should land in a later release.
+- Cursor staff wrote on 2026-04-13 that JSONL transcript files include tool call inputs but not tool outputs.
+- The local transcript samples inspected for this review were still text-only.
+
+What to test next:
+
+- Generate a fresh Cursor agent session on a current stable build that definitely invokes file-edit and shell tools.
+- Inspect the raw `~/.cursor/projects/<slug>/agent-transcripts/...jsonl` immediately.
+- Record whether block types include non-text tool entries, and whether `model`/`usage` passthroughs are present.
+
+Why it matters:
+
+- This decides whether [`/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts`](/Users/yigitkonur/dev/cli-continues/src/parsers/cursor.ts) is merely ahead of the docs or genuinely over-assuming the source.
+
+## 2. Are local `agent-transcripts` and exported transcripts produced by the same pipeline?
+
+Why unresolved:
+
+- First-party forum evidence shows exported transcripts still missing command/file-edit content in March 2026.
+- First-party forum replies about local JSONL transcript files suggest more local information may exist.
+- Cursor Help docs document sharing/export semantics but not local storage schema.
+
+What to test next:
+
+- Run one session.
+- Compare:
+  - raw local `agent-transcripts` JSONL
+  - exported transcript JSONL/text from the UI
+  - shared transcript content
+- Diff for tool inputs, tool outputs, thinking, and file-edit details.
+
+Why it matters:
+
+- Both parsers need to avoid importing export assumptions into local-parser confidence.
+
+## 3. How durable is `~/.cursor/chats/.../store.db` as a supported local source?
+
+Why unresolved:
+
+- It exists and is useful on this machine.
+- `agentlytics` gets real value from it.
+- Cursor public docs do not document it.
+
+What to test next:
+
+- Check multiple Cursor versions and clean installs on macOS, Linux, and Windows.
+- Confirm whether `store.db` is always present for agent sessions, only present on some modes, or a transitional artifact.
+- Track whether `agentId` in `store.db.meta` always matches transcript/session IDs.
+
+Why it matters:
+
+- This is the strongest current source for richer Cursor recovery, but also the least publicly supportable one.
+
+## 4. Is agentlytics’ DB-backed source 2 still valid on current macOS installs?
+
+Why unresolved:
+
+- `editors/cursor.js` expects:
+  - `~/Library/Application Support/Cursor/User/workspaceStorage`
+  - `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`
+- Those paths were absent on this machine during review.
+- First-party recovery threads still mention `state.vscdb` and `workspaceStorage`.
+
+What to test next:
+
+- Verify on a current macOS install with known Composer chats.
+- Determine whether the paths moved, are created lazily, or are only present in some install modes.
+
+Why it matters:
+
+- If source 2 is stale, agentlytics is strongest mainly because of `store.db`, not because of its app-data DB recovery path.
+
+## 5. Should `cli-continues` add a documented warning gate before any Cursor tool summary?
+
+Why unresolved:
+
+- The docs already say yes in substance.
+- The parser code still emits normalized tool summaries with no Cursor-specific warning block.
+
+What to test next:
+
+- Prototype a handoff banner that always appears for Cursor:
+  - raw transcript path
+  - completeness caveat
+  - explicit note that tool outputs may be absent
+- Evaluate whether that is enough without adding a second ingestion path.
+
+Why it matters:
+
+- This is the lowest-risk way to align code behavior with documented Cursor uncertainty.

--- a/docs/research/agentlytics-parser-comparison/gemini/01-gemini-comparison.md
+++ b/docs/research/agentlytics-parser-comparison/gemini/01-gemini-comparison.md
@@ -1,0 +1,290 @@
+# Gemini parser comparison: `cli-continues` vs agentlytics
+
+**Scope:** Gemini only. Compares the current local Gemini parser/docs in this repo against agentlytics' Gemini parser behavior, then checks both against first-party Gemini CLI code and docs.
+**Last updated:** 2026-04-15
+**Confidence:** High for parser-code comparisons and Gemini upstream storage behavior; Medium for exact release-cutover timing because first-party docs and code disagree on some path details.
+
+## Summary
+
+Both implementations are still primarily **legacy-Gemini JSON parsers**, not current **append-only JSONL** parsers.
+
+- `cli-continues` local parser at `/Users/yigitkonur/dev/cli-continues/src/parsers/gemini.ts` scans `session-*.json` under `~/.gemini/tmp/*/chats/` plus legacy `~/.gemini/sessions/*.json`, parses a full `messages[]` object, and then builds a handoff-oriented summary.
+- agentlytics full adapter at `https://raw.githubusercontent.com/f/agentlytics/master/editors/gemini.js` also scans `session-*.json` under `~/.gemini/tmp/*/chats/`, parses the same legacy object shape, and feeds messages into analytics storage.
+- agentlytics' Deno "sandboxed edition" path in `https://raw.githubusercontent.com/f/agentlytics/master/mod.ts` is materially different again: it looks for `.jsonl` files directly under `~/.gemini/tmp/<project>/`, not under `chats/`, and expects line records with `role` and `parts`. That does **not** match current first-party Gemini chat-recording code, which writes JSONL under `.../chats/` and uses metadata/message/update/rewind records rather than simple `{ role, parts }` lines.
+
+The biggest difference between the projects is that this repo's Gemini documentation is ahead of both code paths. The docs under:
+
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/04-gemini.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/04-gemini.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/04-gemini.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/04-gemini.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/04-gemini.md`
+
+already describe the upstream JSONL migration, `$set` metadata updates, and `$rewindTo` markers from the first-party `google-gemini/gemini-cli` code. agentlytics has no comparable Gemini-specific documentation in the inspected surface.
+
+## Agentlytics parser surface
+
+### 1. Full adapter: `editors/gemini.js`
+
+`https://raw.githubusercontent.com/f/agentlytics/master/editors/gemini.js`
+
+- Session discovery:
+  - Reads `~/.gemini/projects.json`.
+  - Scans `~/.gemini/tmp/<proj>/chats/session-*.json`.
+  - Does **not** scan `.jsonl`.
+  - Does **not** honor `GEMINI_CLI_HOME`.
+- Project mapping:
+  - Correctly reverses `projects.json` into `Map<shortId, folderPath>` and populates `folder`.
+- Message reconstruction:
+  - Converts `user` to `role: 'user'`.
+  - Converts `gemini` to `role: 'assistant'`.
+  - Preserves assistant text plus prepends `[thinking] ...` lines from `thoughts`.
+  - Appends `[tool-call: <name>(<argKeys>)]` markers into assistant content.
+  - Emits `info` / `error` / `warning` as `role: 'system'`.
+- Tool capture:
+  - Stores `_toolCalls` with exact `name` and raw `args`.
+  - Stores `_model`, `_inputTokens`, `_outputTokens`, `_cacheRead`.
+  - Does not preserve tool result payloads, `resultDisplay`, tool-call IDs, descriptions, status, or agent IDs.
+- Rewind / metadata handling:
+  - None. It expects a complete legacy JSON object with `record.messages`.
+
+### 2. Registry/integration: `editors/index.js`, `cache.js`, `editors/base.js`
+
+- `https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js`
+  - Registers the Gemini adapter and routes `getMessages(chat)` to it.
+- `https://raw.githubusercontent.com/f/agentlytics/master/cache.js`
+  - Persists Gemini-derived assistant messages, token fields, and `_toolCalls` into SQLite analytics tables.
+  - This gives agentlytics stronger cross-session analytics once parsing succeeds: tool frequency, dominant models, estimated cost, project rollups.
+- `https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js`
+  - Shared helpers only; no Gemini-specific storage logic beyond common artifact and MCP parsing.
+
+### 3. Separate Deno surface: `mod.ts`
+
+`https://raw.githubusercontent.com/f/agentlytics/master/mod.ts`
+
+- Scans `~/.gemini/tmp/<proj>/*.jsonl`, not `~/.gemini/tmp/<proj>/chats/*.jsonl`.
+- Expects each JSONL line to look like chat history with `role === "user" | "model"` and `parts[0].text`.
+- Uses filename as `composerId`.
+- This is inconsistent with first-party `chatRecordingService.ts`, which writes:
+  - initial partial metadata record
+  - message records with `id`, `type`, `content`
+  - metadata updates via `$set`
+  - rewind markers via `$rewindTo`
+  - all under `.../chats/*.jsonl`
+
+So agentlytics currently has **two** Gemini behaviors:
+
+- the main Node adapter, which matches legacy `.json`
+- the Deno edition, which attempts `.jsonl` but not the real Gemini recorder format
+
+## Our parser surface
+
+### 1. Parser: `/Users/yigitkonur/dev/cli-continues/src/parsers/gemini.ts`
+
+- Session discovery:
+  - Honors `GEMINI_CLI_HOME` via `process.env.GEMINI_CLI_HOME || homeDir()`.
+  - Scans `~/.gemini/tmp/<project>/chats/session-*.json`.
+  - Scans legacy `~/.gemini/sessions/*.json`.
+  - Does **not** scan `.jsonl`.
+- Schema assumptions:
+  - `/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts` requires a single JSON object containing `sessionId`, `projectHash`, `startTime`, `lastUpdated`, and `messages[]`.
+  - This matches legacy Gemini session blobs, not current JSONL append logs.
+- Message reconstruction:
+  - User messages: extracts text from `content`.
+  - Assistant messages: only adds a recent message when `extractGeminiContent(msg.content)` is non-empty.
+  - `info` / `error` / `warning` are ignored in recent conversation extraction.
+  - Tool-call-only Gemini messages are therefore omitted from `recentMessages`.
+- Tool capture:
+  - Stronger than agentlytics for handoff fidelity.
+  - Summarizes tool activity with `SummaryCollector`.
+  - Uses `resultDisplay.fileDiff`, `diffStat`, `isNewFile`, shell output tails, fetch previews, exact tool names, and file-path inference.
+  - Extracts `filesModified`.
+- Session notes:
+  - Aggregates model, input/output tokens, cached tokens, thinking tokens, and reasoning highlights from `thoughts`.
+- Project/root recovery:
+  - Leaves `cwd` empty even though Gemini maintains `~/.gemini/projects.json` and project temp directories are keyed by a project identifier.
+  - This is weaker than agentlytics for workspace attribution.
+
+### 2. Local docs
+
+The local Gemini docs are materially broader and more accurate than the parser:
+
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/04-gemini.md`
+  - documents JSONL append-log behavior, `$set`, `$rewindTo`, and legacy migration
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/04-gemini.md`
+  - documents `MessageRecord`, rewind semantics, and replay risks
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/04-gemini.md`
+  - documents `ToolCallRecord` fields and richer `resultDisplay`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/04-gemini.md`
+  - gives separate JSON and JSONL access patterns
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/04-gemini.md`
+  - explicitly says pointer blocks need a storage-variant distinction
+
+## Where agentlytics is stronger
+
+### 1. Workspace/project attribution is better in the main adapter
+
+`editors/gemini.js` loads `~/.gemini/projects.json` and maps Gemini short project IDs back to real folders. `src/parsers/gemini.ts` does not, so it emits `cwd: ''`. On legacy sessions, agentlytics gives better per-project analytics and grouping.
+
+### 2. Assistant reconstruction is more inclusive for thought/tool-only turns
+
+agentlytics turns a Gemini assistant record into one assistant message if it has any of:
+
+- `thoughts`
+- text content
+- `toolCalls`
+
+`src/parsers/gemini.ts` only emits assistant recent messages when `msg.content` yields text. That means tool-call-only Gemini turns disappear from the recent-conversation handoff, even though the raw session stored them.
+
+### 3. Post-parse analytics are stronger
+
+`cache.js` persists:
+
+- tool calls into `tool_calls`
+- token fields into `messages` and `chat_stats`
+- model frequency and cost estimates across sessions
+
+This is better than `cli-continues` if the goal is longitudinal analytics rather than cross-tool handoff context.
+
+## Where our parser/docs are stronger
+
+### 1. Our Gemini docs correctly identify the upstream JSONL recorder
+
+The strongest difference in this comparison is not parser code. It is documentation quality. The local docs explicitly track the current first-party recorder semantics from:
+
+- `packages/core/src/services/chatRecordingService.ts`
+- `packages/core/src/services/chatRecordingTypes.ts`
+- `packages/core/src/config/storage.ts`
+
+and explain append-only JSONL, metadata replay, rewinds, and legacy migration. agentlytics' inspected Gemini files do not show this awareness.
+
+### 2. Tool-call summarization is richer for handoff use
+
+`src/parsers/gemini.ts` preserves more handoff-relevant structure from legacy tool calls than agentlytics does:
+
+- diff stats
+- file diffs
+- new-file detection
+- shell stdout tails
+- fetch previews
+- file modification lists
+- normalized summary buckets for downstream handoff markdown
+
+agentlytics keeps exact tool names and args, which is useful, but it drops most result-display richness.
+
+### 3. We already model the upstream mismatch explicitly
+
+The local docs do not pretend the current parser is current. They explicitly call out that `/Users/yigitkonur/dev/cli-continues/src/parsers/gemini.ts` is behind upstream Gemini storage. That makes this repo's Gemini knowledge base more trustworthy than agentlytics' implementation surface.
+
+### 4. `GEMINI_CLI_HOME` support exists here
+
+First-party Gemini code resolves home paths through `homedir()` in `packages/core/src/utils/paths.ts`, and `homedir()` checks `GEMINI_CLI_HOME` before `os.homedir()`. `src/parsers/gemini.ts` follows that. agentlytics' inspected Gemini code paths use `os.homedir()` / `HOME` directly and ignore that override.
+
+## Confirmed mismatches
+
+### 1. Current Gemini CLI storage is JSONL append-log, not legacy-only JSON
+
+Confirmed from first-party Gemini code:
+
+- `chatRecordingService.ts` loads JSONL by replaying lines, supports `$set` and `$rewindTo`, and falls back to legacy `.json`.
+- new sessions are created as `.jsonl` under `.../chats/`.
+- legacy `.json` sessions can be migrated into `.jsonl`.
+
+Implication:
+
+- `/Users/yigitkonur/dev/cli-continues/src/parsers/gemini.ts` is outdated because it only parses `.json`.
+- `https://raw.githubusercontent.com/f/agentlytics/master/editors/gemini.js` is also outdated because it only parses `.json`.
+
+### 2. agentlytics `mod.ts` JSONL handling does not match Gemini's real JSONL schema
+
+First-party Gemini JSONL records are not plain `{ role, parts }` chat lines. They are a mixed append log of metadata, message records, metadata updates, and rewind markers. agentlytics `mod.ts` therefore does not match the current recorder even where it tries to support `.jsonl`.
+
+### 3. Neither parser handles rewind semantics
+
+First-party `loadConversationRecord()` replays `$rewindTo` and merges repeated message IDs when reconstructing conversation state. Neither:
+
+- `/Users/yigitkonur/dev/cli-continues/src/parsers/gemini.ts`
+- `https://raw.githubusercontent.com/f/agentlytics/master/editors/gemini.js`
+
+implements equivalent logic. On current Gemini JSONL sessions, both can produce the wrong conversation tail unless rewritten to replay the log.
+
+### 4. Both parsers drop or distort some upstream metadata
+
+From first-party `ToolCallRecord` and `MessageRecord` types, Gemini can persist:
+
+- tool call `id`
+- `status`
+- `timestamp`
+- `agentId`
+- `displayName`
+- `description`
+- `resultDisplay`
+- `renderOutputAsMarkdown`
+- token subfields including `tool` and `total`
+
+Observed mismatches:
+
+- agentlytics keeps `name`, `args`, model, and some token fields, but not rich display/result metadata.
+- `cli-continues` keeps more result-display information in summaries, but still does not expose raw IDs, agent IDs, or rewind-aware tool evolution.
+
+### 5. Session discovery differs, and both have blind spots
+
+- agentlytics `editors/gemini.js`:
+  - good: uses `projects.json`
+  - bad: legacy `.json` only, no `GEMINI_CLI_HOME`
+- agentlytics `mod.ts`:
+  - bad: wrong directory and wrong JSONL record assumptions
+- `cli-continues`:
+  - good: supports `GEMINI_CLI_HOME`
+  - bad: no `projects.json` recovery, no `.jsonl`
+
+### 6. Verbosity/summarization tradeoff differs
+
+- agentlytics is better for analytics breadth:
+  - more permissive assistant-message reconstruction
+  - stores message rows, model rows, tool-call rows, and cost estimates
+- `cli-continues` is better for concise handoff:
+  - strips recent conversation down to user/assistant text
+  - summarizes tool activity into categories and file changes
+  - highlights reasoning and pending tasks
+
+But the current `cli-continues` Gemini parser has a concrete summarization bug: tool-only assistant turns are omitted from `recentMessages`, so the handoff can understate what Gemini actually did.
+
+## Still unresolved
+
+- First-party docs and first-party code do not fully agree on whether the `~/.gemini/tmp/<...>/` directory component should be described as a project hash, project ID, or human-readable short slug. Current code uses `ProjectRegistry.getShortId(...)` for directory naming, but some docs still say `<project_hash>`.
+- The exact released Gemini CLI version where recorded chat storage switched from legacy `.json` blobs to current `.jsonl` append logs was not verified from a first-party changelog entry in this comparison.
+- The inspected local docs say legacy `.json` files still exist in the wild, and first-party code supports migrating them, but the exact coexistence behavior across release channels remains partially implicit.
+
+See `/Users/yigitkonur/dev/cli-continues/docs/research/agentlytics-parser-comparison/gemini/99-open-issues.md`.
+
+## URLs
+
+### Local repo files compared
+
+- `/Users/yigitkonur/dev/cli-continues/src/parsers/gemini.ts`
+- `/Users/yigitkonur/dev/cli-continues/src/types/schemas.ts`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/04-gemini.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/04-gemini.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/04-gemini.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/04-gemini.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/04-gemini.md`
+
+### Agentlytics files compared
+
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/gemini.js
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+- https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- https://raw.githubusercontent.com/f/agentlytics/master/cache.js
+
+### First-party Gemini evidence
+
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/services/chatRecordingService.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/services/chatRecordingTypes.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/config/storage.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/config/projectRegistry.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/utils/paths.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/docs/cli/session-management.md
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/cli/src/ui/commands/resumeCommand.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/cli/src/ui/commands/chatCommand.ts

--- a/docs/research/agentlytics-parser-comparison/gemini/99-open-issues.md
+++ b/docs/research/agentlytics-parser-comparison/gemini/99-open-issues.md
@@ -1,0 +1,64 @@
+# Open issues in the Gemini parser comparison
+
+**Scope:** Open questions that matter for a future Gemini parser rewrite or for tightening the Gemini docs in this repo.
+**Last updated:** 2026-04-15
+**Confidence:** Medium
+
+## 1. What should the directory component under `~/.gemini/tmp/` be called?
+
+**Answer:** Still unresolved.
+
+## Evidence
+
+- First-party session docs say sessions live at `~/.gemini/tmp/<project_hash>/chats/`.
+- First-party storage code now initializes a `ProjectRegistry`, stores mappings in `~/.gemini/projects.json`, and uses `getShortId(projectRoot)` for temp/history directory naming.
+- First-party `chatRecordingTypes.ts` still persists a `projectHash` field inside conversation metadata.
+
+## Why this matters
+
+- It affects path-discovery logic, docs wording, and whether parsers should rely on hash naming or `projects.json` slug mapping.
+- agentlytics already assumes `projects.json` short IDs.
+- this repo's docs mix `project-id` and `project-hash` wording.
+
+## 2. Which released Gemini CLI version switched chat recording from legacy `.json` to append-only `.jsonl`?
+
+**Answer:** Not confirmed from a first-party release note in this review.
+
+## Evidence
+
+- Current first-party `chatRecordingService.ts` writes `.jsonl` and migrates legacy `.json`.
+- Local docs and local observations still show legacy `.json` sessions existing on disk.
+- The first-party Google blog and first-party session docs describe session management, but they do not clearly name the exact version where recorder storage changed format.
+
+## Why this matters
+
+- It determines whether a compatibility parser should dual-read forever, gate by version, or prefer JSONL with legacy fallback.
+
+## 3. How much of Gemini's current JSONL surface should a future parser preserve verbatim?
+
+**Answer:** Open design choice, not a factual gap.
+
+## Evidence
+
+- First-party JSONL includes metadata lines, repeated message IDs, tool-call enrichment, rewinds, and tool result updates.
+- agentlytics optimizes for analytics tables and flattens assistant text/tool markers.
+- `cli-continues` optimizes for compact handoff markdown and summarized tool activity.
+
+## Why this matters
+
+- A future parser rewrite needs an explicit target:
+  - analytics-first
+  - handoff-first
+  - or a normalized core plus multiple output views
+
+## Sources
+
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/services/chatRecordingService.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/services/chatRecordingTypes.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/config/storage.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/config/projectRegistry.ts
+- https://raw.githubusercontent.com/google-gemini/gemini-cli/main/docs/cli/session-management.md
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/gemini.js
+- https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- /Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/04-gemini.md
+- /Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/04-gemini.md

--- a/docs/research/agentlytics-parser-comparison/kiro/01-kiro-comparison.md
+++ b/docs/research/agentlytics-parser-comparison/kiro/01-kiro-comparison.md
@@ -1,0 +1,343 @@
+# Kiro parser comparison: `continues` vs `agentlytics`
+
+Last updated: 2026-04-15
+
+## 1. Summary
+
+The strongest first-party evidence says current public Kiro has two documented persistence surfaces:
+
+- normal CLI chat is auto-saved in a SQLite-backed store under `~/.kiro/`
+- ACP sessions are persisted under `~/.kiro/sessions/cli/` as `<session-id>.json` plus `<session-id>.jsonl`
+
+That means both parsers miss the current public Kiro storage story if the goal is "parse what Kiro officially documents today". `continues` is explicit about that mismatch in its Kiro docs, while `agentlytics` is materially better at mining likely IDE-private artifacts under Kiro's VS Code-style extension storage.
+
+The most defensible split is:
+
+- `continues` docs are stronger on source quality and on calling out uncertainty
+- `agentlytics` code is stronger on IDE/private-surface coverage and message recovery breadth
+- neither implementation currently matches the documented CLI SQLite store or the documented ACP event-log store
+
+## 2. Agentlytics parser surface
+
+### 2.1 Full adapter: `editors/kiro.js`
+
+`agentlytics` has a two-strategy Kiro adapter in `editors/kiro.js`.
+
+| Surface | Behavior in `agentlytics` | Evidence status |
+| --- | --- | --- |
+| Root storage path | Uses `getAppDataPath('Kiro')/User/globalStorage/kiro.kiroagent` | Partly supported by first-party issue logs, not by official docs |
+| Strategy 1 | Reads `workspace-sessions/<folder>/sessions.json` plus `<sessionId>.json` | `workspace-sessions` and `sessions.json` are unverified |
+| Strategy 2 | Reads `.chat` files from hashed directories under `.../kiro.kiroagent/`, groups snapshots by `executionId`, keeps the snapshot with the highest message count | `.chat` file existence is supported by first-party issue logs; grouping logic is inferred from code |
+
+Important details from `editors/kiro.js`:
+
+- It assumes the workspace folder name inside `workspace-sessions/` is base64-encoded and decodes it to a real path.
+- It trusts `sessions.json` metadata for `sessionId`, `title`, and `dateCreated`.
+- It tries to recover workspace folders from `session.workspaceDirectory` or the decoded directory name.
+- It treats `.chat` files as "individual agent executions" and deduplicates by `executionId`.
+- It recovers titles from a rules-wrapped human message by taking text after `</user-rule>` and stripping `<EnvironmentContext>` and `<steering-reminder>`.
+- It reconstructs folder paths for `.chat` files by regex-parsing `file://.../.kiro/...` from `context[].id`.
+
+### 2.2 Message reconstruction in `editors/kiro.js`
+
+For `workspace-session` files:
+
+- `getWorkspaceSessionMessages()` reads `history[]`
+- only `user` and `assistant` roles survive
+- message content is flattened from `text` and `mention` blocks
+- assistant model is read from `entry.promptLogs[0].modelTitle` when present
+
+For `.chat` files:
+
+- `human` becomes `user`
+- `bot` becomes `assistant`
+- `tool` becomes `tool`
+- messages starting with `<identity>` or `# ` are treated as system prompts and dropped from user-visible reconstruction
+- tool messages are truncated to 2000 characters
+
+### 2.3 Full analytics path: `cache.js`
+
+`cache.js` preserves all reconstructed messages, including `tool` role messages, but its structured tool-call extraction is weak for Kiro:
+
+- it only records structured tool calls when a message has `msg._toolCalls`, or when assistant text contains a `[tool-call: ...]` marker
+- the Kiro adapter in `editors/kiro.js` never populates `_toolCalls`
+- so Kiro tool analytics mostly fall back to counting raw `tool` messages, not structured tool names/args
+
+This matters because Kiro's official ACP docs describe `ToolCall` and `ToolCallUpdate` as first-class session updates with names and parameters. `agentlytics` does not currently parse Kiro's documented ACP event log.
+
+### 2.4 Sandboxed edition: `mod.ts`
+
+`mod.ts` is weaker than `editors/kiro.js` for Kiro. Its `scanKiro()` only looks at:
+
+- `getAppDataPath("Kiro")/User/globalStorage/kiro.kiroagent`
+- `workspace-sessions/<folder>/sessions.json`
+- `<sessionId>.json`
+
+It does not implement the `.chat` fallback from `editors/kiro.js`.
+
+## 3. Our parser surface
+
+### 3.1 Parser: `/Users/yigitkonur/dev/cli-continues/src/parsers/kiro.ts`
+
+Our current parser is narrow and legacy-shaped:
+
+- root path is `~/Library/Application Support/Kiro/workspace-sessions/`
+- it scans one directory level down and ignores `sessions.json`
+- it only accepts JSON files with `sessionId` and `history[]`
+- it expects `history[].message.role` plus `history[].message.content`
+- it extracts the first `user` message as the session summary
+- it uses file `birthtime` and `mtime` as session timestamps
+- it exposes `selectedModel` as `model`
+- it emits no files-modified, no pending tasks, and no tool summaries
+
+Its message handling is simple:
+
+- `user` stays `user`
+- every non-`user` role is collapsed to `assistant`
+- content is flattened via `extractTextFromBlocks()`
+
+That simplicity avoids some heuristic lossiness, but only if the input file really matches this shape.
+
+### 3.2 Our Kiro docs
+
+The Kiro docs under:
+
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/09-kiro.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/09-kiro.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/09-kiro.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/09-kiro.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/09-kiro.md`
+
+are materially more careful than the implementation:
+
+- they say official Kiro CLI docs now point to `~/.kiro/` SQLite
+- they say the current parser's `workspace-sessions` assumption is not supported by public Kiro docs
+- they explicitly mark tool-call claims as unverified
+- they recommend runtime detection or an explicit "legacy/alternate" warning for Kiro
+
+So the implementation is stale, but the documentation already describes that staleness fairly accurately.
+
+## 4. Where agentlytics is stronger
+
+### 4.1 Better IDE/private-surface coverage
+
+This is the biggest implementation advantage.
+
+`agentlytics` is closer to Kiro's IDE/private surface because:
+
+- it targets the VS Code-style extension root `.../User/globalStorage/kiro.kiroagent`
+- it is cross-platform via `getAppDataPath()`
+- it has a second `.chat` strategy when `workspace-sessions` metadata is absent
+- it retains `tool` messages from `.chat` files
+- it extracts assistant model info from `promptLogs` or `.chat` metadata
+
+There is first-party support for parts of this:
+
+- official Kiro issue logs show extension activation for `kiro.kiroAgent`
+- official Kiro issue logs show storage rooted under `.../User/globalStorage/kiro.kiroagent/...`
+- official Kiro issue logs show `[ChatFile] Wrote chat file ... .chat`
+
+That does not prove all of `editors/kiro.js`, but it does make its root path and `.chat` fallback materially better supported than our current app-support path.
+
+### 4.2 Better message recovery breadth
+
+Compared with `/Users/yigitkonur/dev/cli-continues/src/parsers/kiro.ts`, `agentlytics` can recover:
+
+- legacy workspace-session messages
+- `.chat` execution messages
+- tool-role messages
+- some model metadata
+
+Our parser only handles one JSON shape and throws away all tool fidelity.
+
+### 4.3 Better Kiro-adjacent inventory
+
+`editors/kiro.js` also scans:
+
+- `AGENTS.md`
+- `.kiro/specs`
+- `.kiro/steering`
+- `~/.kiro/settings/mcp.json`
+
+That is broader Kiro ecosystem support than anything in the current `continues` parser.
+
+## 5. Where our parser/docs are stronger
+
+### 5.1 Stronger grounding in official Kiro docs
+
+Our docs correctly anchor on current first-party docs:
+
+- CLI session management says chat is stored in a database under `~/.kiro/`
+- the same docs say `/chat save` and `/chat load` operate on JSON exports
+- ACP docs say ACP sessions live under `~/.kiro/sessions/cli/`
+- ACP docs say interactive chat uses ACP internally
+
+`agentlytics` does not reflect those current public surfaces in either `editors/kiro.js` or `mod.ts`.
+
+### 5.2 Better separation of fact vs inference
+
+Our docs repeatedly say:
+
+- the parser path is not publicly documented
+- the old JSON shape may be real, legacy, or obsolete
+- "Kiro stores no tool call data" is not proven
+
+That is the right stance. `agentlytics` code bakes in several assumptions silently:
+
+- base64 workspace-folder decoding
+- `workspace-sessions/sessions.json`
+- `.chat` snapshot grouping by `executionId`
+- system-prompt stripping rules
+- workspace recovery from `context[].id`
+
+Some may be right. The point is that `agentlytics` does not label them as assumptions.
+
+### 5.3 Less destructive reconstruction for legacy JSON
+
+When our parser does match a file, it is less opinionated:
+
+- it does not drop messages that start with `# `
+- it does not strip XML-ish wrappers
+- it does not infer titles from prompt surgery
+- it does not truncate tool-text because it does not attempt tool parsing at all
+
+That is weaker overall coverage, but lower heuristic risk on the one shape it accepts.
+
+## 6. Confirmed mismatches
+
+### 6.1 Both implementations miss the documented public Kiro storage surfaces
+
+Confirmed by first-party docs:
+
+- CLI session management documents SQLite-backed storage under `~/.kiro/`
+- ACP documents `~/.kiro/sessions/cli/` with `.json` plus `.jsonl`
+- ACP docs also say "Interactive Chat" uses ACP internally
+
+Neither parser reads:
+
+- the CLI SQLite store under `~/.kiro/`
+- the ACP session log under `~/.kiro/sessions/cli/`
+
+So both are mismatched against current public Kiro documentation.
+
+### 6.2 Our parser path is the least supported one
+
+`/Users/yigitkonur/dev/cli-continues/src/parsers/kiro.ts` uses:
+
+- `~/Library/Application Support/Kiro/workspace-sessions/`
+
+I found no first-party documentation or first-party issue-log evidence for that exact root.
+
+By contrast, `agentlytics` uses:
+
+- `.../User/globalStorage/kiro.kiroagent/...`
+
+which is supported by first-party issue logs on Linux, macOS, and Windows. That does not prove its full subtree assumptions, but it does mean its root path is better evidenced than ours.
+
+### 6.3 Agentlytics has a structured tool-call gap even when tool messages exist
+
+This is a code-confirmed mismatch between `agentlytics` behavior and Kiro's documented ACP semantics.
+
+First-party ACP docs say Kiro emits:
+
+- `ToolCall`
+- `ToolCallUpdate`
+
+with tool invocation data during sessions.
+
+But in `agentlytics`:
+
+- `editors/kiro.js` emits `tool` messages, not `_toolCalls`
+- `cache.js` only stores structured tool calls from `_toolCalls` or `[tool-call: ...]` assistant markers
+
+Result:
+
+- Kiro tool activity may appear as raw tool-message text
+- tool names and arguments are often missing from `tool_calls` analytics
+
+This is better than our current "no tool summaries at all", but still well below documented ACP fidelity.
+
+### 6.4 Our current "Kiro has no tool call data" behavior is outdated at the product level
+
+The claim inside `/Users/yigitkonur/dev/cli-continues/src/parsers/kiro.ts` is only true for the specific legacy JSON shape it reads.
+
+At the product level, first-party ACP docs contradict the broader implication:
+
+- Kiro exposes `ToolCall` and `ToolCallUpdate`
+- interactive chat uses ACP internally
+- ACP sessions are persisted as event logs
+
+So the current parser behavior is not just incomplete; it is now incomplete relative to documented Kiro capabilities.
+
+## 7. Still unresolved
+
+### 7.1 Is `workspace-sessions/.../sessions.json` still a live Kiro format?
+
+Best case for `agentlytics`:
+
+- the extension root is real
+- old or current Kiro IDE builds may still keep a structured `workspace-sessions` index there
+
+Best case against:
+
+- no first-party doc or issue log in this review showed `workspace-sessions` or `sessions.json`
+- current public docs describe CLI SQLite plus ACP `.json/.jsonl`, not this layout
+
+Status: unresolved.
+
+### 7.2 How much of `.chat` parsing is correct beyond the file extension itself?
+
+Best case for `agentlytics`:
+
+- first-party issue logs show `.chat` files are written under `.../kiro.kiroagent/...`
+- issue logs around execution history make `executionId`-style grouping plausible
+
+Best case against:
+
+- I did not obtain a first-party sample `.chat` file
+- fields like `metadata.workflow`, `context[]`, `executionId`, and message-role schema remain code-inferred
+
+Status: unresolved.
+
+### 7.3 How exactly do interactive chat, CLI SQLite, and ACP persistence relate?
+
+The docs currently say two things:
+
+- CLI chat is auto-saved to a SQLite-backed store under `~/.kiro/`
+- interactive chat uses ACP internally, and ACP persists sessions under `~/.kiro/sessions/cli/`
+
+Possible interpretations:
+
+- Kiro keeps two layers for the same conversation lifecycle
+- the SQLite store handles chat/session management, while ACP `.jsonl` handles event-level transcripts
+- the docs describe adjacent but not identical surfaces
+
+I could not verify the exact relationship from first-party docs alone.
+
+### 7.4 Does the Kiro IDE still expose a separate app-private execution-history store?
+
+The IDE docs confirm:
+
+- sessions/history UI exists
+- execution history includes code changes, commands, search results, file operations, and more
+
+That strongly suggests richer internal storage than our parser reads today. It still does not publish the on-disk schema.
+
+Status: unresolved.
+
+## 8. URLs
+
+- Kiro CLI chat docs: https://kiro.dev/docs/cli/chat/
+- Kiro CLI session management docs: https://kiro.dev/docs/cli/chat/session-management/
+- Kiro CLI ACP docs: https://kiro.dev/docs/cli/acp/
+- Kiro IDE chat docs: https://kiro.dev/docs/chat/
+- Kiro CLI slash commands: https://kiro.dev/docs/cli/reference/slash-commands/
+- Agentlytics Kiro adapter: https://raw.githubusercontent.com/f/agentlytics/master/editors/kiro.js
+- Agentlytics base helpers: https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+- Agentlytics editor registry: https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+- Agentlytics sandboxed entrypoint: https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+- Agentlytics analytics cache: https://raw.githubusercontent.com/f/agentlytics/master/cache.js
+- Kiro issue #1127: https://github.com/kirodotdev/Kiro/issues/1127
+- Kiro issue #670: https://github.com/kirodotdev/Kiro/issues/670
+- Kiro issue #1749: https://github.com/kirodotdev/Kiro/issues/1749
+- Kiro issue #3454: https://github.com/kirodotdev/Kiro/issues/3454

--- a/docs/research/agentlytics-parser-comparison/kiro/99-open-issues.md
+++ b/docs/research/agentlytics-parser-comparison/kiro/99-open-issues.md
@@ -1,0 +1,65 @@
+# Open Kiro issues for parser comparison
+
+Last updated: 2026-04-15
+
+## 1. Need a real current Kiro sample set
+
+Missing artifacts:
+
+- one current CLI SQLite session from `~/.kiro/`
+- one current ACP session pair from `~/.kiro/sessions/cli/<id>.json` and `<id>.jsonl`
+- one current IDE-private `.chat` file under `.../User/globalStorage/kiro.kiroagent/...`
+- one current `workspace-sessions` sample if that subtree still exists
+
+Why this matters:
+
+- it is the only way to settle whether `continues` should target SQLite, ACP JSONL, IDE-private `.chat`, or multiple Kiro surfaces
+- it would validate or falsify `agentlytics` assumptions around `executionId`, `metadata.workflow`, `context[]`, and tool-message layout
+
+## 2. Resolve the CLI-vs-ACP relationship
+
+Current first-party docs say both:
+
+- normal chat is stored in a SQLite-backed database under `~/.kiro/`
+- ACP persists sessions under `~/.kiro/sessions/cli/`
+- interactive chat uses ACP internally
+
+Open question:
+
+- are these two layers for the same conversation, or different storage systems for different runtimes?
+
+Impact:
+
+- if they are dual layers, the parser likely needs two readers
+- if ACP is now canonical for interactive chat, both current parsers are targeting the wrong surface
+
+## 3. Decide whether Kiro support means CLI, IDE, or both
+
+`continues` currently mixes:
+
+- parser code aimed at an old IDE-like JSON store
+- docs aimed at the current CLI/ACP public surface
+
+Open question:
+
+- should Kiro support be split into explicit variants, or should one variant be chosen as canonical?
+
+Impact:
+
+- without a product-surface decision, "Kiro support" will keep drifting between incompatible storage models
+
+## 4. Tool fidelity is currently unsolved
+
+Known facts:
+
+- Kiro ACP documents `ToolCall` and `ToolCallUpdate`
+- `agentlytics` preserves some raw tool messages but usually misses structured tool names/args
+- `continues` emits no Kiro tool summaries at all
+
+Open question:
+
+- which Kiro surface gives the highest-fidelity tool record: ACP `.jsonl`, IDE `.chat`, or neither?
+
+Impact:
+
+- this determines whether Kiro can participate in accurate handoff summaries, tool analytics, and reconstruction of agent work

--- a/docs/research/agentlytics-parser-comparison/opencode/01-opencode-comparison.md
+++ b/docs/research/agentlytics-parser-comparison/opencode/01-opencode-comparison.md
@@ -1,0 +1,217 @@
+# OpenCode parser/docs comparison: `continues` vs agentlytics
+
+**Scope:** Compare only OpenCode handling in `continues` and agentlytics against first-party OpenCode code and local OpenCode data. This covers storage backend detection, message/part extraction, tool-call fidelity, and verbosity/summarization behavior.
+**Last updated:** 2026-04-15
+**Confidence:** High — local code, agentlytics first-party code, and current OpenCode first-party code largely agree on the main facts; a few ordering details remain unresolved.
+
+## 1. Summary
+
+OpenCode upstream is SQLite-first today, with legacy JSON storage retained for migration and fallback. On that point, `/Users/yigitkonur/dev/cli-continues/src/parsers/opencode.ts` is directionally closer to upstream than agentlytics’ `editors/opencode.js`, and much closer than agentlytics’ `mod.ts`, which only scans flat JSON files under `storage/session`.
+
+Agentlytics is stronger at preserving conversational surface from OpenCode parts: its `https://raw.githubusercontent.com/f/agentlytics/master/editors/opencode.js` keeps text, reasoning, tool-call placeholders, and tool-result previews, while `continues` currently keeps only `text` parts from both SQLite and JSON storage. That makes agentlytics more verbose and more analytically useful for message browsing, but it achieves that by collapsing structured tool parts into lossy bracketed strings.
+
+`continues` has a sharper documentation layer than its implementation. The local docs under `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/.../05-opencode.md` correctly describe upstream tool parts, dual backends, and migration drift better than either parser. But the actual parser does not honor `OPENCODE_DB` or channel-specific DB filenames, and its OpenCode tool summary extraction only reads legacy JSON session files, so DB-only installs can lose all tool summaries.
+
+## 2. Agentlytics parser surface
+
+Agentlytics has two OpenCode surfaces, and they do not agree.
+
+- Full adapter surface:
+  - `https://raw.githubusercontent.com/f/agentlytics/master/editors/opencode.js`
+  - Registered through `https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js`
+  - Used by the cache/analyzer in `https://raw.githubusercontent.com/f/agentlytics/master/cache.js`
+- Sandboxed CLI surface:
+  - `https://raw.githubusercontent.com/f/agentlytics/master/mod.ts`
+
+Documented behavior in `editors/opencode.js`:
+
+- Storage assumptions:
+  - Hardcodes JSON root to `~/.local/share/opencode/storage` and DB path to `~/.local/share/opencode/opencode.db`.
+  - Scans legacy JSON sessions recursively under `storage/session/<project>/ses_*.json` at lines 161-180.
+  - Scans SQLite sessions separately at lines 71-79.
+  - Prefers file sessions first, then appends unseen SQLite sessions at lines 280-325.
+- Message extraction:
+  - For SQLite, reads `message.data`, then all `part.data` rows ordered by `time_created` at lines 81-149.
+  - For JSON, reads `storage/message/<session>` and `storage/part/<message>` at lines 192-271.
+  - Emits:
+    - raw text for `text`
+    - `[thinking] ...` for `thinking` or `reasoning`
+    - `[tool-call: tool(argKeys)]` for `tool-call`, `tool_use`, `tool-use`, or `tool`
+    - `[tool-result] preview` for `tool-result` or `tool_result`, and also reads `state.output` when present
+  - Skips `step-start` and `step-finish` in JSON mode.
+  - If a message has no extracted content, inserts a placeholder like `[assistant]`.
+- Metadata extraction:
+  - Pulls model/provider/token/cache data from `message.data` in both SQLite and JSON paths.
+- Analytics surface:
+  - `cache.js` stores normalized messages, then extracts tool calls either from `msg._toolCalls` or via regex over `[tool-call: ...]` placeholders at lines 241-318.
+  - The OpenCode adapter does not populate `_toolCalls`, so the regex path is the effective one for OpenCode.
+- MCP surface:
+  - `editors/opencode.js` reads `~/.config/opencode/opencode.json` and maps the `mcp` key at lines 343-372.
+  - `editors/base.js` provides the generic config parser used elsewhere, but OpenCode uses a custom path and custom `mcp` key mapping.
+
+Documented behavior in `mod.ts`:
+
+- `mod.ts` only scans `~/.local/share/opencode/storage/session/*.json` flat at lines 748-773.
+- It does not recurse into project subdirectories.
+- It does not read SQLite at all.
+- It sets `bubbleCount: 0` for every OpenCode session.
+
+Inference:
+
+- Agentlytics’ real OpenCode adapter is `editors/opencode.js`, not `mod.ts`.
+- `mod.ts` is still a first-party agentlytics surface, so its OpenCode behavior is a confirmed product-level mismatch, not just dead code.
+
+## 3. Our parser surface
+
+Relevant local files:
+
+- `/Users/yigitkonur/dev/cli-continues/src/parsers/opencode.ts`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/05-opencode.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/message-schema/05-opencode.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/05-opencode.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/access-recipes/05-opencode.md`
+- `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/handoff-pointers/05-opencode.md`
+
+Implementation behavior in `/Users/yigitkonur/dev/cli-continues/src/parsers/opencode.ts`:
+
+- Storage assumptions:
+  - Builds base path from `XDG_DATA_HOME` or `~/.local/share/opencode` at lines 27-31.
+  - Hardcodes DB path to `<base>/opencode.db`.
+  - Tries SQLite first for sessions and messages at lines 195-203 and 327-335.
+  - Falls back to legacy JSON session/project/message/part trees when SQLite is absent or empty.
+  - Unlike agentlytics `mod.ts`, it correctly expects legacy JSON sessions under `storage/session/<project>/ses_*.json`.
+- Session extraction:
+  - SQLite: reads the `session` table and joins `project` only for `worktree` lookup at lines 209-278.
+  - JSON: reads `storage/session/<project>/<session>.json` plus `storage/project/<project>.json` at lines 283-322.
+  - For untitled sessions, both paths try to summarize from the first user text part.
+- Message extraction:
+  - SQLite: reads message rows ordered by `time_created`, then part rows ordered by `time_created`, and concatenates only `text` parts at lines 341-389.
+  - JSON: same policy, only `text` parts at lines 394-450.
+  - Any message with no `text` part disappears from `recentMessages`.
+- Tool summary extraction:
+  - `extractOpenCodeToolSummaries()` reads only legacy JSON session files under `storage/session/<project>/<session>.json` at lines 457-496.
+  - It emits at most one synthetic `Edit` summary derived from `summary.additions`, `summary.deletions`, and `summary.files`.
+  - It never reads SQLite `part` rows of `type: "tool"`.
+  - It does not read SQLite `session.summary_*` either, even though upstream stores these fields on the `session` table.
+- Handoff output:
+  - `extractOpenCodeContext()` passes trimmed recent text-only messages plus tool summaries into the general markdown generator at lines 501-520.
+
+Documentation surface:
+
+- The docs correctly describe upstream SQLite-first storage, legacy JSON migration, and the rich OpenCode part schema.
+- The docs explicitly say the parser currently omits reasoning/tool/patch/compaction parts from recent conversation.
+- The docs are stronger than the implementation on DB path variants and tool-part richness, but a few claims overrun what the parser actually does today.
+
+## 4. Where agentlytics is stronger
+
+- Part extraction is richer. Agentlytics preserves reasoning text, tool-call placeholders, tool-result previews, and role-only placeholders; `continues` keeps only `text` parts.
+- Message browsing is more verbose. For OpenCode sessions with heavy tool use, agentlytics exposes more of the assistant’s operational trace.
+- Analytics are broader. Agentlytics extracts model/provider/token/cache metadata from message rows and stores tool names in its own cache DB, even if the tool arguments are lossy.
+- OpenCode MCP config support exists. `editors/opencode.js` reads `~/.config/opencode/opencode.json` and maps `mcp` entries; `continues` OpenCode parsing does not cover this surface.
+
+Tradeoff:
+
+- That extra verbosity is partly synthetic. Agentlytics converts structured parts into bracketed text, so it is better for dashboards than for high-fidelity continuation.
+
+## 5. Where our parser/docs are stronger
+
+- Backend choice is closer to upstream. `continues` is SQLite-first, which matches current OpenCode upstream and the local installation on this machine.
+- Legacy JSON traversal is more correct than agentlytics `mod.ts`. `continues` searches `storage/session/<project>/ses_*.json`, which matches OpenCode’s migration layout.
+- The documentation is materially better than either parser:
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/tool-call-map/05-opencode.md` correctly records that upstream tool parts are structured `type: "tool"` parts with `state.input`, `state.output` or `state.error`, timing, and optional attachments.
+  - `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/05-opencode.md` and `handoff-pointers/05-opencode.md` correctly frame SQLite vs legacy JSON as a real migration/state issue.
+- The handoff model is more conservative. By omitting reasoning/tool noise, `continues` produces terser resumable context. For some continuation targets that is a feature, not a bug.
+
+Tradeoff:
+
+- This terseness becomes under-informative for OpenCode specifically, because upstream stores important state in non-text parts.
+
+## 6. Confirmed mismatches
+
+### A. Upstream OpenCode vs agentlytics
+
+1. **Backend priority is inverted in `editors/opencode.js`.**
+   - Agentlytics comments call JSON the “newer storage format” and SQLite “older/primary” at `editors/opencode.js:284-307`.
+   - First-party OpenCode code is SQLite-first now:
+     - `packages/opencode/src/storage/db.ts:30-44` resolves the active DB path.
+     - `packages/opencode/src/storage/storage.ts:88-247` contains JSON migration logic for legacy storage.
+   - Local evidence on this machine also supports SQLite-first: `~/.local/share/opencode/opencode.db` exists, while `~/.local/share/opencode/storage/session` does not.
+
+2. **Agentlytics hardcodes only `opencode.db`.**
+   - `editors/opencode.js:16-21` hardcodes `~/.local/share/opencode/opencode.db`.
+   - First-party OpenCode supports `OPENCODE_DB` and channel-specific DB filenames in `packages/opencode/src/storage/db.ts:31-44`.
+   - Recommendation impact: agentlytics can miss non-default DB names or channel DBs.
+
+3. **Agentlytics `mod.ts` does not match current OpenCode storage or its own full adapter.**
+   - `mod.ts:748-773` scans only flat `storage/session/*.json`.
+   - OpenCode legacy JSON migration layout is nested under `storage/session/<project>/...` in `packages/opencode/src/storage/storage.ts:145-215`.
+   - Agentlytics `editors/opencode.js:161-180` already knows the nested layout, so the mismatch is internal to agentlytics.
+
+4. **Agentlytics tool-call fidelity is lossy relative to upstream.**
+   - Upstream `ToolPart` is structured in `packages/opencode/src/session/message-v2.ts:276-349`.
+   - Agentlytics emits bracketed text placeholders at `editors/opencode.js:112-123` and `234-241`.
+   - `cache.js:275-290` then stores only the parsed tool name and `{}` args unless another adapter populated `_toolCalls`.
+   - Consequence: tool names survive, but exact arguments, outputs, errors, timings, attachments, and `callID` do not.
+
+### B. Upstream OpenCode vs `continues`
+
+5. **`continues` docs know about `OPENCODE_DB` and channel DBs, but the parser does not.**
+   - Docs: `/Users/yigitkonur/dev/cli-continues/docs/parser-documentation/storage-format/05-opencode.md:8-13`
+   - Parser: `/Users/yigitkonur/dev/cli-continues/src/parsers/opencode.ts:27-31`
+   - Result: the docs are correct against upstream, but the parser only looks for `<base>/opencode.db`.
+
+6. **`continues` drops almost all upstream part structure.**
+   - Upstream parts include `tool`, `reasoning`, `step-start`, `step-finish`, `snapshot`, `patch`, `agent`, `retry`, `compaction`, and `subtask` in `packages/opencode/src/session/message-v2.ts:386-404`.
+   - Parser only concatenates `text` parts in SQLite and JSON modes at `/Users/yigitkonur/dev/cli-continues/src/parsers/opencode.ts:364-379` and `423-442`.
+   - Consequence: assistant steps with no text vanish from `recentMessages`.
+
+7. **`continues` tool summaries are legacy-JSON-only even though upstream stores summary fields and tool parts in SQLite.**
+   - Parser summary extraction reads only `storage/session/.../<session>.json` at `/Users/yigitkonur/dev/cli-continues/src/parsers/opencode.ts:460-489`.
+   - Upstream stores `summary_additions`, `summary_deletions`, and `summary_files` on the SQLite `session` table in `packages/opencode/src/session/session.sql.ts:29-38`.
+   - Upstream also stores tool parts in SQLite `part.data` in `packages/opencode/src/session/message-v2.ts:344-349`.
+   - On this machine there is no `storage/session` tree, so OpenCode tool summaries from `continues` will be empty on live data.
+
+### C. `continues` vs agentlytics
+
+8. **SQLite vs JSON fallback handling**
+   - `continues` is SQLite-first, then JSON fallback.
+   - agentlytics `editors/opencode.js` is file-first, then SQLite fallback.
+   - agentlytics `mod.ts` is JSON-only.
+   - Against current upstream, `continues` has the better default.
+
+9. **Part extraction**
+   - `continues`: text-only, terse, resumable, but under-informative.
+   - agentlytics: richer and more verbose, but synthetic and lossy.
+
+10. **Verbosity/summarization implications**
+   - `continues` produces smaller handoffs with lower noise, but misses reasoning and tool execution context that often matters in OpenCode sessions.
+   - agentlytics preserves more operational context, but its bracketed placeholders can overstate fidelity and inflate assistant message length with preview text instead of structured facts.
+
+## 7. Still unresolved
+
+- Canonical part ordering is not fully settled from the evidence gathered here.
+  - Both parsers sort SQLite parts by `time_created`.
+  - OpenCode’s client-side sync layer sorts parts by `id`, not `time_created`, in `packages/app/src/context/sync.tsx`.
+  - I did not verify the exact server-side DB query used to materialize parts over the API.
+- The exact product contract for agentlytics `mod.ts` versus the full adapter set is not documented in code beyond “Deno Sandboxed Edition”.
+  - It is clearly a first-party surface.
+  - It is not clear whether the OpenCode path there is intentionally degraded or simply stale.
+
+See `99-open-issues.md` for the follow-up list.
+
+## 8. URLs
+
+- OpenCode repo redirect check:
+  - https://github.com/sst/opencode
+  - Redirects to `https://github.com/anomalyco/opencode` as of 2026-04-15
+- First-party OpenCode code:
+  - https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/storage/db.ts
+  - https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/storage/storage.ts
+  - https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/session/session.sql.ts
+  - https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/session/message-v2.ts
+- First-party agentlytics code:
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/opencode.js
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/base.js
+  - https://raw.githubusercontent.com/f/agentlytics/master/editors/index.js
+  - https://raw.githubusercontent.com/f/agentlytics/master/mod.ts
+  - https://raw.githubusercontent.com/f/agentlytics/master/cache.js

--- a/docs/research/agentlytics-parser-comparison/opencode/99-open-issues.md
+++ b/docs/research/agentlytics-parser-comparison/opencode/99-open-issues.md
@@ -1,0 +1,44 @@
+# OpenCode comparison open issues
+
+**Scope:** Follow-up questions that remained unresolved after comparing `continues`, agentlytics, and first-party OpenCode sources.
+**Last updated:** 2026-04-15
+**Confidence:** Medium — these are real gaps, but they do not change the main comparison conclusions.
+
+## Answer
+
+The main storage and tool-call conclusions are already stable. The remaining uncertainty is about ordering semantics and whether agentlytics’ `mod.ts` should be treated as intentionally reduced functionality or a stale OpenCode implementation.
+
+## Evidence
+
+- OpenCode upstream part schema is clear:
+  - `packages/opencode/src/session/message-v2.ts` defines structured part types including `tool`, `reasoning`, `step-start`, and `step-finish`.
+- OpenCode upstream storage is clear:
+  - `packages/opencode/src/storage/db.ts` resolves the active SQLite DB path.
+  - `packages/opencode/src/storage/storage.ts` preserves legacy JSON migration logic.
+- Part ordering is less clear:
+  - `/Users/yigitkonur/dev/cli-continues/src/parsers/opencode.ts` orders SQLite parts by `time_created`.
+  - `https://raw.githubusercontent.com/f/agentlytics/master/editors/opencode.js` also orders SQLite parts by `time_created`.
+  - OpenCode client sync code sorts parts by `id`, not `time_created`, in `packages/app/src/context/sync.tsx`.
+- Agentlytics has two incompatible OpenCode implementations:
+  - `editors/opencode.js` understands nested legacy JSON plus SQLite.
+  - `mod.ts` only scans flat JSON and skips SQLite.
+
+## Caveats / Negative Signal
+
+- I did not verify the exact OpenCode server/API query that returns message parts to the client, so I cannot prove whether `id` sort or `time_created` sort is canonical.
+- I did not find an explicit agentlytics maintainer note describing the intended support level of `mod.ts` for OpenCode.
+
+## Open questions
+
+1. Should OpenCode part ordering in `continues` use `ORDER BY id`, `ORDER BY time_created, id`, or continue using only `time_created`?
+2. Should OpenCode tool summaries in `continues` be derived directly from SQLite `part.data` and SQLite `session.summary_*`, instead of legacy JSON session files?
+3. Should `continues` honor `OPENCODE_DB` and channel-specific DB filenames to match upstream path resolution?
+4. Should agentlytics `mod.ts` be treated as unsupported for OpenCode until it gains SQLite support and nested legacy JSON traversal?
+
+## Sources
+
+- https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/storage/db.ts — first-party OpenCode DB path logic — accessed 2026-04-15
+- https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/storage/storage.ts — first-party OpenCode JSON migration logic — accessed 2026-04-15
+- https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/session/message-v2.ts — first-party OpenCode part schema — accessed 2026-04-15
+- https://raw.githubusercontent.com/f/agentlytics/master/editors/opencode.js — agentlytics full OpenCode adapter — accessed 2026-04-15
+- https://raw.githubusercontent.com/f/agentlytics/master/mod.ts — agentlytics sandboxed CLI OpenCode scan path — accessed 2026-04-15

--- a/docs/research/final-schema-closure-verification/00-master-summary.md
+++ b/docs/research/final-schema-closure-verification/00-master-summary.md
@@ -1,0 +1,71 @@
+# Final Schema Closure Verification
+
+Access date: 2026-04-15
+
+This directory captures the final deep internet research pass after the first adversarial wave. Its purpose is to reduce the unresolved set as far as current first-party evidence allows.
+
+## Document Index
+
+| File | Description |
+| --- | --- |
+| [01-antigravity-amp-droid.md](./01-antigravity-amp-droid.md) | Final closure pass for Antigravity, Amp, and Droid storage/session surfaces. |
+| [02-kilo-qwen-kiro.md](./02-kilo-qwen-kiro.md) | Final closure pass for Kilo Code, Qwen Code, and Kiro storage/runtime/schema questions. |
+| [03-design-contract.md](./03-design-contract.md) | Final closure pass for the handoff/public-contract design direction. |
+| [04-sessionr-debug-contract.md](./04-sessionr-debug-contract.md) | Final closure pass for `sessionr` async semantics and the `--debug-prompt` contract. |
+
+## Biggest Closures
+
+- `Qwen Code` is effectively closed on storage/runtime shape:
+  - project-scoped JSONL sessions under `~/.qwen/projects/<sanitized-cwd>/chats/`
+  - `QWEN_RUNTIME_DIR` as the runtime-base override
+  - `tmp/` and `history/` as auxiliary roots rather than the primary transcript store
+- `Kilo Code` is now strongly anchored to a DB-backed OpenCode-derived runtime for the canonical live store.
+- `Kiro` is now clearly split:
+  - normal CLI chat: SQLite under `~/.kiro/`
+  - ACP sessions: `.json` + `.jsonl` under `~/.kiro/sessions/cli/`
+- `Antigravity` is better anchored than before:
+  - `conversations/*.pb` looks like the persisted conversation payload
+  - `brain/<id>/` looks like the artifact sidecar
+  - `state.vscdb` / `workspaceStorage/*/state.vscdb` look like UI/index state
+  - `code_tracker` still does not have first-party support as canonical transcript storage
+- `Droid` now has stronger first-party support for `~/.factory/projects/.../*.jsonl` than for `~/.factory/sessions/...`.
+- `Amp` still lacks a first-party published local transcript path/schema; server-backed thread identity remains the safest canonical layer.
+- `sessionr --new --async` is now strongly supported as nondeterministic for created-session ID recovery, even though it is not publicly documented as “broken.”
+
+## Final Corrections To Local Confidence
+
+### Strongly confirmed
+
+- Gemini JSONL-first upstream
+- Qwen `projects/.../chats/*.jsonl` and `QWEN_RUNTIME_DIR`
+- Kilo DB-backed canonical live store
+- Kiro split storage surfaces
+- Cursor transcript completeness warning
+- Copilot `events.jsonl` complete-record / `session-store.db` subset split
+- Crush project-local `.crush/crush.db`
+- `sessionr` async weak session-ID guarantees
+
+### Downgraded and confidence-graded
+
+- Antigravity canonical storage still unresolved at the exact schema level
+- Amp local transcript path/schema still unresolved
+- Droid `projects/...` now stronger than `sessions/...`, but versioned/mixed behavior is still plausible
+- same-tool debug UX is still unresolved beyond the current hard error
+- `default | full` remains plausible for the human-facing view, but not as the only public axis
+
+## Remaining Hard Unresolved Set
+
+- exact Kiro normal-chat SQLite filename/schema
+- exact Antigravity protobuf schema and encryption contract
+- exact Amp local cache/transcript schema
+- exact Droid path/version matrix across `projects/...` vs `sessions/...`
+- exact same-tool debug UX contract
+- exact public shape of any machine-readable prompt-debug artifact if `continues` adds one
+
+## Action Implication
+
+The implementation phase can move forward now, but it should:
+
+1. confidently fix the strong items
+2. confidence-grade the weaker ones
+3. avoid pretending the unresolved items are settled

--- a/docs/research/final-schema-closure-verification/01-antigravity-amp-droid.md
+++ b/docs/research/final-schema-closure-verification/01-antigravity-amp-droid.md
@@ -1,0 +1,50 @@
+# Antigravity, Amp, and Droid Closure Pass
+
+## Summary
+
+- `Antigravity`: strongest first-party evidence now points to `~/.gemini/antigravity/conversations/*.pb` as the persisted conversation payload, with `brain/<id>/` as artifacts and `state.vscdb` / `workspaceStorage/*/state.vscdb` as UI/index state.
+- `Amp`: strongest first-party model is server-backed thread identity plus a thinner local client-history layer. No first-party public local transcript schema/path was found.
+- `Droid`: strongest first-party path is now `~/.factory/projects/.../*.jsonl` via repeated `transcript_path` examples, but releases show storage/session behavior evolving enough that a versioned or mixed model is still plausible.
+
+## New Confirmations
+
+### Antigravity
+
+- Official Google AI Developers Forum bug reports show `.pb` files surviving under `~/.gemini/antigravity/conversations/` alongside `brain/<id>/` even when Agent Manager loses visibility.
+- The same reports show `state.vscdb` and `workspaceStorage/*/state.vscdb` acting as UI/index state.
+
+### Amp
+
+- Amp’s security page explicitly separates local thread history from server-side PostgreSQL-backed thread syncing/storage.
+- Official product/manual pages make the web/server thread object and `T-...` ID the strongest canonical thread identity surface.
+
+### Droid
+
+- Factory’s hook docs repeatedly show `transcript_path` under `~/.factory/projects/.../*.jsonl`.
+- Release notes show active changes to continuation and persistence semantics in late 2025, supporting the “do not over-assume one path behavior” stance.
+
+## New Contradictions
+
+- `code_tracker` still lacks first-party support as Antigravity’s canonical transcript store.
+- a concrete local JSON thread path for Amp remains unsupported by first-party docs
+- `~/.factory/sessions/...` is no longer the best first-party default path for Droid
+
+## Still Unresolved
+
+- exact Antigravity protobuf schema and whether `code_tracker` has parser value
+- exact Amp local cache/transcript schema
+- exact Droid coexistence or replacement story for `projects/...` vs `sessions/...`
+
+## URLs
+
+- https://discuss.ai.google.dev/t/bug-report-undo-function-deletes-conversation-from-google-antigravity-agent-manager/111708
+- https://discuss.ai.google.dev/t/bug-antigravity-agent-manager-conversation-history-exists-on-remote-host-but-is-not-listed-or-creatable-after-latest-update-remote-ssh-mac-ubuntu/112857
+- https://discuss.ai.google.dev/t/antigravity-review/109884
+- https://ampcode.com/security
+- https://ampcode.com/manual
+- https://ampcode.com/manual/appendix
+- https://ampcode.com/news/find-threads
+- https://ampcode.com/threads/T-f6f27b26-5e1c-42dc-be79-da175de730c6
+- https://docs.factory.ai/reference/hooks-reference
+- https://docs.factory.ai/cli/droid-exec/overview
+- https://docs.factory.ai/changelog/release-notes

--- a/docs/research/final-schema-closure-verification/02-kilo-qwen-kiro.md
+++ b/docs/research/final-schema-closure-verification/02-kilo-qwen-kiro.md
@@ -1,0 +1,57 @@
+# Kilo Code, Qwen Code, and Kiro Closure Pass
+
+## Summary
+
+- `Kilo Code`: first-party evidence now strongly favors a DB-backed OpenCode-derived runtime as the canonical live store, centered on `kilo.db`.
+- `Qwen Code`: current first-party code and docs close the `projects/` vs `tmp/` question in favor of `projects/.../chats/*.jsonl` as the primary transcript store.
+- `Kiro`: current first-party docs clearly split normal CLI SQLite storage from ACP `.json` + `.jsonl` sessions.
+
+## New Confirmations
+
+### Kilo Code
+
+- first-party repo code hardcodes `kilo.db` as the DB filename under the app data root unless overridden
+- first-party schema code defines SQLite tables for `session`, `message`, `part`, `todo`, and `permission`
+- legacy VS Code task-folder artifacts appear in explicit migration flows, not current runtime persistence
+
+### Qwen Code
+
+- first-party docs now explicitly say session data is project-scoped JSONL under `~/.qwen/projects/<sanitized-cwd>/chats`
+- first-party code confirms `QWEN_RUNTIME_DIR` precedence for the runtime base
+- first-party code clarifies `tmp/` and `history/` as auxiliary rather than primary session storage
+
+### Kiro
+
+- official docs explicitly state normal CLI chat uses a SQLite database under `~/.kiro/`
+- official ACP docs explicitly state ACP persistence under `~/.kiro/sessions/cli/` as `.json` + `.jsonl`
+
+## New Contradictions
+
+- treating Kilo’s old VS Code transcript/task files as the current canonical live store is no longer defensible
+- treating Qwen’s `tmp/` as a possible current primary transcript store is no longer defensible from current first-party evidence
+- treating Kiro normal CLI chat as `workspace-sessions/*.json` is contradicted by current public CLI docs
+
+## Still Unresolved
+
+- exact Kiro normal-chat SQLite filename
+- exact Kiro normal-chat SQLite schema
+- whether `workspace-sessions/*.json` is still a live IDE-private implementation detail anywhere
+- whether `ui_messages.json` is actively written in any current Kilo shipping surface, though the strongest evidence now points elsewhere
+
+## URLs
+
+- https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/storage/db.ts
+- https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/session/session.sql.ts
+- https://github.com/Kilo-Org/kilocode/blob/main/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+- https://github.com/Kilo-Org/kilocode/blob/main/packages/kilo-vscode/src/legacy-migration/sessions/migrate.ts
+- https://github.com/Kilo-Org/kilocode/blob/main/packages/kilo-vscode/src/legacy-migration/sessions/lib/legacy-conversation.ts
+- https://github.com/Kilo-Org/kilocode/blob/main/README.md
+- https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/config/storage.ts
+- https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/services/sessionService.ts
+- https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/services/chatRecordingService.ts
+- https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/
+- https://kiro.dev/docs/cli/chat/session-management/
+- https://kiro.dev/docs/cli/acp/
+- https://kiro.dev/docs/chat/
+- https://kiro.dev/docs/cli/reference/cli-commands/
+- https://kiro.dev/changelog/cli/

--- a/docs/research/final-schema-closure-verification/03-design-contract.md
+++ b/docs/research/final-schema-closure-verification/03-design-contract.md
@@ -1,0 +1,37 @@
+# Design Contract Closure Pass
+
+## Summary
+
+Current first-party evidence supports simplifying the human-facing handoff contract, but not collapsing the entire product into `default | full` as the only public axis. Major CLIs separate:
+
+- human-readable output
+- machine-readable output
+- explicit session/history/inspection commands
+
+So `default | full` can remain a useful human-facing simplification, but should not be treated as the only public model.
+
+## New Confirmations
+
+- Claude Code, Codex, and Copilot CLI all support structured machine-readable output separately from the default human-facing surface.
+- First-party patterns support a separate inspection/history axis instead of only one detail ladder.
+- Pointer metadata belongs early, but not as the dominant default payload.
+
+## New Contradictions
+
+- treating `default | full` as the whole public contract is too strong
+- treating the pointer block as the universal leading payload is too strong
+- treating plain-text prompt debugging as the sole long-term inspection shape is too strong
+
+## Still Unresolved
+
+- exact public API shape for the separate machine/inspection surface
+- exact placement of the pointer block relative to the summary
+- exact same-tool debug UX
+
+## URLs
+
+- https://code.claude.com/docs/en/cli-reference
+- https://developers.openai.com/codex/cli/reference
+- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+- https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+- https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-best-practices

--- a/docs/research/final-schema-closure-verification/04-sessionr-debug-contract.md
+++ b/docs/research/final-schema-closure-verification/04-sessionr-debug-contract.md
@@ -1,0 +1,39 @@
+# Sessionr And Debug Contract Closure Pass
+
+## Summary
+
+The strongest current first-party conclusion is that `sessionr --new --async` is not a deterministic created-session-ID recovery contract. The README and source support a job-first async contract, but the created session ID is not recovered in the async path the way it is in sync mode.
+
+The current `continues` same-tool `--debug-prompt` rejection is coherent with the code that exists today, because native resume does not synthesize an outbound prompt. But that does not prove it is the best UX. First-party patterns support machine-readable orchestration and explicit next-action surfaces more strongly than plain text alone.
+
+## New Confirmations
+
+- `sessionr` is a structured automation CLI with `api_version`, `meta`, and `actions`
+- sync and async write paths are materially different
+- the local `continues` implementation matches its own semantics
+- major first-party CLIs prefer structured automation output surfaces
+
+## New Contradictions
+
+- any deterministic-ID assumption for `sessionr --new --async`
+- any claim that plain-text-only prompt debugging is the best-supported long-term contract
+
+## Still Unresolved
+
+- whether async new-session-ID recovery is a known bug, accepted tradeoff, or future work in `sessionr`
+- the exact schema of a structured prompt-debug artifact for `continues`
+- whether same-tool debug should hard-error or surface the native resume/action path instead
+
+## URLs
+
+- https://github.com/yigitkonur/cli-sessionr
+- https://github.com/yigitkonur/cli-sessionr/blob/main/src/commands/send.ts
+- https://github.com/yigitkonur/cli-sessionr/blob/main/src/commands/job.ts
+- https://github.com/yigitkonur/cli-sessionr/blob/main/src/jobs.ts
+- https://github.com/yigitkonur/cli-sessionr/blob/main/src/cli.ts
+- https://github.com/yigitkonur/cli-sessionr/blob/main/README.md
+- https://developers.openai.com/codex/noninteractive
+- https://docs.anthropic.com/en/docs/claude-code/cli-reference
+- https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks
+- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+- https://docs.github.com/en/copilot/how-tos/copilot-cli/steer-remotely

--- a/docs/research/high-risk-schema-family-b-adversarial-verification/00-master-summary.md
+++ b/docs/research/high-risk-schema-family-b-adversarial-verification/00-master-summary.md
@@ -1,0 +1,43 @@
+# High-Risk Schema Family B Adversarial Verification
+
+## Document Index
+
+| File | Description |
+| --- | --- |
+| [docs/01-seven-tool-adversarial-verification.md](./docs/01-seven-tool-adversarial-verification.md) | First-party verification of storage, transcript fidelity, and backend-drift claims for `crush`, `amp`, `kilo-code`, `cursor`, `droid`, `copilot`, and `codex`. |
+
+## Critical Findings
+
+- [Amp verification](./docs/01-seven-tool-adversarial-verification.md): the repo’s local JSON thread-store claim is not supported by current first-party docs. Amp’s own security docs say threads are stored on Amp Server in PostgreSQL, while local first-party docs only clearly document settings and credentials paths.
+- [Kilo verification](./docs/01-seven-tool-adversarial-verification.md): the repo overstates the “legacy-only” conclusion. First-party April 2026 docs say the extension was rebuilt on a shared core, but a first-party November 2025 issue for extension `4.117.0+` still shows live `ui_messages.json` writes in VS Code `globalStorage`.
+- [Droid verification](./docs/01-seven-tool-adversarial-verification.md): the repo’s observed `~/.factory/sessions/...` layout is no longer the best first-party anchor. Factory’s hook docs now show `transcript_path` examples under `~/.factory/projects/.../*.jsonl`.
+- [Cursor verification](./docs/01-seven-tool-adversarial-verification.md): the repo’s “tool outputs are missing by design” claim is supported by a first-party staff answer on April 13, 2026.
+- [Copilot verification](./docs/01-seven-tool-adversarial-verification.md): the repo is right that `events.jsonl` exists and that `COPILOT_HOME` / `--config-dir` matter, but GitHub’s docs also say the raw session files are the complete record and `session-store.db` is only a subset for `/chronicle`.
+- [Codex verification](./docs/01-seven-tool-adversarial-verification.md): the repo is broadly right on local rollouts, `history.jsonl`, and SQLite-backed state, but “rollout equals full forensic record” is weakened by a first-party Codex issue showing review-mode tool calls missing from rollout logs.
+- [Crush verification](./docs/01-seven-tool-adversarial-verification.md): current first-party code supports project-local `.crush` data directories, not the home-directory default still asserted in part of the repo research.
+
+## Cross-File Insights
+
+- The repo’s biggest current risk is not “all claims are wrong”; it is inconsistent confidence. The same tool is sometimes described correctly in one local doc and incorrectly in another, especially for `crush` and `kilo-code`.
+- Current first-party material increasingly separates “resume substrate” from “search/index/cache” layers. That distinction is explicit for `copilot` and `codex`, implicit for `cursor`, and currently under-documented for `amp`.
+- The tools with the strongest evidence of intentional fidelity loss are `cursor` and `codex review mode`: one omits tool outputs by design, the other has a first-party bug report alleging missing review-mode tool events in persisted rollouts.
+
+## Action Items
+
+1. Downgrade confidence for `amp`, `droid`, and `kilo-code` storage-path claims until the parser target surface is explicitly split and labeled.
+2. Remove or correct any remaining `~/.crush/crush.db` default-path language; treat project-local `.crush/crush.db` as the current default.
+3. Rewrite `kilo-code` docs to distinguish the current shared-core architecture from still-live extension-side `ui_messages.json` evidence.
+4. For `copilot`, stop implying that `session.db` is required for transcript completeness unless first-party evidence appears; keep the focus on `session-state/<id>/events.jsonl` plus documented overrides.
+5. For `codex`, document that rollouts are primary but not guaranteed to be a perfect audit log for every product surface, citing the review-mode gap.
+
+## Coverage Scope
+
+- Covered: current first-party docs, first-party repo code, first-party issue/forum evidence, and contradictions/support for storage paths, env vars, transcript completeness, and backend drift.
+- Not covered: local live captures, private vendor docs, reverse-engineered binary formats, or non-first-party community writeups unless surfaced through official forums.
+
+## Source Roll-Up
+
+- Official docs: 12
+- First-party repo code files: 4
+- First-party issue/forum threads: 6
+- Other: 0

--- a/docs/research/high-risk-schema-family-b-adversarial-verification/docs/01-seven-tool-adversarial-verification.md
+++ b/docs/research/high-risk-schema-family-b-adversarial-verification/docs/01-seven-tool-adversarial-verification.md
@@ -1,0 +1,163 @@
+# Which current repo claims about Crush, Amp, Kilo Code, Cursor, Droid, Copilot, and Codex survive first-party adversarial verification?
+
+**Scope:** First-party verification of storage paths, env-var overrides, transcript/tool-call completeness, and backend-drift/fidelity-loss claims for seven high-risk tools; this does not include local runtime captures.
+**Last updated:** 2026-04-15
+**Confidence:** Medium — 16 independent first-party sources; several tools still lack public on-disk schema docs.
+
+## Answer
+
+Some repo claims hold up well, especially for `cursor`, `copilot`, and most of `codex`. The most important corrections are that `amp` is much less grounded locally than the repo suggests, `droid` now has first-party transcript-path examples that point at `~/.factory/projects/...` rather than the repo’s `~/.factory/sessions/...` assumption, `kilo-code` is not safely classifiable as “legacy VS Code path only” or “SQLite only,” and `crush` should be treated as project-local `.crush/crush.db` by default.
+
+## Summary
+
+- `crush`: the repo is internally inconsistent; current first-party code supports project-local `.crush/crush.db`, not a home-directory default.
+- `amp`: the repo’s local `threads/*.json` story is not supported by current first-party docs. Amp explicitly stores conversations on Amp Server; local docs clearly document settings and secrets, not a stable local thread transcript schema.
+- `kilo-code`: the repo is right that a new shared-core/OpenCode-style backend exists, but wrong to treat VS Code `ui_messages.json` as merely historical. A first-party issue from November 12, 2025 still shows it active in extension `4.117.0+`.
+- `cursor`: the repo’s fidelity-loss warning is supported. First-party staff say local JSONL transcripts include tool-call inputs but intentionally omit tool-call outputs.
+- `droid`: the repo’s local observation is plausible, but first-party docs now show hook `transcript_path` examples under `~/.factory/projects/.../*.jsonl`, which weakens confidence in `~/.factory/sessions/...` as the canonical path.
+- `copilot`: the repo is directionally right about `events.jsonl`, `session-store.db`, and config overrides, but it overreaches if it implies raw transcript completeness depends on extra undocumented files. GitHub says the per-session files are the complete record and the SQLite store is a subset.
+- `codex`: the repo is mostly right on `CODEX_HOME`, local transcripts, `history.jsonl`, and SQLite-backed state, but “rollout is the full audit trail” is weakened by a first-party Codex issue alleging review-mode tool calls do not land in rollout logs.
+
+## Contradicted Claims
+
+1. **`crush` default path is `~/.crush/crush.db`.**
+The repo’s older conclusion looks plausible because Crush has global config and cache paths, but current first-party code resolves the workspace data directory locally. `internal/config/load.go` sets `Options.DataDirectory` to the closest ancestor `.crush` or `<workingDir>/.crush`, and `internal/cmd/root.go` initializes the DB connection from that data directory. That directly contradicts any claim that the live default session DB is under the home directory.  
+URLs:
+- https://github.com/charmbracelet/crush/blob/main/internal/config/load.go
+- https://github.com/charmbracelet/crush/blob/main/internal/cmd/root.go
+
+2. **`amp` stores live thread transcripts as a documented local JSON thread store under XDG data.**
+This is the weakest repo claim in the set. Current first-party docs explicitly say Amp Server stores conversations in PostgreSQL, and Amp’s security docs describe thread data, retention, and privacy at the server layer. The same docs only clearly document local `~/.local/share/amp/secrets.json`; the manual clearly documents settings under `~/.config/amp/settings.json` or a custom `--settings-file`. That means the repo’s concrete `threads/*.json` local-storage conclusion is not currently supported by first-party material and may be wrong.  
+URLs:
+- https://ampcode.com/security
+- https://ampcode.com/manual
+
+3. **`droid`’s canonical persisted transcript root is `~/.factory/sessions/...`.**
+The repo’s claim is based on local observation, so it could still describe one build, but current first-party docs now expose `transcript_path` in hook payloads and show examples under `~/.factory/projects/.../*.jsonl`. That does not prove the repo’s observed `sessions/` tree is impossible, but it does contradict any strong claim that `sessions/` is the current canonical documented root.  
+URLs:
+- https://docs.factory.ai/reference/hooks-reference
+
+4. **`kilo-code`’s VS Code `ui_messages.json` path is legacy or migration-only now.**
+The repo’s newer-backend conclusion has real support, but it goes too far. First-party April 2026 docs say the extension was rebuilt on a shared open-source core used across VS Code, CLI, and Cloud Agents, which supports the “new backend exists” side. But a first-party Kilo issue opened November 12, 2025 for extension `4.117.0+` still shows active writes to `~/.config/Code/User/globalStorage/kilocode.kilo-code/tasks/.../ui_messages.json` and lock contention on that file. So the safe conclusion is coexistence or transition, not legacy-only.  
+URLs:
+- https://kilo.ai/docs/code-with-ai/platforms/vscode/whats-new
+- https://github.com/Kilo-Org/kilocode/issues/3706
+- https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/storage/db.ts
+
+5. **`copilot` needs extra undocumented side stores to establish transcript completeness.**
+The repo is right that `session-store.db` exists and that undocumented side artifacts may be useful, but GitHub’s current docs are clearer than the repo gives them credit for: every session directory under `~/.copilot/session-state/` contains the complete record for resume, and the SQLite session store is only a subset used for `/chronicle`. That weakens claims that raw fidelity fundamentally depends on `session.db` or other sidecars.  
+URLs:
+- https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference
+
+## Supported Claims
+
+1. **`cursor` local transcripts are fidelity-limited and intentionally omit tool outputs.**
+The repo’s concern is correct. On April 13, 2026, a Cursor staff reply said the JSONL transcript files include user messages, assistant text responses, and tool-call inputs, but intentionally do not include tool-call outputs because outputs can be very large. That directly supports the repo’s claim that transcript recovery is structurally incomplete for tool-output fidelity.  
+URLs:
+- https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311
+
+2. **`cursor` transcript files are not enough for full UI recovery.**
+The repo argued that transcript files exist but may not be sufficient for full history recovery. A February 6, 2026 Cursor forum thread supports that: the user still had `~/.cursor/projects/.../agent-transcripts`, but recovery advice pointed to restoring `state.vscdb` and `workspaceStorage`. That supports the repo’s “transcripts are real, but not the whole recovery story” claim.  
+URLs:
+- https://forum.cursor.com/t/lost-all-cursor-settings-and-chat-history-for-all-projects-i-am-working-on/151081
+- https://forum.cursor.com/t/where-are-cursor-chats-stored/77295/5
+
+3. **`copilot` uses `~/.copilot/session-state/<id>/events.jsonl`, plus `session-store.db`, with `COPILOT_HOME` and `--config-dir` overrides.**
+GitHub’s current docs support all of this directly. They say each session directory stores `events.jsonl` and workspace artifacts, `session-store.db` is a cross-session SQLite database, `COPILOT_HOME` changes the root, and `--config-dir` takes precedence over `COPILOT_HOME`.  
+URLs:
+- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference
+- https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+
+4. **`copilot` session data includes tools used and modified files.**
+The repo’s broader completeness concern is supported at the product level. GitHub says each local session records prompts, responses, the tools that were used, and details of modified files. What remains undocumented is the exact internal shape of those artifacts, not whether GitHub claims they exist.  
+URLs:
+- https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+
+5. **`codex` stores local transcripts under `CODEX_HOME`, keeps `history.jsonl`, and has separate SQLite-backed state.**
+OpenAI’s docs and repo support this. The Codex docs say sessions live under `~/.codex/sessions/` and that `history.jsonl` is controlled by `history.persistence`; the config reference documents `sqlite_home` for SQLite-backed resumable state; and the Codex repo shows date-partitioned rollout files plus `archived_sessions`.  
+URLs:
+- https://developers.openai.com/codex/cli/features
+- https://developers.openai.com/codex/config-reference
+- https://developers.openai.com/codex/config-advanced
+- https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder.rs
+- https://github.com/openai/codex/blob/main/codex-rs/rollout/src/lib.rs
+
+6. **`codex` preserves richer tool-call variants than a simplistic `function_call`/`function_call_output` model.**
+The repo’s fidelity warning is supported by first-party code. Codex protocol definitions include `local_shell_call`, `tool_search_call`, `tool_search_output`, `custom_tool_call`, `custom_tool_call_output`, and other response-item types. If the parser only handles a subset, that is a real fidelity gap.  
+URLs:
+- https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs
+- https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts
+
+7. **`codex` rollouts may fail to capture some first-party product surfaces completely.**
+The repo’s suspicion that rollouts are not always a perfect audit log is strengthened by a first-party issue showing review-mode tool calls missing from rollout logs and resume transcripts. That does not overturn rollout storage itself, but it does weaken “full forensic fidelity” claims.  
+URLs:
+- https://github.com/openai/codex/issues/4792
+
+8. **`droid` exposes strong first-party evidence for tool-call fidelity, even if the exact persisted path is still shifting.**
+Factory’s docs explicitly describe `stream-json` runtime events including `tool_call` and `tool_result`, and hook payloads include `tool_name`, `tool_input`, `tool_response`, `session_id`, and `transcript_path`. That supports the repo’s claim that Droid preserves rich tool-call information; the remaining dispute is storage location and whether runtime and persisted schemas are identical.  
+URLs:
+- https://docs.factory.ai/cli/droid-exec/overview
+- https://docs.factory.ai/reference/hooks-reference
+
+## Still Unresolved
+
+1. **`amp` local on-disk transcript shape and path remain unresolved.**
+Current first-party docs clearly document server-side thread storage, user settings, and local credential storage, but they do not publish a stable local transcript path or schema for the CLI. The repo’s `threads/*.json` claim is therefore unverified, but so is any stronger “no local thread history exists” claim.  
+URLs:
+- https://ampcode.com/security
+- https://ampcode.com/manual
+
+2. **`droid` current persisted transcript root is unresolved between observed `sessions/` and documented `projects/`.**
+First-party hook examples use `~/.factory/projects/.../*.jsonl`, while the repo observed `~/.factory/sessions/...`. Without a current first-party filesystem reference page or live capture across versions, the safest conclusion is that the repo’s path should be downgraded from “documented fact” to “observed variant.”  
+URLs:
+- https://docs.factory.ai/reference/hooks-reference
+- https://docs.factory.ai/cli/configuration/settings
+
+3. **`kilo-code` canonical parser target is unresolved across CLI, VS Code extension, and shared-core internals.**
+First-party docs support persistent sessions, export/import, and cross-platform continuation; first-party code supports `kilo.db`; first-party issue traffic still shows `ui_messages.json` in active extension builds. The repo should not collapse those into a single storage family yet.  
+URLs:
+- https://kilo.ai/docs/code-with-ai/platforms/cli
+- https://kilo.ai/features/sessions
+- https://github.com/Kilo-Org/kilocode/issues/3706
+- https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/storage/db.ts
+
+4. **`codex` exact audit guarantees across all modes are unresolved.**
+The official docs strongly support local transcript persistence, but the review-mode bug report means a parser redesign should not promise perfect completeness across every feature surface unless OpenAI documents or fixes that gap.  
+URLs:
+- https://developers.openai.com/codex/cli/features
+- https://github.com/openai/codex/issues/4792
+
+## Caveats / Negative Signal
+
+- Some first-party evidence comes from official forums or issue trackers rather than polished docs. That is still first-party, but it usually describes a product moment rather than a long-term contract.
+- `cursor`, `amp`, and `droid` are the least contractually documented for raw local storage. The repo’s strongest claims on those tools rely more on observation than on vendor-stated guarantees.
+- `kilo-code` has the clearest “both sides can be right” outcome: the shared-core/SQLite story is real, and the extension-side `ui_messages.json` story is also still real in at least some recent builds.
+
+## URLs
+
+- https://github.com/charmbracelet/crush/blob/main/internal/config/load.go
+- https://github.com/charmbracelet/crush/blob/main/internal/cmd/root.go
+- https://ampcode.com/security
+- https://ampcode.com/manual
+- https://docs.factory.ai/reference/hooks-reference
+- https://docs.factory.ai/cli/droid-exec/overview
+- https://docs.factory.ai/cli/configuration/settings
+- https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311
+- https://forum.cursor.com/t/lost-all-cursor-settings-and-chat-history-for-all-projects-i-am-working-on/151081
+- https://forum.cursor.com/t/where-are-cursor-chats-stored/77295/5
+- https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
+- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference
+- https://developers.openai.com/codex/cli/features
+- https://developers.openai.com/codex/config-reference
+- https://developers.openai.com/codex/config-advanced
+- https://github.com/openai/codex/blob/main/codex-rs/rollout/src/recorder.rs
+- https://github.com/openai/codex/blob/main/codex-rs/rollout/src/lib.rs
+- https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs
+- https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts
+- https://github.com/openai/codex/issues/4792
+- https://kilo.ai/docs/code-with-ai/platforms/cli
+- https://kilo.ai/docs/code-with-ai/platforms/vscode/whats-new
+- https://kilo.ai/features/sessions
+- https://github.com/Kilo-Org/kilocode/issues/3706
+- https://github.com/Kilo-Org/kilocode/blob/main/packages/opencode/src/storage/db.ts

--- a/src/__tests__/codex-parser.test.ts
+++ b/src/__tests__/codex-parser.test.ts
@@ -1,0 +1,156 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { UnifiedSession } from '../types/index.js';
+
+const tempDirs: string[] = [];
+
+function makeCodexHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-parser-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeRollout(root: string, subdir: string, filename: string, rows: unknown[]): string {
+  const targetDir = path.join(root, subdir);
+  fs.mkdirSync(targetDir, { recursive: true });
+  const fullPath = path.join(targetDir, filename);
+  fs.writeFileSync(fullPath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+  return fullPath;
+}
+
+async function loadCodexParser(home: string): Promise<typeof import('../parsers/codex.js')> {
+  vi.resetModules();
+  vi.stubEnv('CODEX_HOME', home);
+  return import('../parsers/codex.js');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe('codex parser hardening', () => {
+  it('discovers sessions from both active and archived session trees', async () => {
+    const home = makeCodexHome();
+
+    writeRollout(
+      home,
+      path.join('sessions', '2026', '04', '15'),
+      'rollout-2026-04-15T10-00-00-active-session-id.jsonl',
+      [
+        {
+          timestamp: '2026-04-15T10:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'active-session-id', cwd: '/tmp/active' },
+        },
+        {
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'Active session' },
+        },
+      ],
+    );
+
+    writeRollout(
+      home,
+      path.join('archived_sessions', '2026', '04', '14'),
+      'rollout-2026-04-14T09-00-00-archived-session-id.jsonl',
+      [
+        {
+          timestamp: '2026-04-14T09:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'archived-session-id', cwd: '/tmp/archived' },
+        },
+        {
+          timestamp: '2026-04-14T09:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'Archived session' },
+        },
+      ],
+    );
+
+    const { parseCodexSessions } = await loadCodexParser(home);
+    const sessions = await parseCodexSessions();
+
+    expect(sessions.map((session) => session.id)).toContain('active-session-id');
+    expect(sessions.map((session) => session.id)).toContain('archived-session-id');
+  });
+
+  it('extracts token usage from nested token_count payload.info totals', async () => {
+    const home = makeCodexHome();
+    const originalPath = writeRollout(
+      home,
+      path.join('sessions', '2026', '04', '15'),
+      'rollout-2026-04-15T10-00-00-token-session-id.jsonl',
+      [
+        {
+          timestamp: '2026-04-15T10:00:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'token-session-id',
+            cwd: '/tmp/project',
+            git: { branch: 'main', repository_url: 'https://github.com/user/project.git' },
+          },
+        },
+        {
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'response_item',
+          payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Token check' }] },
+        },
+        {
+          timestamp: '2026-04-15T10:00:02.000Z',
+          type: 'response_item',
+          payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Done.' }] },
+        },
+        {
+          timestamp: '2026-04-15T10:00:03.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'token_count',
+            info: {
+              total_token_usage: {
+                input_tokens: 120,
+                output_tokens: 45,
+                cached_input_tokens: 17,
+                reasoning_output_tokens: 9,
+              },
+              last_token_usage: {
+                input_tokens: 20,
+                output_tokens: 5,
+                cached_input_tokens: 2,
+                reasoning_output_tokens: 1,
+              },
+            },
+          },
+        },
+      ],
+    );
+
+    const { extractCodexContext } = await loadCodexParser(home);
+    const session: UnifiedSession = {
+      id: 'token-session-id',
+      source: 'codex',
+      cwd: '/tmp/project',
+      repo: 'user/project',
+      branch: 'main',
+      lines: 4,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-04-15T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-15T10:00:03.000Z'),
+      originalPath,
+      summary: 'Token check',
+    };
+
+    const context = await extractCodexContext(session);
+
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 120, output: 45 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 0, read: 17 });
+    expect(context.sessionNotes?.thinkingTokens).toBe(9);
+  });
+});

--- a/src/__tests__/copilot-parser.test.ts
+++ b/src/__tests__/copilot-parser.test.ts
@@ -1,0 +1,374 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { UnifiedSession } from '../types/index.js';
+
+const tmpDirs: string[] = [];
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  const content = rows.map((row) => JSON.stringify(row)).join('\n');
+  fs.writeFileSync(filePath, `${content}\n`, 'utf8');
+}
+
+function createCopilotSession(opts: {
+  copilotHome: string;
+  sessionId: string;
+  workspace?: {
+    cwd?: string;
+    repository?: string;
+    branch?: string;
+    summary?: string;
+    createdAt?: string;
+    updatedAt?: string;
+  };
+  events: unknown[];
+}): string {
+  const sessionDir = path.join(opts.copilotHome, 'session-state', opts.sessionId);
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  const workspace = [
+    `id: ${opts.sessionId}`,
+    `cwd: ${opts.workspace?.cwd ?? '/tmp/copilot-project'}`,
+    `repository: ${opts.workspace?.repository ?? 'acme/copilot-project'}`,
+    `branch: ${opts.workspace?.branch ?? 'main'}`,
+    `summary: "${opts.workspace?.summary ?? 'Copilot parser regression'}"`,
+    `created_at: ${opts.workspace?.createdAt ?? '2026-04-15T10:00:00.000Z'}`,
+    `updated_at: ${opts.workspace?.updatedAt ?? '2026-04-15T10:05:00.000Z'}`,
+  ].join('\n');
+
+  fs.writeFileSync(path.join(sessionDir, 'workspace.yaml'), `${workspace}\n`, 'utf8');
+  writeJsonl(path.join(sessionDir, 'events.jsonl'), opts.events);
+
+  return sessionDir;
+}
+
+async function loadCopilotParserWithHome(homeDir: string): Promise<typeof import('../parsers/copilot.js')> {
+  vi.resetModules();
+  vi.doMock('os', async () => {
+    const actual = await vi.importActual<typeof import('os')>('os');
+    return {
+      ...actual,
+      homedir: () => homeDir,
+    };
+  });
+  return import('../parsers/copilot.js');
+}
+
+function makeSession(sessionDir: string, sessionId: string): UnifiedSession {
+  const eventsPath = path.join(sessionDir, 'events.jsonl');
+  const stats = fs.statSync(eventsPath);
+  return {
+    id: sessionId,
+    source: 'copilot',
+    cwd: '/tmp/copilot-project',
+    repo: 'acme/copilot-project',
+    branch: 'main',
+    summary: 'Copilot parser regression',
+    lines: fs.readFileSync(eventsPath, 'utf8').trim().split('\n').length,
+    bytes: stats.size,
+    createdAt: new Date('2026-04-15T10:00:00.000Z'),
+    updatedAt: new Date('2026-04-15T10:05:00.000Z'),
+    originalPath: sessionDir,
+    model: 'claude-sonnet-4',
+  };
+}
+
+afterEach(() => {
+  vi.doUnmock('os');
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+
+describe('copilot parser regressions', () => {
+  it('discovers sessions from COPILOT_HOME instead of only ~/.copilot', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-home-'));
+    const copilotHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-config-'));
+    tmpDirs.push(fakeHome, copilotHome);
+
+    createCopilotSession({
+      copilotHome,
+      sessionId: 'copilot-home-session',
+      events: [
+        {
+          type: 'session.start',
+          id: 'evt-001',
+          timestamp: '2026-04-15T10:00:00.000Z',
+          parentId: null,
+          data: {
+            sessionId: 'copilot-home-session',
+            selectedModel: 'claude-sonnet-4',
+          },
+        },
+        {
+          type: 'user.message',
+          id: 'evt-002',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          parentId: 'evt-001',
+          data: {
+            content: 'Honor COPILOT_HOME',
+          },
+        },
+      ],
+    });
+
+    vi.stubEnv('COPILOT_HOME', copilotHome);
+    const { parseCopilotSessions } = await loadCopilotParserWithHome(fakeHome);
+    const sessions = await parseCopilotSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('copilot-home-session');
+    expect(sessions[0].originalPath).toContain(copilotHome);
+  });
+
+  it('enriches tool summaries with tool.execution_complete results without double-counting matching assistant tool requests', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-home-'));
+    const copilotHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-config-'));
+    tmpDirs.push(fakeHome, copilotHome);
+
+    const sessionDir = createCopilotSession({
+      copilotHome,
+      sessionId: 'tool-result-session',
+      events: [
+        {
+          type: 'session.start',
+          id: 'evt-001',
+          timestamp: '2026-04-15T10:00:00.000Z',
+          parentId: null,
+          data: {
+            sessionId: 'tool-result-session',
+            selectedModel: 'claude-sonnet-4',
+          },
+        },
+        {
+          type: 'user.message',
+          id: 'evt-002',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          parentId: 'evt-001',
+          data: {
+            content: 'Run the test suite',
+          },
+        },
+        {
+          type: 'assistant.message',
+          id: 'evt-003',
+          timestamp: '2026-04-15T10:00:02.000Z',
+          parentId: 'evt-002',
+          data: {
+            content: 'Running the tests now.',
+            toolRequests: [
+              {
+                name: 'bash',
+                arguments: {
+                  command: 'pnpm test --filter copilot',
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'tool.execution_start',
+          id: 'evt-004',
+          timestamp: '2026-04-15T10:00:03.000Z',
+          parentId: 'evt-003',
+          data: {
+            toolCallId: 'tool-001',
+            toolName: 'bash',
+            arguments: {
+              command: 'pnpm test --filter copilot',
+            },
+          },
+        },
+        {
+          type: 'tool.execution_complete',
+          id: 'evt-005',
+          timestamp: '2026-04-15T10:00:04.000Z',
+          parentId: 'evt-004',
+          data: {
+            toolCallId: 'tool-001',
+            success: true,
+            result: {
+              content: '2 tests passed',
+              detailedContent: '2 tests passed\n<exited with exit code 0>',
+            },
+          },
+        },
+      ],
+    });
+
+    const { extractCopilotContext } = await loadCopilotParserWithHome(fakeHome);
+    const context = await extractCopilotContext(makeSession(sessionDir, 'tool-result-session'));
+    const bashSummary = context.toolSummaries.find((summary) => summary.name === 'bash');
+
+    expect(bashSummary).toBeDefined();
+    expect(bashSummary?.count).toBe(1);
+    expect(bashSummary?.samples[0].summary).toContain('2 tests passed');
+    expect(bashSummary?.samples[0].data).toMatchObject({
+      category: 'shell',
+      command: 'pnpm test --filter copilot',
+      exitCode: 0,
+      stdoutTail: '2 tests passed',
+    });
+  });
+
+  it('captures write activity from tool execution events even when assistant toolRequests are absent', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-home-'));
+    const copilotHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-config-'));
+    tmpDirs.push(fakeHome, copilotHome);
+
+    const sessionDir = createCopilotSession({
+      copilotHome,
+      sessionId: 'tool-write-session',
+      events: [
+        {
+          type: 'session.start',
+          id: 'evt-001',
+          timestamp: '2026-04-15T10:00:00.000Z',
+          parentId: null,
+          data: {
+            sessionId: 'tool-write-session',
+            selectedModel: 'claude-sonnet-4',
+          },
+        },
+        {
+          type: 'user.message',
+          id: 'evt-002',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          parentId: 'evt-001',
+          data: {
+            content: 'Patch the Copilot parser',
+          },
+        },
+        {
+          type: 'assistant.message',
+          id: 'evt-003',
+          timestamp: '2026-04-15T10:00:02.000Z',
+          parentId: 'evt-002',
+          data: {
+            content: 'Applying the parser fix.',
+            toolRequests: [],
+          },
+        },
+        {
+          type: 'tool.execution_start',
+          id: 'evt-004',
+          timestamp: '2026-04-15T10:00:03.000Z',
+          parentId: 'evt-003',
+          data: {
+            toolCallId: 'tool-002',
+            toolName: 'WriteFile',
+            arguments: {
+              path: 'src/parsers/copilot.ts',
+            },
+          },
+        },
+        {
+          type: 'tool.execution_complete',
+          id: 'evt-005',
+          timestamp: '2026-04-15T10:00:04.000Z',
+          parentId: 'evt-004',
+          data: {
+            toolCallId: 'tool-002',
+            success: true,
+            result: {
+              content: 'File updated successfully',
+            },
+          },
+        },
+      ],
+    });
+
+    const { extractCopilotContext } = await loadCopilotParserWithHome(fakeHome);
+    const context = await extractCopilotContext(makeSession(sessionDir, 'tool-write-session'));
+    const writeSummary = context.toolSummaries.find((summary) => summary.name === 'WriteFile');
+
+    expect(writeSummary).toBeDefined();
+    expect(writeSummary?.count).toBe(1);
+    expect(context.filesModified).toContain('src/parsers/copilot.ts');
+    expect(writeSummary?.samples[0].data).toMatchObject({
+      category: 'write',
+      filePath: 'src/parsers/copilot.ts',
+    });
+  });
+
+  it('falls back to result.contents text blocks when tool.execution_complete omits content strings', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-home-'));
+    const copilotHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-config-'));
+    tmpDirs.push(fakeHome, copilotHome);
+
+    const sessionDir = createCopilotSession({
+      copilotHome,
+      sessionId: 'tool-contents-session',
+      events: [
+        {
+          type: 'session.start',
+          id: 'evt-001',
+          timestamp: '2026-04-15T10:00:00.000Z',
+          parentId: null,
+          data: {
+            sessionId: 'tool-contents-session',
+            selectedModel: 'claude-sonnet-4',
+          },
+        },
+        {
+          type: 'user.message',
+          id: 'evt-002',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          parentId: 'evt-001',
+          data: {
+            content: 'Run a fallback-result shell command',
+          },
+        },
+        {
+          type: 'tool.execution_start',
+          id: 'evt-003',
+          timestamp: '2026-04-15T10:00:02.000Z',
+          parentId: 'evt-002',
+          data: {
+            toolCallId: 'tool-003',
+            toolName: 'bash',
+            arguments: {
+              command: 'git status --short',
+            },
+          },
+        },
+        {
+          type: 'tool.execution_complete',
+          id: 'evt-004',
+          timestamp: '2026-04-15T10:00:03.000Z',
+          parentId: 'evt-003',
+          data: {
+            toolCallId: 'tool-003',
+            success: true,
+            result: {
+              contents: [
+                {
+                  type: 'text',
+                  text: 'M src/parsers/copilot.ts\n<exited with exit code 0>',
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    const { extractCopilotContext } = await loadCopilotParserWithHome(fakeHome);
+    const context = await extractCopilotContext(makeSession(sessionDir, 'tool-contents-session'));
+    const bashSummary = context.toolSummaries.find((summary) => summary.name === 'bash');
+
+    expect(bashSummary).toBeDefined();
+    expect(bashSummary?.count).toBe(1);
+    expect(bashSummary?.samples[0].summary).toContain('exit 0');
+    expect(bashSummary?.samples[0].data).toMatchObject({
+      category: 'shell',
+      command: 'git status --short',
+      exitCode: 0,
+      stdoutTail: 'M src/parsers/copilot.ts\n<exited with exit code 0>',
+    });
+  });
+});

--- a/src/__tests__/cursor-parser.test.ts
+++ b/src/__tests__/cursor-parser.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { UnifiedSession } from '../types/index.js';
+
+const tempDirs: string[] = [];
+
+function makeCursorHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-parser-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeCursorTranscript(home: string, slug: string, sessionId: string, rows: unknown[]): string {
+  const dir = path.join(home, '.cursor', 'projects', slug, 'agent-transcripts', sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, `${sessionId}.jsonl`);
+  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+  return filePath;
+}
+
+async function loadCursorParser(home: string): Promise<typeof import('../parsers/cursor.js')> {
+  vi.resetModules();
+  vi.doMock('../utils/parser-helpers.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../utils/parser-helpers.js')>();
+    return {
+      ...actual,
+      homeDir: () => home,
+    };
+  });
+  return import('../parsers/cursor.js');
+}
+
+afterEach(() => {
+  vi.doUnmock('../utils/parser-helpers.js');
+  vi.resetModules();
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+describe('cursor parser confidence warnings', () => {
+  it('includes a transcript completeness warning in extracted context', async () => {
+    const home = makeCursorHome();
+    const sessionId = '11111111-2222-3333-4444-555555555555';
+    const originalPath = writeCursorTranscript(home, 'Users-test-project', sessionId, [
+      {
+        role: 'user',
+        message: {
+          content: [{ type: 'text', text: 'Review auth flow' }],
+        },
+      },
+      {
+        role: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'I checked the transcript.' }],
+        },
+      },
+    ]);
+
+    const { extractCursorContext } = await loadCursorParser(home);
+    const context = await extractCursorContext({
+      id: sessionId,
+      source: 'cursor',
+      cwd: '/Users/test/project',
+      repo: 'test/project',
+      lines: 2,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-04-15T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-15T00:00:00.000Z'),
+      originalPath,
+      summary: 'Review auth flow',
+    } satisfies UnifiedSession);
+
+    expect(context.sessionNotes?.reasoning).toEqual(
+      expect.arrayContaining([expect.stringContaining('Cursor transcript completeness warning')]),
+    );
+    expect(context.markdown).toContain('Cursor transcript completeness warning');
+  });
+});

--- a/src/__tests__/gemini-parser.test.ts
+++ b/src/__tests__/gemini-parser.test.ts
@@ -1,0 +1,233 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { UnifiedSession } from '../types/index.js';
+
+const tempDirs: string[] = [];
+
+function makeGeminiHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-parser-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function loadGeminiParser(home: string): Promise<typeof import('../parsers/gemini.js')> {
+  vi.resetModules();
+  vi.stubEnv('GEMINI_CLI_HOME', home);
+  return import('../parsers/gemini.js');
+}
+
+function writeGeminiJsonlSession(opts: {
+  home: string;
+  projectId: string;
+  fileName: string;
+  records: unknown[];
+  projects?: Record<string, string>;
+}): string {
+  const chatsDir = path.join(opts.home, '.gemini', 'tmp', opts.projectId, 'chats');
+  fs.mkdirSync(chatsDir, { recursive: true });
+  if (opts.projects) {
+    fs.writeFileSync(
+      path.join(opts.home, '.gemini', 'projects.json'),
+      JSON.stringify({ projects: opts.projects }, null, 2),
+      'utf8',
+    );
+  }
+  const filePath = path.join(chatsDir, opts.fileName);
+  fs.writeFileSync(filePath, `${opts.records.map((record) => JSON.stringify(record)).join('\n')}\n`, 'utf8');
+  return filePath;
+}
+
+function writeGeminiLegacySession(opts: {
+  home: string;
+  projectId: string;
+  fileName: string;
+  session: unknown;
+}): string {
+  const chatsDir = path.join(opts.home, '.gemini', 'tmp', opts.projectId, 'chats');
+  fs.mkdirSync(chatsDir, { recursive: true });
+  const filePath = path.join(chatsDir, opts.fileName);
+  fs.writeFileSync(filePath, JSON.stringify(opts.session, null, 2), 'utf8');
+  return filePath;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe('gemini parser hardening', () => {
+  it('discovers JSONL chat recordings and recovers cwd from projects.json mapping', async () => {
+    const home = makeGeminiHome();
+    writeGeminiJsonlSession({
+      home,
+      projectId: 'proj-short-id',
+      fileName: 'session-2026-04-15T10-00-test1234.jsonl',
+      projects: { '/tmp/gemini-project': 'proj-short-id' },
+      records: [
+        {
+          sessionId: 'gemini-jsonl-session',
+          projectHash: 'proj-short-id',
+          startTime: '2026-04-15T10:00:00.000Z',
+          lastUpdated: '2026-04-15T10:00:00.000Z',
+        },
+        {
+          id: 'msg-user-1',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'user',
+          content: [{ type: 'text', text: 'Inspect current recorder format' }],
+        },
+      ],
+    });
+
+    const { parseGeminiSessions } = await loadGeminiParser(home);
+    const sessions = await parseGeminiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('gemini-jsonl-session');
+    expect(sessions[0].cwd).toBe('/tmp/gemini-project');
+    expect(sessions[0].summary).toBe('Inspect current recorder format');
+  });
+
+  it('replays metadata updates and rewind markers in JSONL sessions', async () => {
+    const home = makeGeminiHome();
+    const originalPath = writeGeminiJsonlSession({
+      home,
+      projectId: 'proj-short-id',
+      fileName: 'session-2026-04-15T10-00-replay1234.jsonl',
+      projects: { '/tmp/gemini-project': 'proj-short-id' },
+      records: [
+        {
+          sessionId: 'gemini-replay-session',
+          projectHash: 'proj-short-id',
+          startTime: '2026-04-15T10:00:00.000Z',
+          lastUpdated: '2026-04-15T10:00:00.000Z',
+        },
+        {
+          id: 'msg-user-1',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'user',
+          content: [{ type: 'text', text: 'Find the auth issue' }],
+        },
+        {
+          id: 'msg-asst-1',
+          timestamp: '2026-04-15T10:00:02.000Z',
+          type: 'gemini',
+          content: '',
+          model: 'gemini-2.5-pro',
+          toolCalls: [
+            {
+              id: 'tool-1',
+              name: 'read_file',
+              args: { file_path: 'login.ts' },
+              status: 'completed',
+              timestamp: '2026-04-15T10:00:02.000Z',
+              resultDisplay: { filePath: 'login.ts', fileName: 'login.ts' },
+            },
+          ],
+          tokens: { input: 50, output: 10, cached: 3, thoughts: 2, total: 65 },
+        },
+        {
+          id: 'msg-asst-2',
+          timestamp: '2026-04-15T10:00:03.000Z',
+          type: 'gemini',
+          content: 'Interim answer that should be rewound away',
+        },
+        { $rewindTo: 'msg-asst-2' },
+        {
+          id: 'msg-asst-1',
+          timestamp: '2026-04-15T10:00:04.000Z',
+          type: 'gemini',
+          content: 'Final answer after replay',
+          model: 'gemini-2.5-pro',
+          toolCalls: [
+            {
+              id: 'tool-1',
+              name: 'read_file',
+              args: { file_path: 'login.ts' },
+              status: 'completed',
+              timestamp: '2026-04-15T10:00:04.000Z',
+              resultDisplay: { filePath: 'login.ts', fileName: 'login.ts' },
+            },
+          ],
+          thoughts: [{ subject: 'Next step', description: 'Patch login.ts' }],
+          tokens: { input: 70, output: 20, cached: 5, thoughts: 4, total: 99 },
+        },
+        {
+          $set: {
+            lastUpdated: '2026-04-15T10:00:05.000Z',
+            summary: 'Replayed summary',
+            directories: ['/tmp/gemini-project', '/tmp/extra-dir'],
+          },
+        },
+      ],
+    });
+
+    const { extractGeminiContext } = await loadGeminiParser(home);
+    const session: UnifiedSession = {
+      id: 'gemini-replay-session',
+      source: 'gemini',
+      cwd: '/tmp/gemini-project',
+      repo: '',
+      lines: 7,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-04-15T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-15T10:00:05.000Z'),
+      originalPath,
+      summary: 'Find the auth issue',
+    };
+
+    const context = await extractGeminiContext(session);
+
+    expect(context.recentMessages.map((message) => message.content)).toContain('Final answer after replay');
+    expect(context.recentMessages.map((message) => message.content)).not.toContain(
+      'Interim answer that should be rewound away',
+    );
+    expect(context.filesModified).toContain('login.ts');
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 120, output: 30 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 0, read: 8 });
+    expect(context.sessionNotes?.thinkingTokens).toBe(6);
+    expect(context.sessionNotes?.model).toBe('gemini-2.5-pro');
+  });
+
+  it('falls back to legacy JSON session blobs in chats directories', async () => {
+    const home = makeGeminiHome();
+    writeGeminiLegacySession({
+      home,
+      projectId: 'legacy-proj-id',
+      fileName: 'session-2026-04-15T10-00-legacy1234.json',
+      session: {
+        sessionId: 'gemini-legacy-session',
+        projectHash: 'legacy-proj-id',
+        startTime: '2026-04-15T11:00:00.000Z',
+        lastUpdated: '2026-04-15T11:02:00.000Z',
+        messages: [
+          {
+            id: 'legacy-user-1',
+            timestamp: '2026-04-15T11:00:01.000Z',
+            type: 'user',
+            content: [{ type: 'text', text: 'Handle the fallback path' }],
+          },
+          {
+            id: 'legacy-asst-1',
+            timestamp: '2026-04-15T11:00:02.000Z',
+            type: 'gemini',
+            content: 'Legacy response',
+          },
+        ],
+      },
+    });
+
+    const { parseGeminiSessions } = await loadGeminiParser(home);
+    const sessions = await parseGeminiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('gemini-legacy-session');
+    expect(sessions[0].summary).toBe('Handle the fallback path');
+  });
+});

--- a/src/__tests__/gemini-parser.test.ts
+++ b/src/__tests__/gemini-parser.test.ts
@@ -189,9 +189,9 @@ describe('gemini parser hardening', () => {
       'Interim answer that should be rewound away',
     );
     expect(context.filesModified).toContain('login.ts');
-    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 120, output: 30 });
-    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 0, read: 8 });
-    expect(context.sessionNotes?.thinkingTokens).toBe(6);
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 70, output: 20 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 0, read: 5 });
+    expect(context.sessionNotes?.thinkingTokens).toBe(4);
     expect(context.sessionNotes?.model).toBe('gemini-2.5-pro');
   });
 
@@ -229,5 +229,36 @@ describe('gemini parser hardening', () => {
     expect(sessions).toHaveLength(1);
     expect(sessions[0].id).toBe('gemini-legacy-session');
     expect(sessions[0].summary).toBe('Handle the fallback path');
+  });
+
+  it('skips malformed trailing JSONL lines instead of discarding the whole session', async () => {
+    const home = makeGeminiHome();
+    const filePath = writeGeminiJsonlSession({
+      home,
+      projectId: 'proj-short-id',
+      fileName: 'session-2026-04-15T10-00-malformed1234.jsonl',
+      projects: { '/tmp/gemini-project': 'proj-short-id' },
+      records: [
+        {
+          sessionId: 'gemini-malformed-session',
+          projectHash: 'proj-short-id',
+          startTime: '2026-04-15T10:00:00.000Z',
+          lastUpdated: '2026-04-15T10:00:00.000Z',
+        },
+        {
+          id: 'msg-user-1',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'user',
+          content: [{ type: 'text', text: 'Parser should survive a bad tail line' }],
+        },
+      ],
+    });
+    fs.appendFileSync(filePath, '{"broken":\n', 'utf8');
+
+    const { parseGeminiSessions } = await loadGeminiParser(home);
+    const sessions = await parseGeminiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('gemini-malformed-session');
   });
 });

--- a/src/__tests__/opencode.test.ts
+++ b/src/__tests__/opencode.test.ts
@@ -1,0 +1,554 @@
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
+
+interface OpenCodeFixture {
+  dbPath: string;
+  root: string;
+  cleanup: () => void;
+}
+
+interface OpenCodeJsonFixture {
+  root: string;
+  xdgDataHome: string;
+  cleanup: () => void;
+}
+
+interface JsonSeedOptions {
+  sessionId?: string;
+  sessionTitle?: string;
+  summaryAdditions?: number;
+  summaryDeletions?: number;
+  summaryFiles?: number;
+  messages?: Array<{
+    id: string;
+    role: 'user' | 'assistant';
+    timeCreatedOffsetMs: number;
+    parts: Array<Record<string, unknown>>;
+  }>;
+}
+
+interface SeedOptions {
+  sessionId?: string;
+  sessionTitle?: string;
+  summaryAdditions?: number | null;
+  summaryDeletions?: number | null;
+  summaryFiles?: number | null;
+  messages?: Array<{
+    id: string;
+    role: 'user' | 'assistant';
+    timeCreatedOffsetMs: number;
+    parts: Array<Record<string, unknown>>;
+  }>;
+}
+
+const originalEnv = {
+  OPENCODE_DB: process.env.OPENCODE_DB,
+  XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+};
+
+function createOpenCodeSqliteFixture(dbFileName: string, options: SeedOptions = {}): OpenCodeFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-parser-'));
+  const dbDir = path.join(root, 'db');
+  const dbPath = path.join(dbDir, dbFileName);
+  fs.mkdirSync(dbDir, { recursive: true });
+
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE project (
+      id TEXT PRIMARY KEY,
+      worktree TEXT NOT NULL
+    );
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      slug TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      title TEXT NOT NULL,
+      version TEXT NOT NULL,
+      summary_additions INTEGER,
+      summary_deletions INTEGER,
+      summary_files INTEGER,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+
+  const now = Date.now();
+  const sessionId = options.sessionId ?? 'ses_test_sqlite';
+  const summaryAdditions = options.summaryAdditions ?? null;
+  const summaryDeletions = options.summaryDeletions ?? null;
+  const summaryFiles = options.summaryFiles ?? null;
+  const messages = options.messages ?? [
+    {
+      id: 'msg_user_1',
+      role: 'user' as const,
+      timeCreatedOffsetMs: -3_000,
+      parts: [{ type: 'text', text: 'Investigate login.ts failures' }],
+    },
+    {
+      id: 'msg_assistant_1',
+      role: 'assistant' as const,
+      timeCreatedOffsetMs: -2_000,
+      parts: [{ type: 'text', text: 'The validation branch is missing.' }],
+    },
+  ];
+
+  db.prepare('INSERT INTO project (id, worktree) VALUES (?, ?)').run('proj_test', '/home/user/project');
+  db.prepare(
+    `INSERT INTO session (
+      id,
+      project_id,
+      slug,
+      directory,
+      title,
+      version,
+      summary_additions,
+      summary_deletions,
+      summary_files,
+      time_created,
+      time_updated
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    sessionId,
+    'proj_test',
+    'test-session',
+    '/home/user/project',
+    options.sessionTitle ?? 'New session',
+    '1.2.0',
+    summaryAdditions,
+    summaryDeletions,
+    summaryFiles,
+    now - 5_000,
+    now,
+  );
+
+  for (const message of messages) {
+    const timeCreated = now + message.timeCreatedOffsetMs;
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)').run(
+      message.id,
+      sessionId,
+      timeCreated,
+      JSON.stringify({ role: message.role, time: { created: timeCreated } }),
+    );
+
+    message.parts.forEach((part, index) => {
+      db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)').run(
+        `${message.id}_part_${index + 1}`,
+        message.id,
+        sessionId,
+        timeCreated + index,
+        JSON.stringify(part),
+      );
+    });
+  }
+
+  db.close();
+
+  return {
+    dbPath,
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function createOpenCodeChannelSqliteFixture(dbFileName: string, options: SeedOptions = {}): OpenCodeFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-parser-channel-'));
+  const xdgDataHome = path.join(root, 'xdg-data');
+  const dbDir = path.join(xdgDataHome, 'opencode');
+  const dbPath = path.join(dbDir, dbFileName);
+  fs.mkdirSync(dbDir, { recursive: true });
+
+  const fixture = createOpenCodeSqliteFixture(dbFileName, options);
+  fs.copyFileSync(fixture.dbPath, dbPath);
+  fixture.cleanup();
+
+  return {
+    dbPath,
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function createOpenCodeJsonFixture(options: JsonSeedOptions = {}): OpenCodeJsonFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-parser-json-'));
+  const xdgDataHome = path.join(root, 'xdg-data');
+  const storageDir = path.join(xdgDataHome, 'opencode', 'storage');
+  const projectId = 'proj_json';
+  const sessionId = options.sessionId ?? 'ses_json';
+  const now = Date.now();
+  const messages = options.messages ?? [
+    {
+      id: 'msg_user_1',
+      role: 'user' as const,
+      timeCreatedOffsetMs: -4_000,
+      parts: [{ type: 'text', text: 'Audit the auth validation flow' }],
+    },
+    {
+      id: 'msg_assistant_1',
+      role: 'assistant' as const,
+      timeCreatedOffsetMs: -3_000,
+      parts: [
+        {
+          type: 'reasoning',
+          text: 'The early return bypasses token validation.',
+        },
+        {
+          type: 'tool',
+          callID: 'call_edit_1',
+          tool: 'edit',
+          state: {
+            status: 'completed',
+            input: { filePath: 'src/auth.ts' },
+            output: 'Inserted token validation before the early return.',
+          },
+        },
+      ],
+    },
+  ];
+
+  fs.mkdirSync(path.join(storageDir, 'session', projectId), { recursive: true });
+  fs.mkdirSync(path.join(storageDir, 'project'), { recursive: true });
+  fs.mkdirSync(path.join(storageDir, 'message', sessionId), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(storageDir, 'session', projectId, `${sessionId}.json`),
+    JSON.stringify({
+      id: sessionId,
+      slug: 'json-session',
+      version: '1.1.47',
+      projectID: projectId,
+      directory: '/home/user/project',
+      title: options.sessionTitle ?? 'New session',
+      time: { created: now - 5_000, updated: now },
+      summary: {
+        additions: options.summaryAdditions,
+        deletions: options.summaryDeletions,
+        files: options.summaryFiles,
+      },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(storageDir, 'project', `${projectId}.json`),
+    JSON.stringify({ id: projectId, worktree: '/home/user/project' }),
+  );
+
+  for (const message of messages) {
+    const timeCreated = now + message.timeCreatedOffsetMs;
+    fs.writeFileSync(
+      path.join(storageDir, 'message', sessionId, `${message.id}.json`),
+      JSON.stringify({
+        id: message.id,
+        sessionID: sessionId,
+        role: message.role,
+        time: { created: timeCreated, ...(message.role === 'assistant' ? { completed: timeCreated + 500 } : {}) },
+      }),
+    );
+
+    const partDir = path.join(storageDir, 'part', message.id);
+    fs.mkdirSync(partDir, { recursive: true });
+
+    message.parts.forEach((part, index) => {
+      fs.writeFileSync(
+        path.join(partDir, `prt_${message.id}_${index + 1}.json`),
+        JSON.stringify({
+          id: `prt_${message.id}_${index + 1}`,
+          sessionID: sessionId,
+          messageID: message.id,
+          ...part,
+        }),
+      );
+    });
+  }
+
+  return {
+    root,
+    xdgDataHome,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+async function importOpenCodeParser() {
+  vi.resetModules();
+  return import('../parsers/opencode.js');
+}
+
+afterEach(() => {
+  process.env.OPENCODE_DB = originalEnv.OPENCODE_DB;
+  process.env.XDG_DATA_HOME = originalEnv.XDG_DATA_HOME;
+  vi.resetModules();
+});
+
+describe('OpenCode parser', () => {
+  it('discovers channel-specific SQLite DB filenames when OPENCODE_DB is unset', async () => {
+    const fixture = createOpenCodeChannelSqliteFixture('opencode-preview.db', {
+      sessionId: 'ses_channel',
+      sessionTitle: 'Preview channel session',
+    });
+
+    try {
+      process.env.XDG_DATA_HOME = path.join(fixture.root, 'xdg-data');
+      delete process.env.OPENCODE_DB;
+
+      const { parseOpenCodeSessions } = await importOpenCodeParser();
+      const sessions = await parseOpenCodeSessions();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]).toMatchObject({
+        id: 'ses_channel',
+        originalPath: fixture.dbPath,
+        summary: 'Preview channel session',
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('prefers OPENCODE_DB when resolving the SQLite database path', async () => {
+    const fixture = createOpenCodeSqliteFixture('opencode-preview.db', {
+      sessionId: 'ses_override',
+      sessionTitle: 'Override DB session',
+    });
+
+    try {
+      process.env.XDG_DATA_HOME = path.join(fixture.root, 'xdg-data');
+      process.env.OPENCODE_DB = fixture.dbPath;
+
+      const { parseOpenCodeSessions } = await importOpenCodeParser();
+      const sessions = await parseOpenCodeSessions();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]).toMatchObject({
+        id: 'ses_override',
+        originalPath: fixture.dbPath,
+        summary: 'Override DB session',
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps high-value non-text SQLite parts in extracted recent messages', async () => {
+    const fixture = createOpenCodeSqliteFixture('opencode.db', {
+      sessionId: 'ses_parts',
+      messages: [
+        {
+          id: 'msg_user_1',
+          role: 'user',
+          timeCreatedOffsetMs: -3_000,
+          parts: [{ type: 'text', text: 'Inspect the failing auth flow' }],
+        },
+        {
+          id: 'msg_assistant_1',
+          role: 'assistant',
+          timeCreatedOffsetMs: -2_000,
+          parts: [
+            { type: 'reasoning', text: 'Need to inspect login.ts and confirm the guard path.' },
+            {
+              type: 'tool',
+              callID: 'call_read_1',
+              tool: 'read',
+              state: {
+                status: 'completed',
+                input: { filePath: 'src/login.ts' },
+                output: 'Guard returns early without validating the token.',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      process.env.OPENCODE_DB = fixture.dbPath;
+
+      const { parseOpenCodeSessions, extractOpenCodeContext } = await importOpenCodeParser();
+      const [session] = await parseOpenCodeSessions();
+      const context = await extractOpenCodeContext(session);
+      const assistantMessages = context.recentMessages.filter((message) => message.role === 'assistant');
+
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0].content).toContain('Need to inspect login.ts');
+      expect(assistantMessages[0].content).toContain('read');
+      expect(assistantMessages[0].toolCalls).toEqual([
+        {
+          id: 'call_read_1',
+          name: 'read',
+          arguments: { filePath: 'src/login.ts' },
+          result: 'Guard returns early without validating the token.',
+          success: true,
+        },
+      ]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps high-value non-text legacy JSON parts in extracted recent messages', async () => {
+    const fixture = createOpenCodeJsonFixture();
+
+    try {
+      process.env.XDG_DATA_HOME = fixture.xdgDataHome;
+      delete process.env.OPENCODE_DB;
+
+      const { parseOpenCodeSessions, extractOpenCodeContext } = await importOpenCodeParser();
+      const [session] = await parseOpenCodeSessions();
+      const context = await extractOpenCodeContext(session);
+      const assistantMessages = context.recentMessages.filter((message) => message.role === 'assistant');
+
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0].content).toContain('The early return bypasses token validation.');
+      expect(assistantMessages[0].content).toContain('tool:edit completed');
+      expect(assistantMessages[0].toolCalls).toEqual([
+        {
+          id: 'call_edit_1',
+          name: 'edit',
+          arguments: { filePath: 'src/auth.ts' },
+          result: 'Inserted token validation before the early return.',
+          success: true,
+        },
+      ]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('extracts tool summaries from SQLite tool parts and session edit stats', async () => {
+    const fixture = createOpenCodeSqliteFixture('opencode.db', {
+      sessionId: 'ses_tools',
+      summaryAdditions: 7,
+      summaryDeletions: 3,
+      summaryFiles: 2,
+      messages: [
+        {
+          id: 'msg_user_1',
+          role: 'user',
+          timeCreatedOffsetMs: -3_000,
+          parts: [{ type: 'text', text: 'Fix auth validation and check the diff' }],
+        },
+        {
+          id: 'msg_assistant_1',
+          role: 'assistant',
+          timeCreatedOffsetMs: -2_000,
+          parts: [
+            {
+              type: 'tool',
+              callID: 'call_read_1',
+              tool: 'read',
+              state: {
+                status: 'completed',
+                input: { filePath: 'src/login.ts' },
+                output: 'Read src/login.ts successfully.',
+              },
+            },
+            {
+              type: 'tool',
+              callID: 'call_bash_1',
+              tool: 'bash',
+              state: {
+                status: 'error',
+                input: { command: 'pnpm test auth' },
+                error: 'Command failed with exit code 1.',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      process.env.OPENCODE_DB = fixture.dbPath;
+
+      const { parseOpenCodeSessions, extractOpenCodeContext } = await importOpenCodeParser();
+      const [session] = await parseOpenCodeSessions();
+      const context = await extractOpenCodeContext(session);
+      const summaries = new Map(context.toolSummaries.map((summary) => [summary.name, summary]));
+
+      expect(summaries.get('read')?.samples[0]?.summary).toContain('completed');
+      expect(summaries.get('bash')?.samples[0]?.summary).toContain('error');
+      expect(summaries.get('bash')?.errorCount).toBe(1);
+      expect(summaries.get('Edit')?.samples[0]?.summary).toContain('2 file(s) changed (+7 -3)');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('extracts tool summaries from legacy JSON tool parts and session edit stats', async () => {
+    const fixture = createOpenCodeJsonFixture({
+      sessionId: 'ses_json_tools',
+      summaryAdditions: 4,
+      summaryDeletions: 1,
+      summaryFiles: 2,
+      messages: [
+        {
+          id: 'msg_user_1',
+          role: 'user',
+          timeCreatedOffsetMs: -3_000,
+          parts: [{ type: 'text', text: 'Fix auth validation and check the diff' }],
+        },
+        {
+          id: 'msg_assistant_1',
+          role: 'assistant',
+          timeCreatedOffsetMs: -2_000,
+          parts: [
+            {
+              type: 'tool',
+              callID: 'call_read_json_1',
+              tool: 'read',
+              state: {
+                status: 'completed',
+                input: { filePath: 'src/login.ts' },
+                output: 'Read src/login.ts successfully.',
+              },
+            },
+            {
+              type: 'tool',
+              callID: 'call_bash_json_1',
+              tool: 'bash',
+              state: {
+                status: 'error',
+                input: { command: 'pnpm test auth' },
+                error: 'Command failed with exit code 1.',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      process.env.XDG_DATA_HOME = fixture.xdgDataHome;
+      delete process.env.OPENCODE_DB;
+
+      const { parseOpenCodeSessions, extractOpenCodeContext } = await importOpenCodeParser();
+      const [session] = await parseOpenCodeSessions();
+      const context = await extractOpenCodeContext(session);
+      const summaries = new Map(context.toolSummaries.map((summary) => [summary.name, summary]));
+
+      expect(summaries.get('read')?.samples[0]?.summary).toContain('completed');
+      expect(summaries.get('bash')?.samples[0]?.summary).toContain('error');
+      expect(summaries.get('bash')?.errorCount).toBe(1);
+      expect(summaries.get('Edit')?.samples[0]?.summary).toContain('2 file(s) changed (+4 -1)');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/src/__tests__/opencode.test.ts
+++ b/src/__tests__/opencode.test.ts
@@ -346,6 +346,38 @@ describe('OpenCode parser', () => {
     }
   });
 
+  it('discovers sessions from channel DBs even when the default opencode.db also exists', async () => {
+    const defaultFixture = createOpenCodeSqliteFixture('opencode.db', {
+      sessionId: 'ses_default',
+      sessionTitle: 'Default DB session',
+    });
+    const channelFixture = createOpenCodeChannelSqliteFixture('opencode-preview.db', {
+      sessionId: 'ses_preview',
+      sessionTitle: 'Preview DB session',
+    });
+
+    try {
+      const mergedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-parser-merged-'));
+      const xdgDataHome = path.join(mergedRoot, 'xdg-data');
+      const dbDir = path.join(xdgDataHome, 'opencode');
+      fs.mkdirSync(dbDir, { recursive: true });
+      fs.copyFileSync(defaultFixture.dbPath, path.join(dbDir, 'opencode.db'));
+      fs.copyFileSync(channelFixture.dbPath, path.join(dbDir, 'opencode-preview.db'));
+
+      process.env.XDG_DATA_HOME = xdgDataHome;
+      process.env.OPENCODE_DB = '';
+
+      const { parseOpenCodeSessions } = await importOpenCodeParser();
+      const sessions = await parseOpenCodeSessions();
+
+      expect(sessions.map((session) => session.id)).toContain('ses_default');
+      expect(sessions.map((session) => session.id)).toContain('ses_preview');
+    } finally {
+      defaultFixture.cleanup();
+      channelFixture.cleanup();
+    }
+  });
+
   it('keeps high-value non-text SQLite parts in extracted recent messages', async () => {
     const fixture = createOpenCodeSqliteFixture('opencode.db', {
       sessionId: 'ses_parts',

--- a/src/__tests__/resume-command-debug.test.ts
+++ b/src/__tests__/resume-command-debug.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { UnifiedSession } from '../types/index.js';
+
+const findSessionMock = vi.fn<() => Promise<UnifiedSession | null>>();
+const getAllSessionsMock = vi.fn();
+const formatSessionMock = vi.fn(() => '[claude] test session');
+const resumeMock = vi.fn();
+const getResumeCommandMock = vi.fn(() => 'continues resume resume-debug-test --in codex');
+const resolveCrossToolForwardingMock = vi.fn(() => ({
+  mappedArgs: [],
+  passthroughArgs: [],
+  extraArgs: [],
+  warnings: [],
+  parsed: { tokens: [], occurrences: [] },
+  consumedIndices: new Set<number>(),
+}));
+
+vi.mock('../utils/index.js', () => ({
+  findSession: findSessionMock,
+  getAllSessions: getAllSessionsMock,
+  formatSession: formatSessionMock,
+}));
+
+vi.mock('../utils/resume.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../utils/resume.js')>();
+  return {
+    ...orig,
+    resume: resumeMock,
+    getResumeCommand: getResumeCommandMock,
+    resolveCrossToolForwarding: resolveCrossToolForwardingMock,
+  };
+});
+
+vi.mock('../commands/_shared.js', () => ({
+  selectTargetTool: vi.fn(),
+  showForwardingWarnings: vi.fn(),
+}));
+
+const { resumeCommand } = await import('../commands/resume-cmd.js');
+
+function makeSession(): UnifiedSession {
+  return {
+    id: 'resume-debug-test',
+    source: 'claude',
+    cwd: '/tmp/project',
+    repo: 'test/repo',
+    branch: 'main',
+    summary: 'Test debug prompt passthrough',
+    lines: 10,
+    bytes: 100,
+    createdAt: new Date('2026-04-15T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-15T00:00:00.000Z'),
+    originalPath: '/tmp/project/session.jsonl',
+  };
+}
+
+describe('resumeCommand debug prompt option', () => {
+  const chdirSpy = vi.spyOn(process, 'chdir').mockImplementation(() => undefined);
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {
+    // Silence command output during tests.
+  });
+
+  afterEach(() => {
+    findSessionMock.mockReset();
+    getAllSessionsMock.mockReset();
+    resumeMock.mockReset();
+    getResumeCommandMock.mockClear();
+    resolveCrossToolForwardingMock.mockClear();
+    logSpy.mockClear();
+    process.exitCode = undefined;
+  });
+
+  it('forwards debugPrompt to resume and suppresses the normal session/command preamble', async () => {
+    findSessionMock.mockResolvedValue(makeSession());
+
+    await resumeCommand('resume-debug-test', { in: 'codex', noTui: true, debugPrompt: true } as never, {
+      isTTY: false,
+    });
+
+    expect(resumeMock).toHaveBeenCalledTimes(1);
+    expect(resumeMock.mock.calls[0]?.[4]).toMatchObject({ debugPrompt: true });
+
+    const output = logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(output).not.toContain('Session:');
+    expect(output).not.toContain('Command:');
+    expect(chdirSpy).toHaveBeenCalledWith('/tmp/project');
+  });
+});

--- a/src/__tests__/resume-debug-prompt.test.ts
+++ b/src/__tests__/resume-debug-prompt.test.ts
@@ -1,0 +1,96 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionContext, UnifiedSession } from '../types/index.js';
+
+const spawnMock = vi.fn();
+const extractContextMock = vi.fn<() => Promise<SessionContext>>();
+const saveContextMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock('../utils/index.js', () => ({
+  extractContext: extractContextMock,
+  saveContext: saveContextMock,
+}));
+
+const { crossToolResume } = await import('../utils/resume.js');
+
+function makeSession(cwd: string): UnifiedSession {
+  return {
+    id: 'resume-debug-test',
+    source: 'claude',
+    cwd,
+    repo: 'test/repo',
+    branch: 'main',
+    summary: 'Carry parser redesign context into codex',
+    lines: 10,
+    bytes: 100,
+    createdAt: new Date('2026-04-15T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-15T00:00:00.000Z'),
+    originalPath: path.join(cwd, 'session.jsonl'),
+  };
+}
+
+function makeContext(session: UnifiedSession): SessionContext {
+  return {
+    session,
+    recentMessages: [
+      { role: 'user', content: 'Investigate parser drift.' },
+      { role: 'assistant', content: 'I found several mismatches.' },
+    ],
+    filesModified: ['src/utils/markdown.ts'],
+    pendingTasks: ['Implement pointer-first handoff'],
+    toolSummaries: [],
+    markdown: '# Session Handoff Context\n\nResearch-backed handoff body.',
+  };
+}
+
+describe('crossToolResume debug prompt mode', () => {
+  let cwd: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-debug-prompt-'));
+    spawnMock.mockReset();
+    extractContextMock.mockReset();
+    saveContextMock.mockReset();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {
+      // Silence prompt output during tests.
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('prints the inline handoff prompt and does not launch the target CLI', async () => {
+    const session = makeSession(cwd);
+    extractContextMock.mockResolvedValue(makeContext(session));
+
+    await crossToolResume(session, 'codex', 'inline', undefined, { debugPrompt: true } as never);
+
+    const output = logSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('\n');
+    expect(output).toContain("I'm continuing a coding session from **Claude Code**");
+    expect(output).toContain('# Session Handoff Context');
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(cwd, '.continues-handoff.md'))).toBe(true);
+  });
+
+  it('prints the reference handoff prompt and does not launch the target CLI', async () => {
+    const session = makeSession(cwd);
+    extractContextMock.mockResolvedValue(makeContext(session));
+
+    await crossToolResume(session, 'codex', 'reference', undefined, { debugPrompt: true } as never);
+
+    const output = logSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('\n');
+    expect(output).toContain('# 🔄 Session Handoff');
+    expect(output).toContain('.continues-handoff.md');
+    expect(output).toContain('Read `.continues-handoff.md` first, then continue the work.');
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -189,6 +189,7 @@ program
   .description('Resume a session by ID or short ID')
   .option('-i, --in <cli-tool>', `Target CLI tool (${ALL_TOOLS.join(', ')})`)
   .option('--reference', 'Use file reference instead of inline context (for very large sessions)')
+  .option('--debug-prompt', 'Print the exact handoff prompt instead of launching the target tool')
   .option('--no-tui', 'Disable interactive prompts')
   .allowUnknownOption(true)
   .allowExcessArguments(true)

--- a/src/commands/resume-cmd.ts
+++ b/src/commands/resume-cmd.ts
@@ -13,7 +13,15 @@ import { selectTargetTool, showForwardingWarnings } from './_shared.js';
  */
 export async function resumeCommand(
   sessionId: string,
-  options: { in?: string; reference?: boolean; noTui?: boolean; preset?: string; configPath?: string; chain?: boolean },
+  options: {
+    in?: string;
+    reference?: boolean;
+    noTui?: boolean;
+    preset?: string;
+    configPath?: string;
+    chain?: boolean;
+    debugPrompt?: boolean;
+  },
   context: { isTTY: boolean },
   forwarding?: HandoffForwardingOptions,
 ): Promise<void> {
@@ -48,7 +56,18 @@ export async function resumeCommand(
 
     const target = options.in as SessionSource | undefined;
     const mode = options.reference ? ('reference' as const) : ('inline' as const);
-    const contextOptions = { preset: options.preset, configPath: options.configPath, chain: options.chain };
+    const contextOptions = {
+      preset: options.preset,
+      configPath: options.configPath,
+      chain: options.chain,
+      debugPrompt: options.debugPrompt,
+    };
+
+    if (options.debugPrompt && !target) {
+      console.error(chalk.red('Error:'), '--debug-prompt requires --in <cli-tool>.');
+      process.exitCode = 1;
+      return;
+    }
 
     const forwardingFor = (candidateTarget: SessionSource | undefined): HandoffForwardingOptions | undefined => {
       if (!candidateTarget || candidateTarget === session.source) return undefined;
@@ -63,9 +82,11 @@ export async function resumeCommand(
         await showForwardingWarnings(resolved.warnings, context);
       }
 
-      console.log(chalk.gray('Session: ') + formatSession(session));
-      console.log(chalk.gray('Command: ') + chalk.cyan(getResumeCommand(session, target, effectiveForwarding)));
-      console.log();
+      if (!options.debugPrompt) {
+        console.log(chalk.gray('Session: ') + formatSession(session));
+        console.log(chalk.gray('Command: ') + chalk.cyan(getResumeCommand(session, target, effectiveForwarding)));
+        console.log();
+      }
 
       if (session.cwd) process.chdir(session.cwd);
       await resume(session, target, mode, effectiveForwarding, contextOptions);
@@ -88,8 +109,10 @@ export async function resumeCommand(
         await showForwardingWarnings(resolved.warnings, context);
       }
 
-      clack.log.step(`Handing off to ${selectedTarget}...`);
-      clack.outro(`Launching ${selectedTarget}`);
+      if (!options.debugPrompt) {
+        clack.log.step(`Handing off to ${selectedTarget}...`);
+        clack.outro(`Launching ${selectedTarget}`);
+      }
 
       if (session.cwd) process.chdir(session.cwd);
       await resume(session, selectedTarget, mode, effectiveForwarding, contextOptions);
@@ -101,9 +124,11 @@ export async function resumeCommand(
         await showForwardingWarnings(resolved.warnings, context);
       }
 
-      console.log(chalk.gray('Session: ') + formatSession(session));
-      console.log(chalk.gray('Command: ') + chalk.cyan(getResumeCommand(session, target, effectiveForwarding)));
-      console.log();
+      if (!options.debugPrompt) {
+        console.log(chalk.gray('Session: ') + formatSession(session));
+        console.log(chalk.gray('Command: ') + chalk.cyan(getResumeCommand(session, target, effectiveForwarding)));
+        console.log();
+      }
 
       if (session.cwd) process.chdir(session.cwd);
       await resume(session, target, mode, effectiveForwarding, contextOptions);

--- a/src/parsers/codex.ts
+++ b/src/parsers/codex.ts
@@ -1,5 +1,7 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type {
   ConversationMessage,
@@ -9,13 +11,11 @@ import type {
   UnifiedSession,
 } from '../types/index.js';
 import type { CodexMessage, CodexSessionMeta } from '../types/schemas.js';
+import { countDiffStats, extractStdoutTail } from '../utils/diff.js';
 import { findFiles } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepo, homeDir } from '../utils/parser-helpers.js';
-import { countDiffStats, extractStdoutTail } from '../utils/diff.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 import {
   extractExitCode,
   mcpSummary,
@@ -26,17 +26,19 @@ import {
   withResult,
 } from '../utils/tool-summarizer.js';
 
-const CODEX_SESSIONS_DIR = process.env.CODEX_HOME
-  ? path.join(process.env.CODEX_HOME, 'sessions')
-  : path.join(homeDir(), '.codex', 'sessions');
+const CODEX_HOME_DIR = process.env.CODEX_HOME || path.join(homeDir(), '.codex');
+const CODEX_SESSIONS_DIR = path.join(CODEX_HOME_DIR, 'sessions');
+const CODEX_ARCHIVED_SESSIONS_DIR = path.join(CODEX_HOME_DIR, 'archived_sessions');
 
 /**
  * Find all Codex session files recursively
  */
 async function findSessionFiles(): Promise<string[]> {
-  return findFiles(CODEX_SESSIONS_DIR, {
-    match: (entry) => entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl'),
-  });
+  return [CODEX_SESSIONS_DIR, CODEX_ARCHIVED_SESSIONS_DIR].flatMap((dir) =>
+    findFiles(dir, {
+      match: (entry) => entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl'),
+    }),
+  );
 }
 
 /**
@@ -92,7 +94,7 @@ function parseFilename(filename: string): { timestamp: Date; id: string } | null
  */
 export async function parseCodexSessions(): Promise<UnifiedSession[]> {
   const files = await findSessionFiles();
-  const sessions: UnifiedSession[] = [];
+  const sessionsById = new Map<string, UnifiedSession>();
 
   for (const filePath of files) {
     try {
@@ -111,7 +113,7 @@ export async function parseCodexSessions(): Promise<UnifiedSession[]> {
 
       const summary = cleanSummary(firstUserMessage);
 
-      sessions.push({
+      const nextSession: UnifiedSession = {
         id: parsed.id,
         source: 'codex',
         cwd,
@@ -123,14 +125,19 @@ export async function parseCodexSessions(): Promise<UnifiedSession[]> {
         updatedAt: fileStats.mtime,
         originalPath: filePath,
         summary: summary || undefined,
-      });
+      };
+
+      const existing = sessionsById.get(nextSession.id);
+      if (!existing || existing.updatedAt.getTime() < nextSession.updatedAt.getTime()) {
+        sessionsById.set(nextSession.id, nextSession);
+      }
     } catch (err) {
       logger.debug('codex: skipping unparseable session', filePath, err);
       // Skip files we can't parse
     }
   }
 
-  return sessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  return Array.from(sessionsById.values()).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 }
 
 /**
@@ -198,7 +205,10 @@ function trackShellFileWrites(cmd: string, collector: SummaryCollector): void {
 /**
  * Extract tool usage summaries and files modified using shared SummaryCollector
  */
-function extractToolData(messages: CodexMessage[], config?: VerbosityConfig): { summaries: ToolUsageSummary[]; filesModified: string[] } {
+function extractToolData(
+  messages: CodexMessage[],
+  config?: VerbosityConfig,
+): { summaries: ToolUsageSummary[]; filesModified: string[] } {
   const collector = new SummaryCollector(config);
   const outputsById = new Map<string, string>();
 
@@ -253,9 +263,13 @@ function extractToolData(messages: CodexMessage[], config?: VerbosityConfig): { 
           } else if (name === 'write_stdin') {
             collector.add('write_stdin', `stdin: "${truncate(String(args.input || args.data || ''), 60)}"`);
           } else if (['read_mcp_resource', 'list_mcp_resources', 'list_mcp_resource_templates'].includes(name)) {
-            collector.add('mcp-resource', `${name}: ${truncate(String(args.uri || args.server_label || '(all)'), 60)}`, {
-              data: { category: 'mcp', toolName: name, params: String(args.uri || args.server_label || '') },
-            });
+            collector.add(
+              'mcp-resource',
+              `${name}: ${truncate(String(args.uri || args.server_label || '(all)'), 60)}`,
+              {
+                data: { category: 'mcp', toolName: name, params: String(args.uri || args.server_label || '') },
+              },
+            );
           } else if (name === 'request_user_input') {
             const question = truncate(String(args.prompt || args.message || ''), 80);
             collector.add('user-input', `ask: "${question}"`, {
@@ -351,6 +365,19 @@ function extractSessionNotes(messages: CodexMessage[]): SessionNotes {
   const notes: SessionNotes = {};
   const reasoning: string[] = [];
 
+  const readTokenUsage = (
+    raw: unknown,
+  ): { input: number; output: number; cached: number; reasoning?: number } | null => {
+    if (!raw || typeof raw !== 'object') return null;
+    const usage = raw as Record<string, unknown>;
+    const input = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+    const output = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+    const cached = typeof usage.cached_input_tokens === 'number' ? usage.cached_input_tokens : 0;
+    const reasoningTokens =
+      typeof usage.reasoning_output_tokens === 'number' ? usage.reasoning_output_tokens : undefined;
+    return { input, output, cached, ...(reasoningTokens !== undefined ? { reasoning: reasoningTokens } : {}) };
+  };
+
   for (const msg of messages) {
     // Model from turn_context
     if (msg.type === 'turn_context') {
@@ -371,11 +398,19 @@ function extractSessionNotes(messages: CodexMessage[]): SessionNotes {
 
     // Token usage (take last value — cumulative)
     if (payload.type === 'token_count') {
-      notes.tokenUsage = { input: payload.input_tokens || 0, output: payload.output_tokens || 0 };
-      // Codex may report reasoning tokens separately (OpenAI o-series models)
-      const reasoningTokens = (payload as Record<string, unknown>).reasoning_output_tokens;
-      if (typeof reasoningTokens === 'number' && reasoningTokens > 0) {
-        notes.thinkingTokens = reasoningTokens;
+      const payloadRecord = payload as Record<string, unknown>;
+      const info = payloadRecord.info as Record<string, unknown> | undefined;
+      const usage =
+        readTokenUsage(info?.total_token_usage) ?? readTokenUsage(info?.last_token_usage) ?? readTokenUsage(payload);
+
+      if (usage) {
+        notes.tokenUsage = { input: usage.input, output: usage.output };
+        if (usage.cached > 0) {
+          notes.cacheTokens = { creation: 0, read: usage.cached };
+        }
+        if (typeof usage.reasoning === 'number' && usage.reasoning > 0) {
+          notes.thinkingTokens = usage.reasoning;
+        }
       }
     }
   }
@@ -475,7 +510,15 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
   }
 
   // Generate markdown for injection
-  const markdown = generateHandoffMarkdown(session, trimmed, filesModified, pendingTasks, toolSummaries, sessionNotes, resolvedConfig);
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    sessionNotes,
+    resolvedConfig,
+  );
 
   return {
     session,

--- a/src/parsers/copilot.ts
+++ b/src/parsers/copilot.ts
@@ -1,24 +1,61 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import YAML from 'yaml';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type { ConversationMessage, SessionContext, ToolUsageSummary, UnifiedSession } from '../types/index.js';
-import { classifyToolName } from '../types/tool-names.js';
+import type {
+  ConversationMessage,
+  SessionContext,
+  StructuredToolSample,
+  ToolUsageSummary,
+  UnifiedSession,
+} from '../types/index.js';
 import type { CopilotEvent, CopilotWorkspace } from '../types/schemas.js';
+import { classifyToolName } from '../types/tool-names.js';
 import { listSubdirectories } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { homeDir } from '../utils/parser-helpers.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
+import {
+  extractExitCode,
+  fetchSummary,
+  fileSummary,
+  globSummary,
+  grepSummary,
+  mcpSummary,
+  SummaryCollector,
+  searchSummary,
+  shellSummary,
+  truncate,
+  withResult,
+} from '../utils/tool-summarizer.js';
 
-const COPILOT_SESSIONS_DIR = path.join(homeDir(), '.copilot', 'session-state');
+interface CopilotToolInvocation {
+  name: string;
+  arguments: Record<string, unknown>;
+  order: number;
+  resultText?: string;
+  resultDetail?: string;
+  success?: boolean;
+}
+
+function getCopilotRoot(): string {
+  const configuredHome = process.env.COPILOT_HOME?.trim();
+  return configuredHome || path.join(homeDir(), '.copilot');
+}
+
+function getCopilotSessionsDir(): string {
+  return path.join(getCopilotRoot(), 'session-state');
+}
 
 /**
  * Find all Copilot session directories
  */
 async function findSessionDirs(): Promise<string[]> {
-  return listSubdirectories(COPILOT_SESSIONS_DIR).filter((dir) => fs.existsSync(path.join(dir, 'workspace.yaml')));
+  const sessionsDir = getCopilotSessionsDir();
+  if (!fs.existsSync(sessionsDir)) return [];
+  return listSubdirectories(sessionsDir).filter((dir) => fs.existsSync(path.join(dir, 'workspace.yaml')));
 }
 
 /**
@@ -101,7 +138,10 @@ export async function parseCopilotSessions(): Promise<UnifiedSession[]> {
 /**
  * Extract context from a Copilot session for cross-tool continuation
  */
-export async function extractCopilotContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
+export async function extractCopilotContext(
+  session: UnifiedSession,
+  config?: VerbosityConfig,
+): Promise<SessionContext> {
   const resolvedConfig = config ?? getPreset('standard');
   const eventsPath = path.join(session.originalPath, 'events.jsonl');
   const events = await readJsonlFile<CopilotEvent>(eventsPath);
@@ -165,7 +205,15 @@ export async function extractCopilotContext(session: UnifiedSession, config?: Ve
   const trimmed = recentMessages.slice(-resolvedConfig.recentMessages);
 
   // Generate markdown for injection
-  const markdown = generateHandoffMarkdown(session, trimmed, filesModified, pendingTasks, toolSummaries, undefined, resolvedConfig);
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    undefined,
+    resolvedConfig,
+  );
 
   return {
     session,
@@ -178,54 +226,42 @@ export async function extractCopilotContext(session: UnifiedSession, config?: Ve
 }
 
 /**
- * Extract tool usage summaries from Copilot events' toolRequests arrays.
- * Copilot doesn't provide tool results, so we capture names and arguments only.
+ * Extract tool usage summaries from Copilot assistant toolRequests and
+ * enrich them with actual execution results when tool.execution_* events exist.
  */
-function extractCopilotToolSummaries(events: CopilotEvent[], config: VerbosityConfig): { summaries: ToolUsageSummary[]; filesModified: string[] } {
-  const toolCounts = new Map<string, { count: number; samples: Array<{ summary: string; data?: import('../types/index.js').StructuredToolSample }> }>();
-  const files = new Set<string>();
-  const defaultSampleLimit = config.mcp.maxSamplesPerNamespace;
+function extractCopilotToolSummaries(
+  events: CopilotEvent[],
+  config: VerbosityConfig,
+): { summaries: ToolUsageSummary[]; filesModified: string[] } {
+  const collector = new SummaryCollector(config);
 
-  for (const event of events) {
-    if (event.type !== 'assistant.message') continue;
-    const toolRequests = event.data?.toolRequests || [];
-    for (const tr of toolRequests) {
-      const name = tr.name || 'unknown';
-      const category = classifyToolName(name);
-      if (!category) continue; // skip internal tools
+  for (const invocation of mergeCopilotToolInvocations(events)) {
+    const category = classifyToolName(invocation.name);
+    if (!category) continue;
 
-      if (!toolCounts.has(name)) {
-        toolCounts.set(name, { count: 0, samples: [] });
-      }
-      const entry = toolCounts.get(name)!;
-      entry.count++;
+    const filePath = getCopilotFilePath(invocation.arguments);
+    const data = buildCopilotSampleData(
+      category,
+      invocation.name,
+      invocation.arguments,
+      invocation.resultText,
+      invocation.resultDetail,
+      invocation.success,
+    );
 
-      const args = tr.arguments || {};
-      const fp = (args.path as string) || (args.file_path as string) || '';
-
-      // Track files from write/edit tool requests
-      if ((category === 'write' || category === 'edit') && fp) {
-        files.add(fp);
-      }
-
-      if (entry.samples.length < defaultSampleLimit) {
-        const data = buildCopilotSampleData(category, name, args);
-        const argsStr = Object.keys(args).length > 0 ? JSON.stringify(args).slice(0, 100) : '';
-        entry.samples.push({
-          summary: argsStr ? `${name}(${argsStr})` : name,
-          data,
-        });
-      }
-    }
+    collector.add(
+      invocation.name,
+      buildCopilotSummary(category, invocation.name, invocation.arguments, invocation.resultText, data),
+      {
+        data,
+        ...(filePath ? { filePath } : {}),
+        isWrite: (category === 'write' || category === 'edit') && Boolean(filePath),
+        isError: invocation.success === false || (data.category === 'shell' && data.errored === true),
+      },
+    );
   }
 
-  const summaries = Array.from(toolCounts.entries()).map(([name, { count, samples }]) => ({
-    name,
-    count,
-    samples,
-  }));
-
-  return { summaries, filesModified: Array.from(files) };
+  return { summaries: collector.getSummaries(), filesModified: collector.getFilesModified() };
 }
 
 /** Build the correct StructuredToolSample for a Copilot tool request based on its classified category */
@@ -233,17 +269,40 @@ function buildCopilotSampleData(
   category: import('../types/tool-names.js').ToolSampleCategory,
   name: string,
   args: Record<string, unknown>,
-): import('../types/index.js').StructuredToolSample {
-  const fp = (args.path as string) || (args.file_path as string) || '';
+  resultText?: string,
+  resultDetail?: string,
+  success?: boolean,
+): StructuredToolSample {
+  const fp = getCopilotFilePath(args);
+  const output = resultText || resultDetail || '';
+  const exitCode = extractExitCode(resultDetail || resultText);
+  const errored = success === false || (exitCode !== undefined && exitCode !== 0);
   switch (category) {
-    case 'shell':
-      return { category: 'shell', command: (args.command as string) || (args.cmd as string) || '' };
+    case 'shell': {
+      const stdoutTail = resultText ? truncate(resultText, 500) : undefined;
+      return {
+        category: 'shell',
+        command: (args.command as string) || (args.cmd as string) || '',
+        ...(exitCode !== undefined ? { exitCode } : {}),
+        ...(stdoutTail ? { stdoutTail } : {}),
+        ...(errored ? { errored } : {}),
+        ...(errored && output ? { errorMessage: truncate(output, 200) } : {}),
+      };
+    }
     case 'read':
       return { category: 'read', filePath: fp };
     case 'write':
-      return { category: 'write', filePath: fp };
+      return {
+        category: 'write',
+        filePath: fp,
+        ...(errored && output ? { errorMessage: truncate(output, 200) } : {}),
+      };
     case 'edit':
-      return { category: 'edit', filePath: fp };
+      return {
+        category: 'edit',
+        filePath: fp,
+        ...(errored && output ? { errorMessage: truncate(output, 200) } : {}),
+      };
     case 'grep':
       return {
         category: 'grep',
@@ -253,11 +312,23 @@ function buildCopilotSampleData(
     case 'glob':
       return { category: 'glob', pattern: (args.pattern as string) || fp };
     case 'search':
-      return { category: 'search', query: (args.query as string) || '' };
+      return {
+        category: 'search',
+        query: (args.query as string) || '',
+        ...(resultText ? { resultPreview: truncate(resultText, 100) } : {}),
+      };
     case 'fetch':
-      return { category: 'fetch', url: (args.url as string) || '' };
+      return {
+        category: 'fetch',
+        url: (args.url as string) || '',
+        ...(resultText ? { resultPreview: truncate(resultText, 100) } : {}),
+      };
     case 'task':
-      return { category: 'task', description: (args.description as string) || '' };
+      return {
+        category: 'task',
+        description: (args.description as string) || '',
+        ...(resultText ? { resultSummary: truncate(resultText, 100) } : {}),
+      };
     case 'ask':
       return { category: 'ask', question: ((args.question as string) || '').slice(0, 80) };
     default:
@@ -265,6 +336,184 @@ function buildCopilotSampleData(
         category: 'mcp',
         toolName: name,
         ...(Object.keys(args).length > 0 ? { params: JSON.stringify(args).slice(0, 100) } : {}),
+        ...(resultText ? { result: truncate(resultText, 100) } : {}),
       };
   }
+}
+
+function mergeCopilotToolInvocations(events: CopilotEvent[]): CopilotToolInvocation[] {
+  const planned: CopilotToolInvocation[] = [];
+  const executionStarts = new Map<string, { name: string; arguments: Record<string, unknown> }>();
+  const executionOnly: CopilotToolInvocation[] = [];
+  let order = 0;
+
+  for (const event of events) {
+    if (event.type === 'assistant.message') {
+      for (const toolRequest of event.data?.toolRequests || []) {
+        planned.push({
+          name: toolRequest.name || 'unknown',
+          arguments: normalizeCopilotArguments(toolRequest.arguments),
+          order: order++,
+        });
+      }
+      continue;
+    }
+
+    if (event.type === 'tool.execution_start') {
+      const toolCallId = getOptionalString(event.data?.toolCallId);
+      const toolName = getOptionalString(event.data?.toolName);
+      if (!toolCallId || !toolName) continue;
+      executionStarts.set(toolCallId, {
+        name: toolName,
+        arguments: normalizeCopilotArguments(event.data?.arguments),
+      });
+      continue;
+    }
+
+    if (event.type !== 'tool.execution_complete') continue;
+
+    const toolCallId = getOptionalString(event.data?.toolCallId);
+    if (!toolCallId) continue;
+    const start = executionStarts.get(toolCallId);
+    if (!start) continue;
+
+    const actual: CopilotToolInvocation = {
+      name: start.name,
+      arguments: start.arguments,
+      order: order++,
+      success: typeof event.data?.success === 'boolean' ? event.data.success : undefined,
+      ...extractCopilotResult(event.data?.result),
+    };
+
+    const matched = findMatchingPlannedInvocation(planned, actual);
+    if (matched) {
+      matched.success = actual.success;
+      matched.resultText = actual.resultText;
+      matched.resultDetail = actual.resultDetail;
+      if (Object.keys(matched.arguments).length === 0 && Object.keys(actual.arguments).length > 0) {
+        matched.arguments = actual.arguments;
+      }
+    } else {
+      executionOnly.push(actual);
+    }
+  }
+
+  return [...planned, ...executionOnly].sort((a, b) => a.order - b.order);
+}
+
+function findMatchingPlannedInvocation(
+  planned: CopilotToolInvocation[],
+  actual: CopilotToolInvocation,
+): CopilotToolInvocation | undefined {
+  const exactMatch = planned.find(
+    (candidate) =>
+      candidate.resultText === undefined &&
+      candidate.name === actual.name &&
+      stableStringify(candidate.arguments) === stableStringify(actual.arguments),
+  );
+  if (exactMatch) return exactMatch;
+
+  return planned.find((candidate) => candidate.resultText === undefined && candidate.name === actual.name);
+}
+
+function buildCopilotSummary(
+  category: import('../types/tool-names.js').ToolSampleCategory,
+  name: string,
+  args: Record<string, unknown>,
+  resultText: string | undefined,
+  data: StructuredToolSample,
+): string {
+  const filePath = getCopilotFilePath(args);
+
+  switch (category) {
+    case 'shell':
+      return shellSummary((args.command as string) || (args.cmd as string) || '', resultText);
+    case 'read':
+      return fileSummary('read', filePath);
+    case 'write':
+      return withResult(fileSummary('write', filePath), resultText);
+    case 'edit':
+      return withResult(fileSummary('edit', filePath), resultText);
+    case 'grep':
+      return withResult(
+        grepSummary((args.pattern as string) || (args.query as string) || '', filePath || undefined),
+        resultText,
+      );
+    case 'glob':
+      return withResult(globSummary((args.pattern as string) || filePath), resultText);
+    case 'search':
+      return withResult(searchSummary((args.query as string) || ''), resultText);
+    case 'fetch':
+      return withResult(fetchSummary((args.url as string) || ''), resultText);
+    case 'task':
+      return withResult(`task "${truncate((args.description as string) || '', 60)}"`, resultText);
+    case 'ask':
+      return `ask "${truncate((data.category === 'ask' && data.question) || '', 80)}"`;
+    default: {
+      const argsStr = Object.keys(args).length > 0 ? JSON.stringify(args).slice(0, 100) : '';
+      return mcpSummary(name, argsStr, resultText);
+    }
+  }
+}
+
+function extractCopilotResult(result: unknown): { resultText?: string; resultDetail?: string } {
+  if (typeof result === 'string') {
+    return { resultText: result };
+  }
+
+  if (!result || typeof result !== 'object') {
+    return {};
+  }
+
+  const content = getOptionalString((result as { content?: unknown }).content);
+  const detailedContent = getOptionalString((result as { detailedContent?: unknown }).detailedContent);
+  const contentsText = extractCopilotContentsText((result as { contents?: unknown }).contents);
+  return {
+    ...(content ? { resultText: content } : contentsText ? { resultText: contentsText } : {}),
+    ...(detailedContent ? { resultDetail: detailedContent } : contentsText ? { resultDetail: contentsText } : {}),
+  };
+}
+
+function extractCopilotContentsText(contents: unknown): string | undefined {
+  if (!Array.isArray(contents)) return undefined;
+
+  const parts = contents
+    .map((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) {
+        return undefined;
+      }
+      return getOptionalString((item as { text?: unknown }).text);
+    })
+    .filter((part): part is string => Boolean(part));
+
+  if (parts.length === 0) return undefined;
+  return parts.join('\n');
+}
+
+function getCopilotFilePath(args: Record<string, unknown>): string {
+  return getOptionalString(args.path) || getOptionalString(args.file_path) || '';
+}
+
+function normalizeCopilotArguments(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function getOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
 }

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -1,5 +1,7 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type { ConversationMessage, SessionContext, SessionNotes, UnifiedSession } from '../types/index.js';
 import type { CursorTranscriptLine } from '../types/schemas.js';
@@ -9,8 +11,6 @@ import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
 import { cwdFromSlug } from '../utils/slug.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 import {
   type AnthropicMessage,
   extractAnthropicToolData,
@@ -153,6 +153,11 @@ export async function extractCursorContext(session: UnifiedSession, config?: Ver
   const reasoning = extractThinkingHighlights(anthropicMsgs);
   if (reasoning.length > 0) sessionNotes.reasoning = reasoning;
 
+  if (!sessionNotes.reasoning) sessionNotes.reasoning = [];
+  sessionNotes.reasoning.push(
+    'Cursor transcript completeness warning: local agent-transcripts may omit tool outputs and can be less complete than hidden local stores or exported/session state.',
+  );
+
   // Aggregate token usage, cache tokens, and model from passthrough fields.
   // Cursor CLI agent-transcripts use Anthropic API format — the schema's
   // .passthrough() preserves `usage` and `model` on each JSONL line.
@@ -208,7 +213,15 @@ export async function extractCursorContext(session: UnifiedSession, config?: Ver
 
   const trimmed = recentMessages.slice(-resolvedConfig.recentMessages);
 
-  const markdown = generateHandoffMarkdown(session, trimmed, filesModified, pendingTasks, toolSummaries, sessionNotes, resolvedConfig);
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    sessionNotes,
+    resolvedConfig,
+  );
 
   return {
     session,

--- a/src/parsers/gemini.ts
+++ b/src/parsers/gemini.ts
@@ -1,5 +1,8 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as readline from 'node:readline';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type {
   ConversationMessage,
@@ -8,20 +11,29 @@ import type {
   ToolUsageSummary,
   UnifiedSession,
 } from '../types/index.js';
-import type { GeminiSession } from '../types/schemas.js';
-import { GeminiSessionSchema } from '../types/schemas.js';
+import type { GeminiMessage, GeminiSession } from '../types/schemas.js';
+import { GeminiMessageSchema, GeminiSessionSchema } from '../types/schemas.js';
+import { classifyToolName } from '../types/tool-names.js';
 import { extractTextFromBlocks } from '../utils/content.js';
 import { findFiles, listSubdirectories } from '../utils/fs-helpers.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
-import { classifyToolName } from '../types/tool-names.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
-import { fileSummary, mcpSummary, shellSummary, SummaryCollector, truncate } from '../utils/tool-summarizer.js';
+import { fileSummary, mcpSummary, SummaryCollector, shellSummary, truncate } from '../utils/tool-summarizer.js';
 
 const geminiHome = process.env.GEMINI_CLI_HOME || homeDir();
 const GEMINI_BASE_DIR = path.join(geminiHome, '.gemini', 'tmp');
 const GEMINI_LEGACY_DIR = path.join(geminiHome, '.gemini', 'sessions');
+const GEMINI_PROJECTS_PATH = path.join(geminiHome, '.gemini', 'projects.json');
+
+type GeminiSessionData = GeminiSession & {
+  directories?: string[];
+  summary?: string;
+};
+
+type GeminiJsonlRecord = Partial<GeminiSessionData> & {
+  $rewindTo?: string;
+  $set?: Partial<GeminiSessionData>;
+};
 
 /**
  * Find all Gemini session files (new and legacy storage formats)
@@ -29,14 +41,16 @@ const GEMINI_LEGACY_DIR = path.join(geminiHome, '.gemini', 'sessions');
 async function findSessionFiles(): Promise<string[]> {
   const results: string[] = [];
 
-  // New format: ~/.gemini/tmp/<project-hash>/chats/session-*.json
+  // Current format: ~/.gemini/tmp/<project-hash>/chats/*.jsonl
+  // Legacy chats path: ~/.gemini/tmp/<project-hash>/chats/session-*.json
   if (fs.existsSync(GEMINI_BASE_DIR)) {
     for (const projectDir of listSubdirectories(GEMINI_BASE_DIR)) {
       if (path.basename(projectDir) === 'bin') continue;
       const chatsDir = path.join(projectDir, 'chats');
       results.push(
         ...findFiles(chatsDir, {
-          match: (entry) => entry.name.startsWith('session-') && entry.name.endsWith('.json'),
+          match: (entry) =>
+            entry.name.endsWith('.jsonl') || (entry.name.startsWith('session-') && entry.name.endsWith('.json')),
           recursive: false,
         }),
       );
@@ -56,12 +70,138 @@ async function findSessionFiles(): Promise<string[]> {
   return results;
 }
 
+async function loadProjectDirectoryMap(): Promise<Map<string, string>> {
+  try {
+    const content = await fs.promises.readFile(GEMINI_PROJECTS_PATH, 'utf8');
+    const parsed = JSON.parse(content) as { projects?: Record<string, string> };
+    const entries = Object.entries(parsed.projects ?? {});
+    return new Map(entries.map(([cwd, projectId]) => [projectId, cwd]));
+  } catch (err) {
+    logger.debug('gemini: failed to load projects.json mapping', GEMINI_PROJECTS_PATH, err);
+    return new Map();
+  }
+}
+
+async function countFileLines(filePath: string): Promise<number> {
+  const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+  let lines = 0;
+
+  try {
+    for await (const _line of rl) {
+      lines++;
+    }
+    return lines;
+  } finally {
+    rl.close();
+    stream.close();
+  }
+}
+
+function toGeminiMessage(record: GeminiJsonlRecord): GeminiMessage | null {
+  const result = GeminiMessageSchema.safeParse(record);
+  if (result.success) return result.data;
+  logger.debug('gemini: message validation failed', result.error.message);
+  return null;
+}
+
+function getSessionDirectory(session: GeminiSessionData, projectDirectories: Map<string, string>): string {
+  const metadataDirectory = session.directories?.find(
+    (directory) => typeof directory === 'string' && directory.length > 0,
+  );
+  return metadataDirectory || projectDirectories.get(session.projectHash) || '';
+}
+
+function findRewindIndex(messages: GeminiMessage[], messageId: string): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]?.id === messageId) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+async function parseJsonlSessionFile(filePath: string): Promise<GeminiSessionData | null> {
+  const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+  const sessionState: Partial<GeminiSessionData> = {};
+  const messages: GeminiMessage[] = [];
+
+  try {
+    for await (const rawLine of rl) {
+      const line = rawLine.trim();
+      if (!line) continue;
+
+      let record: GeminiJsonlRecord;
+      try {
+        record = JSON.parse(line) as GeminiJsonlRecord;
+      } catch (err) {
+        logger.debug('gemini: invalid JSONL record', filePath, err);
+        return null;
+      }
+
+      if (record.$set && typeof record.$set === 'object') {
+        Object.assign(sessionState, record.$set);
+        continue;
+      }
+
+      if (typeof record.$rewindTo === 'string') {
+        const rewindIndex = findRewindIndex(messages, record.$rewindTo);
+        if (rewindIndex >= 0) {
+          messages.length = rewindIndex;
+        }
+        continue;
+      }
+
+      const message = toGeminiMessage(record);
+      if (message) {
+        messages.push(message);
+        continue;
+      }
+
+      Object.assign(sessionState, record);
+    }
+  } finally {
+    rl.close();
+    stream.close();
+  }
+
+  const parsed = GeminiSessionSchema.safeParse({
+    sessionId: sessionState.sessionId,
+    projectHash: sessionState.projectHash,
+    startTime: sessionState.startTime,
+    lastUpdated: sessionState.lastUpdated,
+    messages,
+  });
+
+  if (!parsed.success) {
+    logger.debug('gemini: JSONL session validation failed', filePath, parsed.error.message);
+    return null;
+  }
+
+  return {
+    ...parsed.data,
+    ...(typeof sessionState.summary === 'string' ? { summary: sessionState.summary } : {}),
+    ...(Array.isArray(sessionState.directories)
+      ? {
+          directories: sessionState.directories.filter(
+            (directory): directory is string => typeof directory === 'string' && directory.length > 0,
+          ),
+        }
+      : {}),
+  };
+}
+
 /**
  * Parse a single Gemini session file
  */
-function parseSessionFile(filePath: string): GeminiSession | null {
+async function parseSessionFile(filePath: string): Promise<GeminiSessionData | null> {
   try {
-    const content = fs.readFileSync(filePath, 'utf8');
+    if (filePath.endsWith('.jsonl')) {
+      return await parseJsonlSessionFile(filePath);
+    }
+
+    const content = await fs.promises.readFile(filePath, 'utf8');
     const result = GeminiSessionSchema.safeParse(JSON.parse(content));
     if (result.success) return result.data;
     logger.debug('gemini: session validation failed', filePath, result.error.message);
@@ -94,7 +234,10 @@ function extractFirstUserMessage(session: GeminiSession): string {
 /**
  * Extract tool usage summaries and files modified using shared SummaryCollector
  */
-function extractToolData(sessionData: GeminiSession, config?: VerbosityConfig): { summaries: ToolUsageSummary[]; filesModified: string[] } {
+function extractToolData(
+  sessionData: GeminiSession,
+  config?: VerbosityConfig,
+): { summaries: ToolUsageSummary[]; filesModified: string[] } {
   const collector = new SummaryCollector(config);
 
   for (const msg of sessionData.messages) {
@@ -145,6 +288,7 @@ function extractToolData(sessionData: GeminiSession, config?: VerbosityConfig): 
             filePath: fp,
             isError,
           });
+          if (fp) collector.trackFile(fp);
           break;
         case 'shell': {
           const cmd = (args?.command as string) || (args?.cmd as string) || '';
@@ -297,26 +441,20 @@ function extractSessionNotes(sessionData: GeminiSession): SessionNotes {
  */
 export async function parseGeminiSessions(): Promise<UnifiedSession[]> {
   const files = await findSessionFiles();
+  const projectDirectories = await loadProjectDirectoryMap();
   const sessions: UnifiedSession[] = [];
 
   for (const filePath of files) {
     try {
-      const session = parseSessionFile(filePath);
+      const session = await parseSessionFile(filePath);
       if (!session || !session.sessionId) continue;
 
-      // Get cwd from parent directory structure (project hash dir)
-      const projectHashDir = path.dirname(path.dirname(filePath));
-      const projectHash = path.basename(projectHashDir);
-
-      // Gemini does not store working directory in its session data
-      const cwd = '';
-
       const firstUserMessage = extractFirstUserMessage(session);
-      const summary = cleanSummary(firstUserMessage);
+      const summary = cleanSummary(session.summary || firstUserMessage);
 
-      const fileStats = fs.statSync(filePath);
-      const content = fs.readFileSync(filePath, 'utf8');
-      const lines = content.split('\n').length;
+      const fileStats = await fs.promises.stat(filePath);
+      const lines = await countFileLines(filePath);
+      const cwd = getSessionDirectory(session, projectDirectories);
 
       sessions.push({
         id: session.sessionId,
@@ -347,7 +485,7 @@ export async function parseGeminiSessions(): Promise<UnifiedSession[]> {
  */
 export async function extractGeminiContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const resolvedConfig = config ?? getPreset('standard');
-  const sessionData = parseSessionFile(session.originalPath);
+  const sessionData = await parseSessionFile(session.originalPath);
   const recentMessages: ConversationMessage[] = [];
   let filesModified: string[] = [];
   const pendingTasks: string[] = [];

--- a/src/parsers/gemini.ts
+++ b/src/parsers/gemini.ts
@@ -126,6 +126,7 @@ async function parseJsonlSessionFile(filePath: string): Promise<GeminiSessionDat
   const rl = readline.createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
   const sessionState: Partial<GeminiSessionData> = {};
   const messages: GeminiMessage[] = [];
+  const messageIndexById = new Map<string, number>();
 
   try {
     for await (const rawLine of rl) {
@@ -136,8 +137,8 @@ async function parseJsonlSessionFile(filePath: string): Promise<GeminiSessionDat
       try {
         record = JSON.parse(line) as GeminiJsonlRecord;
       } catch (err) {
-        logger.debug('gemini: invalid JSONL record', filePath, err);
-        return null;
+        logger.debug('gemini: skipping malformed JSONL record', filePath, err);
+        continue;
       }
 
       if (record.$set && typeof record.$set === 'object') {
@@ -149,13 +150,28 @@ async function parseJsonlSessionFile(filePath: string): Promise<GeminiSessionDat
         const rewindIndex = findRewindIndex(messages, record.$rewindTo);
         if (rewindIndex >= 0) {
           messages.length = rewindIndex;
+          for (const [messageId, index] of messageIndexById.entries()) {
+            if (index >= rewindIndex) {
+              messageIndexById.delete(messageId);
+            }
+          }
         }
         continue;
       }
 
       const message = toGeminiMessage(record);
       if (message) {
-        messages.push(message);
+        if (message.id) {
+          const existingIndex = messageIndexById.get(message.id);
+          if (existingIndex !== undefined) {
+            messages[existingIndex] = message;
+          } else {
+            messageIndexById.set(message.id, messages.length);
+            messages.push(message);
+          }
+        } else {
+          messages.push(message);
+        }
         continue;
       }
 

--- a/src/parsers/opencode.ts
+++ b/src/parsers/opencode.ts
@@ -1,9 +1,17 @@
-import * as fs from 'fs';
-import { createRequire } from 'module';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
 import { z } from 'zod';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type { ConversationMessage, SessionContext, ToolUsageSummary, UnifiedSession } from '../types/index.js';
+import type {
+  ConversationMessage,
+  SessionContext,
+  ToolCall,
+  ToolUsageSummary,
+  UnifiedSession,
+} from '../types/index.js';
 import type {
   OpenCodeProject,
   OpenCodeSession,
@@ -21,14 +29,7 @@ import {
 import { findFiles, listSubdirectories } from '../utils/fs-helpers.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
-
-const OPENCODE_BASE_DIR = process.env.XDG_DATA_HOME
-  ? path.join(process.env.XDG_DATA_HOME, 'opencode')
-  : path.join(homeDir(), '.local', 'share', 'opencode');
-const OPENCODE_STORAGE_DIR = path.join(OPENCODE_BASE_DIR, 'storage');
-const OPENCODE_DB_PATH = path.join(OPENCODE_BASE_DIR, 'opencode.db');
+import { SummaryCollector, truncate } from '../utils/tool-summarizer.js';
 
 /** Minimal typed interface for node:sqlite DatabaseSync */
 interface SqlitePreparedStatement {
@@ -47,25 +48,189 @@ const SqliteMsgDataSchema = z.object({ role: z.string() }).passthrough();
 /** Zod schema for part data blob stored in SQLite data column */
 const SqlitePartDataSchema = z.object({ type: z.string(), text: z.string().optional() }).passthrough();
 
+function getOpenCodeBaseDir(): string {
+  return process.env.XDG_DATA_HOME
+    ? path.join(process.env.XDG_DATA_HOME, 'opencode')
+    : path.join(homeDir(), '.local', 'share', 'opencode');
+}
+
+function getOpenCodeStorageDir(): string {
+  return path.join(getOpenCodeBaseDir(), 'storage');
+}
+
+function getOpenCodeDbPath(): string {
+  if (process.env.OPENCODE_DB) {
+    return process.env.OPENCODE_DB;
+  }
+
+  const baseDir = getOpenCodeBaseDir();
+  const defaultDbPath = path.join(baseDir, 'opencode.db');
+  if (fs.existsSync(defaultDbPath)) {
+    return defaultDbPath;
+  }
+
+  try {
+    const channelDbPaths = fs
+      .readdirSync(baseDir)
+      .filter((entry) => /^opencode-[^.]+\.db$/u.test(entry))
+      .map((entry) => path.join(baseDir, entry))
+      .sort((left, right) => {
+        const rightStat = fs.statSync(right);
+        const leftStat = fs.statSync(left);
+        return rightStat.mtimeMs - leftStat.mtimeMs || left.localeCompare(right);
+      });
+    if (channelDbPaths.length > 0) {
+      return channelDbPaths[0];
+    }
+  } catch (err) {
+    logger.debug('opencode: failed to inspect channel SQLite DB variants', baseDir, err);
+  }
+
+  return defaultDbPath;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function previewUnknown(value: unknown, maxLength = 160): string {
+  if (typeof value === 'string') {
+    return truncate(normalizeWhitespace(value), maxLength);
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  try {
+    return truncate(normalizeWhitespace(JSON.stringify(value)), maxLength);
+  } catch (err) {
+    logger.debug('opencode: failed to stringify preview value', err);
+    return '';
+  }
+}
+
+function extractGenericPartPreview(
+  partData: Record<string, unknown>,
+  preferredKeys: string[] = ['text', 'title', 'summary', 'message', 'content', 'patch', 'diff'],
+): string {
+  for (const key of preferredKeys) {
+    const preview = previewUnknown(partData[key]);
+    if (preview) return preview;
+  }
+
+  const state = isRecord(partData.state) ? partData.state : undefined;
+  if (state) {
+    for (const key of ['output', 'error', 'title', 'input']) {
+      const preview = previewUnknown(state[key]);
+      if (preview) return preview;
+    }
+  }
+
+  return '';
+}
+
+function normalizeToolArguments(input: unknown): Record<string, unknown> | undefined {
+  if (isRecord(input)) return input;
+  if (input === undefined) return undefined;
+  return { value: input };
+}
+
+function renderToolPart(partData: Record<string, unknown>): {
+  content: string;
+  toolCall: ToolCall;
+  summary: string;
+  toolName: string;
+  isError: boolean;
+} | null {
+  const toolName = typeof partData.tool === 'string' ? partData.tool : 'tool';
+  const state = isRecord(partData.state) ? partData.state : {};
+  const status = typeof state.status === 'string' ? state.status : undefined;
+  const resultPreview = previewUnknown(state.output) || previewUnknown(state.error);
+  const argPreview = previewUnknown(state.input, 120);
+
+  const detailBits = [argPreview, resultPreview].filter(Boolean);
+  const statusLabel = status ? ` ${status}` : '';
+  const content = [`[tool:${toolName}${statusLabel}]`, ...detailBits].join(' ').trim();
+
+  const summaryBits = [status, argPreview && `input=${argPreview}`, resultPreview && `result=${resultPreview}`].filter(
+    Boolean,
+  );
+  const summary = summaryBits.length > 0 ? summaryBits.join(' | ') : 'invoked';
+  const success = status === 'completed' ? true : status === 'error' ? false : undefined;
+
+  return {
+    content,
+    toolName,
+    summary,
+    isError: success === false,
+    toolCall: {
+      name: toolName,
+      ...(typeof partData.callID === 'string' ? { id: partData.callID } : {}),
+      ...(normalizeToolArguments(state.input) ? { arguments: normalizeToolArguments(state.input) } : {}),
+      ...(resultPreview ? { result: resultPreview } : {}),
+      ...(success !== undefined ? { success } : {}),
+    },
+  };
+}
+
+function renderHighValuePart(partData: Record<string, unknown>): {
+  content?: string;
+  toolCall?: ToolCall;
+} {
+  switch (partData.type) {
+    case 'text':
+      return { content: typeof partData.text === 'string' ? partData.text : undefined };
+    case 'reasoning': {
+      const preview = extractGenericPartPreview(partData, ['text', 'summary', 'content']);
+      return preview ? { content: `[reasoning] ${preview}` } : {};
+    }
+    case 'tool': {
+      const rendered = renderToolPart(partData);
+      return rendered ? { content: rendered.content, toolCall: rendered.toolCall } : {};
+    }
+    case 'patch':
+    case 'compaction':
+    case 'snapshot':
+    case 'agent':
+    case 'retry':
+    case 'subtask': {
+      const preview = extractGenericPartPreview(partData);
+      return preview ? { content: `[${partData.type}] ${preview}` } : {};
+    }
+    default:
+      return {};
+  }
+}
+
 /**
  * Check if SQLite DB exists and is usable
  */
 function hasSqliteDb(): boolean {
-  return fs.existsSync(OPENCODE_DB_PATH);
+  return fs.existsSync(getOpenCodeDbPath());
 }
 
 /**
  * Open SQLite database using node:sqlite (built-in)
  */
 function openDb(): { db: SqliteDatabase; close: () => void } | null {
+  const dbPath = getOpenCodeDbPath();
   try {
     // Dynamic import of node:sqlite to avoid issues on older Node versions
     const require = createRequire(import.meta.url);
     const { DatabaseSync } = require('node:sqlite');
-    const db = new DatabaseSync(OPENCODE_DB_PATH, { open: true, readOnly: true }) as SqliteDatabase;
+    const db = new DatabaseSync(dbPath, { open: true, readOnly: true }) as SqliteDatabase;
     return { db, close: () => db.close() };
   } catch (err) {
-    logger.debug('opencode: failed to open SQLite database', OPENCODE_DB_PATH, err);
+    logger.debug('opencode: failed to open SQLite database', dbPath, err);
     return null;
   }
 }
@@ -74,7 +239,7 @@ function openDb(): { db: SqliteDatabase; close: () => void } | null {
  * Find all OpenCode session files
  */
 async function findSessionFiles(): Promise<string[]> {
-  const sessionDir = path.join(OPENCODE_STORAGE_DIR, 'session');
+  const sessionDir = path.join(getOpenCodeStorageDir(), 'session');
   const results: string[] = [];
   for (const projectDir of listSubdirectories(sessionDir)) {
     results.push(
@@ -107,7 +272,7 @@ function parseSessionFile(filePath: string): OpenCodeSession | null {
  * Load project info to get worktree/cwd
  */
 function loadProjectInfo(projectId: string): OpenCodeProject | null {
-  const projectFile = path.join(OPENCODE_STORAGE_DIR, 'project', `${projectId}.json`);
+  const projectFile = path.join(getOpenCodeStorageDir(), 'project', `${projectId}.json`);
   try {
     if (fs.existsSync(projectFile)) {
       const content = fs.readFileSync(projectFile, 'utf8');
@@ -125,7 +290,7 @@ function loadProjectInfo(projectId: string): OpenCodeProject | null {
  * Get first user message from session messages
  */
 function getFirstUserMessage(sessionId: string): string {
-  const messageDir = path.join(OPENCODE_STORAGE_DIR, 'message', sessionId);
+  const messageDir = path.join(getOpenCodeStorageDir(), 'message', sessionId);
   if (!fs.existsSync(messageDir)) return '';
 
   try {
@@ -144,7 +309,7 @@ function getFirstUserMessage(sessionId: string): string {
       if (msg.role === 'user') {
         // Get the message text from parts
         const messageId = msg.id;
-        const partDir = path.join(OPENCODE_STORAGE_DIR, 'part', messageId);
+        const partDir = path.join(getOpenCodeStorageDir(), 'part', messageId);
 
         if (fs.existsSync(partDir)) {
           const partFiles = fs
@@ -177,7 +342,7 @@ function getFirstUserMessage(sessionId: string): string {
  * Count message lines for a session
  */
 function countSessionLines(sessionId: string): number {
-  const messageDir = path.join(OPENCODE_STORAGE_DIR, 'message', sessionId);
+  const messageDir = path.join(getOpenCodeStorageDir(), 'message', sessionId);
   if (!fs.existsSync(messageDir)) return 0;
 
   try {
@@ -247,8 +412,8 @@ function parseSessionsFromSqlite(): UnifiedSession[] {
             if (partData.text) {
               summary = partData.text.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 50);
             }
-          } catch (_err) {
-            /* ignore malformed part data */
+          } catch (err) {
+            logger.debug('opencode: failed to parse SQLite first-message part', row.id, err);
           }
         }
       }
@@ -262,7 +427,7 @@ function parseSessionsFromSqlite(): UnifiedSession[] {
         bytes: 0, // SQLite doesn't have per-session file size
         createdAt: new Date(row.time_created),
         updatedAt: new Date(row.time_updated),
-        originalPath: OPENCODE_DB_PATH,
+        originalPath: getOpenCodeDbPath(),
         summary: summary?.slice(0, 60) || row.slug || undefined,
         model: undefined,
       });
@@ -358,23 +523,34 @@ function readMessagesFromSqlite(sessionId: string): ConversationMessage[] {
 
       // Get text parts for this message
       const partRows = db
-        .prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC')
+        .prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC, id ASC')
         .all(msgRow.id) as SqlitePartRow[];
 
-      let text = '';
+      const contentParts: string[] = [];
+      const toolCalls: NonNullable<ConversationMessage['toolCalls']> = [];
       for (const partRow of partRows) {
-        const partDataResult = SqlitePartDataSchema.safeParse(JSON.parse(partRow.data));
-        if (!partDataResult.success) continue;
-        if (partDataResult.data.type === 'text' && partDataResult.data.text) {
-          text += partDataResult.data.text + '\n';
+        let rawPartData: unknown;
+        try {
+          rawPartData = JSON.parse(partRow.data);
+        } catch (err) {
+          logger.debug('opencode: failed to parse SQLite part JSON', msgRow.id, err);
+          continue;
         }
+
+        const partDataResult = SqlitePartDataSchema.safeParse(rawPartData);
+        if (!partDataResult.success) continue;
+        const rendered = renderHighValuePart(partDataResult.data);
+        if (rendered.content) contentParts.push(rendered.content);
+        if (rendered.toolCall) toolCalls.push(rendered.toolCall);
       }
 
-      if (text.trim()) {
+      const content = contentParts.join('\n').trim();
+      if (content) {
         messages.push({
           role,
-          content: text.trim(),
+          content,
           timestamp: new Date(msgRow.time_created),
+          ...(toolCalls.length > 0 ? { toolCalls } : {}),
         });
       }
     }
@@ -393,7 +569,7 @@ function readMessagesFromSqlite(sessionId: string): ConversationMessage[] {
  */
 function readMessagesFromJson(sessionId: string): ConversationMessage[] {
   const messages: ConversationMessage[] = [];
-  const messageDir = path.join(OPENCODE_STORAGE_DIR, 'message', sessionId);
+  const messageDir = path.join(getOpenCodeStorageDir(), 'message', sessionId);
 
   if (!fs.existsSync(messageDir)) return messages;
 
@@ -411,8 +587,9 @@ function readMessagesFromJson(sessionId: string): ConversationMessage[] {
       const msg = msgResult.data;
 
       // Get message text from parts
-      const partDir = path.join(OPENCODE_STORAGE_DIR, 'part', msg.id);
-      let text = '';
+      const partDir = path.join(getOpenCodeStorageDir(), 'part', msg.id);
+      const contentParts: string[] = [];
+      const toolCalls: NonNullable<ConversationMessage['toolCalls']> = [];
 
       if (fs.existsSync(partDir)) {
         const partFiles = fs
@@ -425,19 +602,19 @@ function readMessagesFromJson(sessionId: string): ConversationMessage[] {
           const partContent = fs.readFileSync(partPath, 'utf8');
           const partResult = OpenCodePartSchema.safeParse(JSON.parse(partContent));
           if (!partResult.success) continue;
-          const part = partResult.data;
-
-          if (part.type === 'text' && part.text) {
-            text += part.text + '\n';
-          }
+          const rendered = renderHighValuePart(partResult.data);
+          if (rendered.content) contentParts.push(rendered.content);
+          if (rendered.toolCall) toolCalls.push(rendered.toolCall);
         }
       }
 
-      if (text.trim()) {
+      const content = contentParts.join('\n').trim();
+      if (content) {
         messages.push({
           role: msg.role === 'user' ? 'user' : 'assistant',
-          content: text.trim(),
+          content,
           timestamp: new Date(msg.time.created),
+          ...(toolCalls.length > 0 ? { toolCalls } : {}),
         });
       }
     }
@@ -455,10 +632,79 @@ function readMessagesFromJson(sessionId: string): ConversationMessage[] {
  * so we produce a single high-level "Edit" summary when data is available.
  */
 function extractOpenCodeToolSummaries(sessionId: string): ToolUsageSummary[] {
-  const summaries: ToolUsageSummary[] = [];
+  const collector = new SummaryCollector();
 
-  // Try to read the raw session file for summary.additions/deletions/files
-  const sessionDir = path.join(OPENCODE_STORAGE_DIR, 'session');
+  if (hasSqliteDb()) {
+    const sqliteSummaries = extractOpenCodeToolSummariesFromSqlite(sessionId, collector);
+    if (sqliteSummaries.length > 0) {
+      return sqliteSummaries;
+    }
+  }
+
+  return extractOpenCodeToolSummariesFromJson(sessionId, collector);
+}
+
+function extractOpenCodeToolSummariesFromSqlite(sessionId: string, collector: SummaryCollector): ToolUsageSummary[] {
+  const handle = openDb();
+  if (!handle) return [];
+
+  const { db, close } = handle;
+  try {
+    const sessionRow = db
+      .prepare('SELECT summary_additions, summary_deletions, summary_files FROM session WHERE id = ?')
+      .get(sessionId) as
+      | {
+          summary_additions: number | null;
+          summary_deletions: number | null;
+          summary_files: number | null;
+        }
+      | undefined;
+
+    const added = sessionRow?.summary_additions ?? 0;
+    const removed = sessionRow?.summary_deletions ?? 0;
+    const files = sessionRow?.summary_files ?? 0;
+    if (files > 0 || added > 0 || removed > 0) {
+      collector.add('Edit', `${files} file(s) changed (+${added} -${removed})`, {
+        data: {
+          category: 'edit',
+          filePath: `(${files} files)`,
+          diffStats: { added, removed },
+        },
+      });
+    }
+
+    const partRows = db
+      .prepare('SELECT data FROM part WHERE session_id = ? ORDER BY time_created ASC, id ASC')
+      .all(sessionId) as SqlitePartRow[];
+
+    for (const partRow of partRows) {
+      let rawPartData: unknown;
+      try {
+        rawPartData = JSON.parse(partRow.data);
+      } catch (err) {
+        logger.debug('opencode: failed to parse SQLite tool-summary part JSON', sessionId, err);
+        continue;
+      }
+
+      const partDataResult = SqlitePartDataSchema.safeParse(rawPartData);
+      if (!partDataResult.success || partDataResult.data.type !== 'tool') continue;
+
+      const rendered = renderToolPart(partDataResult.data);
+      if (!rendered) continue;
+      collector.add(rendered.toolName, rendered.summary, { isError: rendered.isError });
+    }
+
+    return collector.getSummaries();
+  } catch (err) {
+    logger.debug('opencode: SQLite tool summary query failed', sessionId, err);
+    return [];
+  } finally {
+    close();
+  }
+}
+
+function extractOpenCodeToolSummariesFromJson(sessionId: string, collector: SummaryCollector): ToolUsageSummary[] {
+  const sessionDir = path.join(getOpenCodeStorageDir(), 'session');
   try {
     for (const projectDir of listSubdirectories(sessionDir)) {
       const sessionFile = path.join(projectDir, `${sessionId}.json`);
@@ -467,38 +713,74 @@ function extractOpenCodeToolSummaries(sessionId: string): ToolUsageSummary[] {
       const result = OpenCodeSessionSchema.safeParse(JSON.parse(content));
       if (!result.success) break;
       const raw = result.data;
-      if (raw.summary && (raw.summary.additions || raw.summary.deletions)) {
+      if (raw.summary && (raw.summary.additions || raw.summary.deletions || raw.summary.files)) {
         const added = raw.summary.additions || 0;
         const removed = raw.summary.deletions || 0;
         const files = raw.summary.files || 0;
-        summaries.push({
-          name: 'Edit',
-          count: files || 1,
-          samples: [
-            {
-              summary: `${files} file(s) changed (+${added} -${removed})`,
-              data: {
-                category: 'edit',
-                filePath: `(${files} files)`,
-                diffStats: { added, removed },
-              },
-            },
-          ],
+        collector.add('Edit', `${files} file(s) changed (+${added} -${removed})`, {
+          data: {
+            category: 'edit',
+            filePath: `(${files} files)`,
+            diffStats: { added, removed },
+          },
         });
       }
-      break; // found the session file
+      break;
     }
-  } catch {
-    // Silently skip — tool summaries are optional
+  } catch (err) {
+    logger.debug('opencode: failed to read JSON tool summaries', sessionId, err);
   }
 
-  return summaries;
+  const messageDir = path.join(getOpenCodeStorageDir(), 'message', sessionId);
+  if (!fs.existsSync(messageDir)) {
+    return collector.getSummaries();
+  }
+
+  try {
+    const messageFiles = fs
+      .readdirSync(messageDir)
+      .filter((fileName) => fileName.startsWith('msg_') && fileName.endsWith('.json'))
+      .sort();
+
+    for (const messageFile of messageFiles) {
+      const messagePath = path.join(messageDir, messageFile);
+      const messageContent = fs.readFileSync(messagePath, 'utf8');
+      const messageResult = OpenCodeMessageSchema.safeParse(JSON.parse(messageContent));
+      if (!messageResult.success) continue;
+
+      const partDir = path.join(getOpenCodeStorageDir(), 'part', messageResult.data.id);
+      if (!fs.existsSync(partDir)) continue;
+
+      const partFiles = fs
+        .readdirSync(partDir)
+        .filter((fileName) => fileName.startsWith('prt_') && fileName.endsWith('.json'))
+        .sort();
+
+      for (const partFile of partFiles) {
+        const partPath = path.join(partDir, partFile);
+        const partContent = fs.readFileSync(partPath, 'utf8');
+        const partResult = OpenCodePartSchema.safeParse(JSON.parse(partContent));
+        if (!partResult.success || partResult.data.type !== 'tool') continue;
+
+        const rendered = renderToolPart(partResult.data);
+        if (!rendered) continue;
+        collector.add(rendered.toolName, rendered.summary, { isError: rendered.isError });
+      }
+    }
+  } catch (err) {
+    logger.debug('opencode: failed to read JSON tool-part summaries', sessionId, err);
+  }
+
+  return collector.getSummaries();
 }
 
 /**
  * Extract context from an OpenCode session for cross-tool continuation
  */
-export async function extractOpenCodeContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
+export async function extractOpenCodeContext(
+  session: UnifiedSession,
+  config?: VerbosityConfig,
+): Promise<SessionContext> {
   const resolvedConfig = config ?? getPreset('standard');
   const recentMessages = readAllMessages(session.id);
   const filesModified: string[] = [];
@@ -507,7 +789,15 @@ export async function extractOpenCodeContext(session: UnifiedSession, config?: V
 
   const trimmed = recentMessages.slice(-resolvedConfig.recentMessages);
 
-  const markdown = generateHandoffMarkdown(session, trimmed, filesModified, pendingTasks, toolSummaries, undefined, resolvedConfig);
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    undefined,
+    resolvedConfig,
+  );
 
   return {
     session,

--- a/src/parsers/opencode.ts
+++ b/src/parsers/opencode.ts
@@ -58,15 +58,16 @@ function getOpenCodeStorageDir(): string {
   return path.join(getOpenCodeBaseDir(), 'storage');
 }
 
-function getOpenCodeDbPath(): string {
+function getOpenCodeDbPaths(): string[] {
   if (process.env.OPENCODE_DB) {
-    return process.env.OPENCODE_DB;
+    return [process.env.OPENCODE_DB];
   }
 
   const baseDir = getOpenCodeBaseDir();
   const defaultDbPath = path.join(baseDir, 'opencode.db');
+  const dbPaths: string[] = [];
   if (fs.existsSync(defaultDbPath)) {
-    return defaultDbPath;
+    dbPaths.push(defaultDbPath);
   }
 
   try {
@@ -79,14 +80,16 @@ function getOpenCodeDbPath(): string {
         const leftStat = fs.statSync(left);
         return rightStat.mtimeMs - leftStat.mtimeMs || left.localeCompare(right);
       });
-    if (channelDbPaths.length > 0) {
-      return channelDbPaths[0];
+    for (const channelDbPath of channelDbPaths) {
+      if (!dbPaths.includes(channelDbPath)) {
+        dbPaths.push(channelDbPath);
+      }
     }
   } catch (err) {
     logger.debug('opencode: failed to inspect channel SQLite DB variants', baseDir, err);
   }
 
-  return defaultDbPath;
+  return dbPaths;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -215,14 +218,13 @@ function renderHighValuePart(partData: Record<string, unknown>): {
  * Check if SQLite DB exists and is usable
  */
 function hasSqliteDb(): boolean {
-  return fs.existsSync(getOpenCodeDbPath());
+  return getOpenCodeDbPaths().some((dbPath) => fs.existsSync(dbPath));
 }
 
 /**
  * Open SQLite database using node:sqlite (built-in)
  */
-function openDb(): { db: SqliteDatabase; close: () => void } | null {
-  const dbPath = getOpenCodeDbPath();
+function openDb(dbPath: string): { db: SqliteDatabase; close: () => void } | null {
   try {
     // Dynamic import of node:sqlite to avoid issues on older Node versions
     const require = createRequire(import.meta.url);
@@ -372,74 +374,80 @@ export async function parseOpenCodeSessions(): Promise<UnifiedSession[]> {
  * Parse sessions from SQLite database
  */
 function parseSessionsFromSqlite(): UnifiedSession[] {
-  const handle = openDb();
-  if (!handle) return [];
+  const sessionsById = new Map<string, UnifiedSession>();
 
-  const { db, close } = handle;
-  try {
-    const rows = db
-      .prepare(
-        'SELECT id, project_id, slug, directory, title, version, summary_additions, summary_deletions, summary_files, time_created, time_updated FROM session ORDER BY time_updated DESC',
-      )
-      .all() as SqliteSessionRow[];
+  for (const dbPath of getOpenCodeDbPaths()) {
+    const handle = openDb(dbPath);
+    if (!handle) continue;
 
-    // Build project lookup
-    const projectRows = db.prepare('SELECT id, worktree FROM project').all() as SqliteProjectRow[];
-    const projectMap = new Map(projectRows.map((p: SqliteProjectRow) => [p.id, p.worktree]));
+    const { db, close } = handle;
+    try {
+      const rows = db
+        .prepare(
+          'SELECT id, project_id, slug, directory, title, version, summary_additions, summary_deletions, summary_files, time_created, time_updated FROM session ORDER BY time_updated DESC',
+        )
+        .all() as SqliteSessionRow[];
 
-    const sessions: UnifiedSession[] = [];
+      // Build project lookup
+      const projectRows = db.prepare('SELECT id, worktree FROM project').all() as SqliteProjectRow[];
+      const projectMap = new Map(projectRows.map((p: SqliteProjectRow) => [p.id, p.worktree]));
 
-    for (const row of rows) {
-      const cwd = row.directory || projectMap.get(row.project_id) || '';
+      for (const row of rows) {
+        const cwd = row.directory || projectMap.get(row.project_id) || '';
 
-      // Count messages for this session
-      const msgCount = db.prepare('SELECT COUNT(*) as cnt FROM message WHERE session_id = ?').get(row.id) as
-        | { cnt: number }
-        | undefined;
+        // Count messages for this session
+        const msgCount = db.prepare('SELECT COUNT(*) as cnt FROM message WHERE session_id = ?').get(row.id) as
+          | { cnt: number }
+          | undefined;
 
-      // Get first user message for summary if no title
-      let summary = row.title || '';
-      if (!summary || summary.startsWith('New session')) {
-        const firstMsg = db
-          .prepare(
-            'SELECT m.id, p.data FROM message m JOIN part p ON p.message_id = m.id WHERE m.session_id = ? AND m.data LIKE \'%"role":"user"%\' AND p.data LIKE \'%"type":"text"%\' ORDER BY m.time_created ASC LIMIT 1',
-          )
-          .get(row.id) as { id: string; data: string } | undefined;
+        // Get first user message for summary if no title
+        let summary = row.title || '';
+        if (!summary || summary.startsWith('New session')) {
+          const firstMsg = db
+            .prepare(
+              'SELECT m.id, p.data FROM message m JOIN part p ON p.message_id = m.id WHERE m.session_id = ? AND m.data LIKE \'%"role":"user"%\' AND p.data LIKE \'%"type":"text"%\' ORDER BY m.time_created ASC LIMIT 1',
+            )
+            .get(row.id) as { id: string; data: string } | undefined;
 
-        if (firstMsg) {
-          try {
-            const partData = JSON.parse(firstMsg.data);
-            if (partData.text) {
-              summary = partData.text.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 50);
+          if (firstMsg) {
+            try {
+              const partData = JSON.parse(firstMsg.data);
+              if (partData.text) {
+                summary = partData.text.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 50);
+              }
+            } catch (err) {
+              logger.debug('opencode: failed to parse SQLite first-message part', row.id, err);
             }
-          } catch (err) {
-            logger.debug('opencode: failed to parse SQLite first-message part', row.id, err);
           }
         }
+
+        const nextSession: UnifiedSession = {
+          id: row.id,
+          source: 'opencode',
+          cwd,
+          repo: extractRepoFromCwd(cwd),
+          lines: msgCount?.cnt ?? 0,
+          bytes: 0, // SQLite doesn't have per-session file size
+          createdAt: new Date(row.time_created),
+          updatedAt: new Date(row.time_updated),
+          originalPath: dbPath,
+          summary: summary?.slice(0, 60) || row.slug || undefined,
+          model: undefined,
+        };
+
+        const existing = sessionsById.get(nextSession.id);
+        if (!existing || existing.updatedAt.getTime() < nextSession.updatedAt.getTime()) {
+          sessionsById.set(nextSession.id, nextSession);
+        }
       }
-
-      sessions.push({
-        id: row.id,
-        source: 'opencode',
-        cwd,
-        repo: extractRepoFromCwd(cwd),
-        lines: msgCount?.cnt ?? 0,
-        bytes: 0, // SQLite doesn't have per-session file size
-        createdAt: new Date(row.time_created),
-        updatedAt: new Date(row.time_updated),
-        originalPath: getOpenCodeDbPath(),
-        summary: summary?.slice(0, 60) || row.slug || undefined,
-        model: undefined,
-      });
+    } catch (err) {
+      logger.debug('opencode: SQLite session query failed', dbPath, err);
+    } finally {
+      close();
     }
-
-    return sessions;
-  } catch (err) {
-    logger.debug('opencode: SQLite session query failed', err);
-    return [];
-  } finally {
-    close();
   }
+
+  return Array.from(sessionsById.values()).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 }
 
 /**
@@ -504,64 +512,68 @@ function readAllMessages(sessionId: string): ConversationMessage[] {
  * Read messages from SQLite database
  */
 function readMessagesFromSqlite(sessionId: string): ConversationMessage[] {
-  const handle = openDb();
-  if (!handle) return [];
+  for (const dbPath of getOpenCodeDbPaths()) {
+    const handle = openDb(dbPath);
+    if (!handle) continue;
 
-  const { db, close } = handle;
-  try {
-    // Get messages with their data
-    const msgRows = db
-      .prepare('SELECT id, session_id, time_created, data FROM message WHERE session_id = ? ORDER BY time_created ASC')
-      .all(sessionId) as SqliteMessageRow[];
+    const { db, close } = handle;
+    try {
+      const msgRows = db
+        .prepare(
+          'SELECT id, session_id, time_created, data FROM message WHERE session_id = ? ORDER BY time_created ASC',
+        )
+        .all(sessionId) as SqliteMessageRow[];
+      if (msgRows.length === 0) continue;
 
-    const messages: ConversationMessage[] = [];
+      const messages: ConversationMessage[] = [];
 
-    for (const msgRow of msgRows) {
-      const msgDataResult = SqliteMsgDataSchema.safeParse(JSON.parse(msgRow.data));
-      if (!msgDataResult.success) continue;
-      const role: 'user' | 'assistant' = msgDataResult.data.role === 'user' ? 'user' : 'assistant';
+      for (const msgRow of msgRows) {
+        const msgDataResult = SqliteMsgDataSchema.safeParse(JSON.parse(msgRow.data));
+        if (!msgDataResult.success) continue;
+        const role: 'user' | 'assistant' = msgDataResult.data.role === 'user' ? 'user' : 'assistant';
 
-      // Get text parts for this message
-      const partRows = db
-        .prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC, id ASC')
-        .all(msgRow.id) as SqlitePartRow[];
+        const partRows = db
+          .prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC, id ASC')
+          .all(msgRow.id) as SqlitePartRow[];
 
-      const contentParts: string[] = [];
-      const toolCalls: NonNullable<ConversationMessage['toolCalls']> = [];
-      for (const partRow of partRows) {
-        let rawPartData: unknown;
-        try {
-          rawPartData = JSON.parse(partRow.data);
-        } catch (err) {
-          logger.debug('opencode: failed to parse SQLite part JSON', msgRow.id, err);
-          continue;
+        const contentParts: string[] = [];
+        const toolCalls: NonNullable<ConversationMessage['toolCalls']> = [];
+        for (const partRow of partRows) {
+          let rawPartData: unknown;
+          try {
+            rawPartData = JSON.parse(partRow.data);
+          } catch (err) {
+            logger.debug('opencode: failed to parse SQLite part JSON', msgRow.id, err);
+            continue;
+          }
+
+          const partDataResult = SqlitePartDataSchema.safeParse(rawPartData);
+          if (!partDataResult.success) continue;
+          const rendered = renderHighValuePart(partDataResult.data);
+          if (rendered.content) contentParts.push(rendered.content);
+          if (rendered.toolCall) toolCalls.push(rendered.toolCall);
         }
 
-        const partDataResult = SqlitePartDataSchema.safeParse(rawPartData);
-        if (!partDataResult.success) continue;
-        const rendered = renderHighValuePart(partDataResult.data);
-        if (rendered.content) contentParts.push(rendered.content);
-        if (rendered.toolCall) toolCalls.push(rendered.toolCall);
+        const content = contentParts.join('\n').trim();
+        if (content) {
+          messages.push({
+            role,
+            content,
+            timestamp: new Date(msgRow.time_created),
+            ...(toolCalls.length > 0 ? { toolCalls } : {}),
+          });
+        }
       }
 
-      const content = contentParts.join('\n').trim();
-      if (content) {
-        messages.push({
-          role,
-          content,
-          timestamp: new Date(msgRow.time_created),
-          ...(toolCalls.length > 0 ? { toolCalls } : {}),
-        });
-      }
+      return messages;
+    } catch (err) {
+      logger.debug('opencode: SQLite message query failed for session', dbPath, sessionId, err);
+    } finally {
+      close();
     }
-
-    return messages;
-  } catch (err) {
-    logger.debug('opencode: SQLite message query failed for session', sessionId, err);
-    return [];
-  } finally {
-    close();
   }
+
+  return [];
 }
 
 /**
@@ -645,62 +657,66 @@ function extractOpenCodeToolSummaries(sessionId: string): ToolUsageSummary[] {
 }
 
 function extractOpenCodeToolSummariesFromSqlite(sessionId: string, collector: SummaryCollector): ToolUsageSummary[] {
-  const handle = openDb();
-  if (!handle) return [];
+  for (const dbPath of getOpenCodeDbPaths()) {
+    const handle = openDb(dbPath);
+    if (!handle) continue;
 
-  const { db, close } = handle;
-  try {
-    const sessionRow = db
-      .prepare('SELECT summary_additions, summary_deletions, summary_files FROM session WHERE id = ?')
-      .get(sessionId) as
-      | {
-          summary_additions: number | null;
-          summary_deletions: number | null;
-          summary_files: number | null;
-        }
-      | undefined;
+    const { db, close } = handle;
+    try {
+      const sessionRow = db
+        .prepare('SELECT summary_additions, summary_deletions, summary_files FROM session WHERE id = ?')
+        .get(sessionId) as
+        | {
+            summary_additions: number | null;
+            summary_deletions: number | null;
+            summary_files: number | null;
+          }
+        | undefined;
 
-    const added = sessionRow?.summary_additions ?? 0;
-    const removed = sessionRow?.summary_deletions ?? 0;
-    const files = sessionRow?.summary_files ?? 0;
-    if (files > 0 || added > 0 || removed > 0) {
-      collector.add('Edit', `${files} file(s) changed (+${added} -${removed})`, {
-        data: {
-          category: 'edit',
-          filePath: `(${files} files)`,
-          diffStats: { added, removed },
-        },
-      });
-    }
-
-    const partRows = db
-      .prepare('SELECT data FROM part WHERE session_id = ? ORDER BY time_created ASC, id ASC')
-      .all(sessionId) as SqlitePartRow[];
-
-    for (const partRow of partRows) {
-      let rawPartData: unknown;
-      try {
-        rawPartData = JSON.parse(partRow.data);
-      } catch (err) {
-        logger.debug('opencode: failed to parse SQLite tool-summary part JSON', sessionId, err);
-        continue;
+      const added = sessionRow?.summary_additions ?? 0;
+      const removed = sessionRow?.summary_deletions ?? 0;
+      const files = sessionRow?.summary_files ?? 0;
+      if (files > 0 || added > 0 || removed > 0) {
+        collector.add('Edit', `${files} file(s) changed (+${added} -${removed})`, {
+          data: {
+            category: 'edit',
+            filePath: `(${files} files)`,
+            diffStats: { added, removed },
+          },
+        });
       }
 
-      const partDataResult = SqlitePartDataSchema.safeParse(rawPartData);
-      if (!partDataResult.success || partDataResult.data.type !== 'tool') continue;
+      const partRows = db
+        .prepare('SELECT data FROM part WHERE session_id = ? ORDER BY time_created ASC, id ASC')
+        .all(sessionId) as SqlitePartRow[];
+      if (partRows.length === 0) continue;
 
-      const rendered = renderToolPart(partDataResult.data);
-      if (!rendered) continue;
-      collector.add(rendered.toolName, rendered.summary, { isError: rendered.isError });
+      for (const partRow of partRows) {
+        let rawPartData: unknown;
+        try {
+          rawPartData = JSON.parse(partRow.data);
+        } catch (err) {
+          logger.debug('opencode: failed to parse SQLite tool-summary part JSON', sessionId, err);
+          continue;
+        }
+
+        const partDataResult = SqlitePartDataSchema.safeParse(rawPartData);
+        if (!partDataResult.success || partDataResult.data.type !== 'tool') continue;
+
+        const rendered = renderToolPart(partDataResult.data);
+        if (!rendered) continue;
+        collector.add(rendered.toolName, rendered.summary, { isError: rendered.isError });
+      }
+
+      return collector.getSummaries();
+    } catch (err) {
+      logger.debug('opencode: SQLite tool summary query failed', dbPath, sessionId, err);
+    } finally {
+      close();
     }
-
-    return collector.getSummaries();
-  } catch (err) {
-    logger.debug('opencode: SQLite tool summary query failed', sessionId, err);
-    return [];
-  } finally {
-    close();
   }
+
+  return [];
 }
 
 function extractOpenCodeToolSummariesFromJson(sessionId: string, collector: SummaryCollector): ToolUsageSummary[] {

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -10,7 +10,7 @@ import { TOOL_NAMES } from './tool-names.js';
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /** Content that can be a string or an array of blocks */
-const StringOrBlockArray = z.union([
+const _StringOrBlockArray = z.union([
   z.string(),
   z.array(z.object({ type: z.string(), text: z.string().optional() }).passthrough()),
 ]);
@@ -80,6 +80,29 @@ export const CodexEventMsgSchema = z
         content: z.array(z.object({ type: z.string(), text: z.string().optional() }).passthrough()).optional(),
         input_tokens: z.number().optional(),
         output_tokens: z.number().optional(),
+        info: z
+          .object({
+            total_token_usage: z
+              .object({
+                input_tokens: z.number().optional(),
+                output_tokens: z.number().optional(),
+                cached_input_tokens: z.number().optional(),
+                reasoning_output_tokens: z.number().optional(),
+              })
+              .passthrough()
+              .optional(),
+            last_token_usage: z
+              .object({
+                input_tokens: z.number().optional(),
+                output_tokens: z.number().optional(),
+                cached_input_tokens: z.number().optional(),
+                reasoning_output_tokens: z.number().optional(),
+              })
+              .passthrough()
+              .optional(),
+          })
+          .passthrough()
+          .optional(),
       })
       .passthrough()
       .optional(),

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -20,6 +20,7 @@ export interface HandoffContextOptions {
   preset?: string;
   configPath?: string;
   chain?: boolean;
+  debugPrompt?: boolean;
 }
 
 /**
@@ -159,6 +160,11 @@ export async function crossToolResume(
   const adapter = adapters[target];
   if (!adapter) throw new Error(`Unknown target: ${target}`);
 
+  if (contextOptions?.debugPrompt) {
+    console.log(prompt);
+    return;
+  }
+
   const resolved = resolveCrossToolForwarding(target, forwarding);
   const defaultInitArgs = getDefaultHandoffInitArgs(target, resolved.extraArgs);
   await runCommand(
@@ -234,6 +240,12 @@ export async function resume(
   contextOptions?: HandoffContextOptions,
 ): Promise<void> {
   const actualTarget = target || session.source;
+
+  if (contextOptions?.debugPrompt && actualTarget === session.source) {
+    throw new Error(
+      '--debug-prompt requires a cross-tool handoff target. Use --in <tool> different from the source session.',
+    );
+  }
 
   if (actualTarget === session.source) {
     // Same tool - use native resume


### PR DESCRIPTION
## Summary

This PR hardens `continues`’ parsing system using the research corpus gathered in this branch.

It does two things together:

1. adds a large parser-research and comparison corpus covering our supported tools, current upstream storage behavior, and `f/agentlytics` overlap, and
2. implements the highest-confidence parser fixes that fell out of that research.

The parser changes in this PR focus on Codex, Copilot, Gemini, OpenCode, and Cursor, plus the `resume --debug-prompt` support used to inspect outbound handoff prompts safely.

## Root Cause

The underlying problem was not one bug. It was a pattern:

- our parser docs were often ahead of our actual parser implementations
- some parsers were still aligned to older storage formats even after upstream tools had moved
- some discovery logic ignored documented env/config roots
- some parsers underused richer native surfaces that were already present
- some outputs implied more confidence than the raw sources justified

The biggest confirmed examples were:

- Gemini: docs already described current JSONL append-log behavior, but the parser was still legacy-JSON-first
- Codex: current protocol nests token usage under `payload.info.*`, but our parser still expected older flatter token_count shapes
- Copilot: documented `COPILOT_HOME` / `--config-dir` support and `tool.execution_complete` result events were not reflected in the parser
- OpenCode: docs already treated SQLite as canonical, but the parser still dropped non-text parts and ignored `OPENCODE_DB`
- Cursor: our docs were cautious about transcript completeness, but the code still projected more confidence than the raw transcript justified

## What Changed

### Parser fixes

- `src/parsers/codex.ts`
  - scans both `sessions/` and `archived_sessions/`
  - reads nested `event_msg.token_count.payload.info.*`
  - deduplicates active vs archived session IDs

- `src/parsers/copilot.ts`
  - honors `COPILOT_HOME`
  - merges `tool.execution_start` / `tool.execution_complete`
  - falls back to `result.contents[]` text blocks when direct content strings are absent
  - tracks write activity from execution events

- `src/parsers/gemini.ts`
  - adds JSONL-first discovery and replay
  - handles `$set` metadata updates and `$rewindTo`
  - recovers `cwd` from `projects.json` and metadata
  - preserves legacy JSON fallback

- `src/parsers/opencode.ts`
  - honors `OPENCODE_DB`
  - supports channel DB variants
  - preserves high-value non-text parts in context
  - improves SQLite and legacy JSON tool-summary extraction

- `src/parsers/cursor.ts`
  - emits an explicit transcript-completeness warning in session notes / handoff output

### Handoff debugging

- `src/cli.ts`
- `src/commands/resume-cmd.ts`
- `src/utils/resume.ts`

Added `continues resume --debug-prompt`, which writes the handoff file as usual, prints the exact cross-tool prompt instead of launching the target tool, and exits. This gives us a direct way to inspect what we are actually passing to the next agent.

### Tests

Added or updated parser-specific regressions:

- `src/__tests__/codex-parser.test.ts`
- `src/__tests__/copilot-parser.test.ts`
- `src/__tests__/gemini-parser.test.ts`
- `src/__tests__/opencode.test.ts`
- `src/__tests__/cursor-parser.test.ts`
- `src/__tests__/resume-debug-prompt.test.ts`
- `src/__tests__/resume-command-debug.test.ts`

### Research and planning corpus

Added:

- `docs/parser-documentation/**`
- `docs/research/high-risk-schema-family-b-adversarial-verification/**`
- `docs/research/final-schema-closure-verification/**`
- `docs/research/agentlytics-parser-comparison/**`

These files now capture:

- current storage/message/tool schemas per supported tool
- adversarial internet verification of the riskiest assumptions
- overlap-by-overlap comparison with `f/agentlytics`
- an updated implementation backlog and unresolved set

## Why This Is Better

This improves correctness in three ways.

### 1. We now parse what upstream tools actually store more often

- Gemini now supports the current JSONL append-log model instead of only the older monolithic JSON sessions.
- Codex now reads the nested token-count structure used by current protocol definitions.
- OpenCode now aligns better with SQLite-first reality and DB override behavior.

### 2. We now make better use of richer native surfaces

- Copilot now uses execution-complete events for better tool/result fidelity.
- Codex now includes archived sessions.
- OpenCode now preserves materially useful non-text parts and better tool summaries.

### 3. We now surface uncertainty more honestly

- Cursor handoffs now carry an explicit transcript-completeness warning instead of silently implying full fidelity.
- The docs and backlog now clearly separate high-confidence fixes from unresolved backend questions.

## Validation

Fresh verification run in the working tree:

- `pnpm exec vitest run src/__tests__/codex-parser.test.ts src/__tests__/copilot-parser.test.ts src/__tests__/gemini-parser.test.ts src/__tests__/opencode.test.ts src/__tests__/cursor-parser.test.ts`
  - passed: 5 files, 16 tests

- `pnpm test`
  - passed: 17 files, 736 tests, 2 skipped

- `pnpm build`
  - passed

- `pnpm exec biome check src/parsers/codex.ts src/types/schemas.ts src/parsers/copilot.ts src/parsers/cursor.ts src/parsers/gemini.ts src/parsers/opencode.ts src/__tests__/codex-parser.test.ts src/__tests__/copilot-parser.test.ts src/__tests__/cursor-parser.test.ts src/__tests__/gemini-parser.test.ts src/__tests__/opencode.test.ts`
  - passed

Known repo-level caveat:

- `pnpm run check` still fails because of unrelated pre-existing Biome debt elsewhere in the repo, outside the files touched for these parser fixes.

## Key Source URLs

### Gemini
- https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts
- https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingTypes.ts

### Codex
- https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs
- https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts
- https://github.com/openai/codex/issues/4792

### Copilot
- https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle
- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference

### OpenCode
- https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/storage/db.ts
- https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/storage/storage.ts
- https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/session/message-v2.ts

### Cursor
- https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311
- https://forum.cursor.com/t/jsonl-format-should-fully-record-the-tool-use-information/154777

### Agentlytics comparison target
- https://github.com/f/agentlytics

## Merge Request

Please merge this if the scope looks right.

The code changes are intentionally focused on high-confidence parser correctness, while the docs/research corpus captures the remaining unresolved areas so we do not overclaim support where upstream evidence is still incomplete.
