### PR TITLE
fix(parsers): close P1 resume, extraction, and loading gaps

### DIFF
--- a/agent-docs/2026-04-27-p1-parser-debug-audit.md
+++ b/agent-docs/2026-04-27-p1-parser-debug-audit.md
@@ -1,0 +1,100 @@
+# 2026-04-27 P1 Parser Debug Audit
+
+## Scope
+
+Focused audit for hidden P0/P1 bugs in `continues`, especially Claude, Codex,
+Droid, and Copilot. No P0 was confirmed. This note records only P1 findings
+that should be fixed before broad multi-agent use.
+
+## Primary Sources
+
+- Claude Code CLI resume and hooks:
+  https://code.claude.com/docs/en/cli-usage,
+  https://code.claude.com/docs/en/hooks
+- OpenAI Codex CLI resume and rollout layout:
+  https://developers.openai.com/codex/cli/features,
+  https://developers.openai.com/codex/cli/reference,
+  https://github.com/openai/codex/blob/main/codex-rs/rollout/src/list.rs
+- GitHub Copilot CLI session storage and command reference:
+  https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-best-practices,
+  https://docs.github.com/en/enterprise-cloud@latest/copilot/concepts/agents/copilot-cli/chronicle,
+  https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+- Factory Droid CLI, exec, and hooks:
+  https://docs.factory.ai/reference/cli-reference,
+  https://docs.factory.ai/cli/droid-exec/overview,
+  https://docs.factory.ai/reference/hooks-reference
+
+## P1 Findings
+
+| ID | Area | Symptom | Mechanism | Required Regression |
+|---|---|---|---|---|
+| P1-01 | Codex resume | Same-tool Codex resume can start fresh or fail. | `src/parsers/registry.ts` uses obsolete `-c experimental_resume=<path>` instead of `codex resume <id>`. | Assert Codex native args/display use `resume <id>`. |
+| P1-02 | Droid resume | Same-tool Droid resume uses an invalid top-level flag. | `droid -s <id>` mixes `droid exec --session-id` semantics into interactive resume. | Assert Droid native args/display use `--resume <id>`. |
+| P1-03 | Cross-tool resume | Invalid `--in` can write handoff files before failing. | Target validation happens after `extractContext()`, local `.continues-handoff.md`, and global context writes. | Invalid target rejects before extract/write/save. |
+| P1-04 | Copilot cache | `COPILOT_HOME` changes can serve stale cached sessions. | Copilot parser reads `COPILOT_HOME`, but adapter metadata lacks `envVar`, so index fingerprint ignores it. | `indexNeedsRebuild()` returns true after `COPILOT_HOME` changes. |
+| P1-05 | Claude handoff | Recent handoff can omit the last user request. | Parser slices raw conversational rows before dropping assistant thinking/tool-only rows. | Fixture with user plus many tool-only assistant rows still includes user. |
+| P1-06 | Claude subagents | Claude `Agent` sidecar results can be missed. | Parser relies on queue-operation task IDs and ignores `toolUseResult.agentId`/sidecar output. | Fixture with `Agent` + `toolUseResult.agentId` extracts subagent result. |
+| P1-07 | Claude ordering | Old Claude sessions can appear newest. | Parser sorts by filesystem `mtime`, which metadata touches can update after transcript activity. | Fixture uses transcript timestamps instead of stat `mtime`. |
+| P1-08 | Codex compaction | Long Codex handoffs lose canonical compacted state. | Parser ignores top-level `compacted` rollout records. | Fixture with `compacted.payload.message` renders compact summary. |
+| P1-09 | Codex edits | `edit_file` calls do not populate `filesModified`. | Function-call edit tools fall through to generic MCP summaries. | Fixture with `edit_file` and MCP-namespaced edit tracks paths as edits. |
+| P1-10 | Codex stdin | `write_stdin` summaries are blank for current Codex logs. | Parser reads `input`/`data`, but logs use `chars`. | Fixture with `chars` appears in tool summary. |
+| P1-11 | Droid discovery | Documented Droid transcript roots may be missed. | Parser scans only `~/.factory/sessions`, while hooks expose `.factory/projects/.../*.jsonl`. | Fixture under both roots is discovered and deduped. |
+| P1-12 | Droid recency | Long Droid sessions sort stale. | Parser scans only first 100 lines and derives `updatedAt` from that window. | Long fixture orders by true latest timestamp. |
+| P1-13 | Droid edits | Droid edit/patch calls lose diffs and modified files. | Shared Anthropic extractor misses `old_str/new_str`, `ApplyPatch input.input`, and `morph___edit_file`. | Fixture covers all three forms and tracks files/diffs. |
+| P1-14 | Copilot handoff | Recent Copilot handoffs can lose the actual conversation. | Parser slices raw event tail before filtering conversation events; tool/hook/shutdown events dominate tails. | Fixture with 20+ non-message tail events still includes last conversation. |
+| P1-15 | Copilot writes | Native Copilot `create` calls are not classified as writes. | Lowercase `create` is absent from `WRITE_TOOLS`, so files are not tracked. | Fixture with `toolName: "create"` tracks the new file. |
+
+## Implementation Order
+
+1. Fix registry/resume validation first because these are user-facing command
+   correctness bugs with low code churn.
+2. Fix shared tool classification/extraction before parser-specific edit tests,
+   so Droid/Copilot/Codex file tracking uses one canonical vocabulary where
+   practical.
+3. Fix parser-tail and timestamp bugs with focused fixtures for each tool.
+4. Run parser regression tests, then the full project checks.
+
+## Fix Status
+
+Status after the 2026-04-27 fix pass:
+
+- P1-01 through P1-04: fixed in registry/resume/cache handling.
+- P1-05 through P1-07: fixed in Claude transcript trimming, Agent sidecar
+  extraction, and transcript timestamp ordering.
+- P1-08 through P1-10: fixed in Codex compaction parsing, namespaced edit
+  classification, and `write_stdin.chars` summaries.
+- P1-11 through P1-13: fixed in Droid root discovery/dedupe/recency scanning and
+  shared Anthropic-style tool extraction.
+- P1-14 through P1-15: fixed in Copilot full-event parsing before trimming and
+  lowercase `create` write classification.
+
+Primary files changed:
+
+- `src/parsers/claude.ts`
+- `src/parsers/codex.ts`
+- `src/parsers/copilot.ts`
+- `src/parsers/droid.ts`
+- `src/parsers/registry.ts`
+- `src/utils/resume.ts`
+- `src/utils/tool-extraction.ts`
+- `src/utils/jsonl.ts`
+- `src/types/tool-names.ts`
+- `src/types/schemas.ts`
+
+## Verification Commands
+
+If `node_modules` is missing, run `pnpm install` first. Then run:
+
+```bash
+pnpm test
+pnpm run check
+```
+
+Do not run watch, real e2e, stress, or local-machine session tests unless a user
+explicitly asks for them.
+
+Known verification note: `pnpm test` passed after the fix pass. `pnpm run check`
+may still fail in this repository on unrelated pre-existing Biome findings in
+files such as `src/__tests__/e2e-conversions.test.ts`,
+`src/__tests__/extract-handoffs.ts`, and `src/utils/tool-summarizer.ts`; confirm
+whether those files are in scope before changing them.

--- a/agent-docs/README.md
+++ b/agent-docs/README.md
@@ -1,0 +1,11 @@
+# Agent Docs
+
+Notes in this directory are written for follow-up coding agents. They capture
+audit state, implementation plans, and verification notes that should survive
+session handoffs.
+
+## Index
+
+- [2026-04-27 P1 Parser Debug Audit](./2026-04-27-p1-parser-debug-audit.md) -
+  source-backed P1 findings for Claude, Codex, Droid, and Copilot session
+  parsing/resume behavior.

--- a/src/__tests__/claude-parser.test.ts
+++ b/src/__tests__/claude-parser.test.ts
@@ -1,0 +1,103 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const tmpDirs: string[] = [];
+
+function makeConfigDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-parser-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function writeJsonl(filePath: string, rows: unknown[]): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+}
+
+function makeRows(opts: { id: string; first: string; last: string; cwd: string }): unknown[] {
+  return [
+    {
+      type: 'user',
+      uuid: `${opts.id}-user`,
+      timestamp: opts.first,
+      sessionId: opts.id,
+      cwd: opts.cwd,
+      gitBranch: 'main',
+      message: { role: 'user', content: [{ type: 'text', text: `Start ${opts.id}` }] },
+    },
+    {
+      type: 'assistant',
+      uuid: `${opts.id}-assistant`,
+      timestamp: opts.last,
+      sessionId: opts.id,
+      cwd: opts.cwd,
+      gitBranch: 'main',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'This assistant response is intentionally long enough to keep the fixture above the parser size filter.',
+          },
+        ],
+      },
+    },
+  ];
+}
+
+async function loadClaudeParser(configDir: string): Promise<typeof import('../parsers/claude.js')> {
+  vi.resetModules();
+  vi.stubEnv('CLAUDE_CONFIG_DIR', configDir);
+  return import('../parsers/claude.js');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+
+describe('claude parser hardening', () => {
+  it('orders sessions by transcript timestamps instead of filesystem mtime', async () => {
+    const configDir = makeConfigDir();
+    const projectDir = path.join(configDir, 'projects', '-tmp-claude-project');
+    const olderId = '11111111-1111-4111-8111-111111111111';
+    const newerId = '22222222-2222-4222-8222-222222222222';
+    const olderPath = path.join(projectDir, `${olderId}.jsonl`);
+    const newerPath = path.join(projectDir, `${newerId}.jsonl`);
+
+    writeJsonl(
+      olderPath,
+      makeRows({
+        id: olderId,
+        first: '2026-04-15T10:00:00.000Z',
+        last: '2026-04-15T10:05:00.000Z',
+        cwd: '/tmp/claude-project',
+      }),
+    );
+    writeJsonl(
+      newerPath,
+      makeRows({
+        id: newerId,
+        first: '2026-04-15T11:00:00.000Z',
+        last: '2026-04-15T11:30:00.000Z',
+        cwd: '/tmp/claude-project',
+      }),
+    );
+
+    fs.utimesSync(olderPath, new Date('2026-04-15T12:00:00.000Z'), new Date('2026-04-15T12:00:00.000Z'));
+    fs.utimesSync(newerPath, new Date('2026-04-15T09:00:00.000Z'), new Date('2026-04-15T09:00:00.000Z'));
+
+    const { parseClaudeSessions } = await loadClaudeParser(configDir);
+    const sessions = await parseClaudeSessions();
+
+    expect(sessions[0].id).toBe(newerId);
+    expect(sessions[0].updatedAt.toISOString()).toBe('2026-04-15T11:30:00.000Z');
+    expect(sessions[1].id).toBe(olderId);
+  });
+});

--- a/src/__tests__/claude-parser.test.ts
+++ b/src/__tests__/claude-parser.test.ts
@@ -63,6 +63,23 @@ afterEach(() => {
 });
 
 describe('claude parser hardening', () => {
+  it('normalizes Windows cwd paths for direct Claude project lookup', async () => {
+    const configDir = makeConfigDir();
+    const id = '33333333-3333-4333-8333-333333333333';
+    const cwd = 'C:\\Users\\me\\my.project';
+    const projectDir = path.join(configDir, 'projects', 'C-Users-me-my-project');
+    writeJsonl(
+      path.join(projectDir, `${id}.jsonl`),
+      makeRows({ id, first: '2026-04-15T10:00:00.000Z', last: '2026-04-15T10:05:00.000Z', cwd }),
+    );
+
+    const { claudeProjectSlugFromCwd, parseClaudeSessions } = await loadClaudeParser(configDir);
+    const sessions = await parseClaudeSessions({ cwd, lightweight: true });
+
+    expect(claudeProjectSlugFromCwd(cwd)).toBe('C-Users-me-my-project');
+    expect(sessions.map((session) => session.id)).toContain(id);
+  });
+
   it('orders sessions by transcript timestamps instead of filesystem mtime', async () => {
     const configDir = makeConfigDir();
     const projectDir = path.join(configDir, 'projects', '-tmp-claude-project');

--- a/src/__tests__/claude-task-reconciliation.test.ts
+++ b/src/__tests__/claude-task-reconciliation.test.ts
@@ -101,7 +101,8 @@ describe('Claude task reconciliation', () => {
             {
               type: 'tool_result',
               tool_use_id: 'tu-taskoutput',
-              content: '<retrieval_status>success</retrieval_status><task_id>a222222</task_id><status>completed</status>',
+              content:
+                '<retrieval_status>success</retrieval_status><task_id>a222222</task_id><status>completed</status>',
             },
           ],
         },
@@ -140,5 +141,92 @@ describe('Claude task reconciliation', () => {
 
     const ctx = await extractClaudeContext(makeSession(filePath), getPreset('standard'));
     expect(ctx.pendingTasks).not.toContain('Incomplete subagent: Create architecture docs');
+  });
+
+  it('keeps the last real user message when assistant tool-only rows dominate the tail', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-claude-tail-'));
+    tempDirs.push(tmp);
+    const filePath = path.join(tmp, 'session.jsonl');
+
+    writeJsonl(filePath, [
+      {
+        type: 'user',
+        timestamp: '2026-03-03T00:00:01.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'Please fix the hidden parser bug' }] },
+      },
+      ...Array.from({ length: 8 }, (_, index) => ({
+        type: 'assistant',
+        timestamp: `2026-03-03T00:00:${String(index + 2).padStart(2, '0')}.000Z`,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: `toolu-${index}`, name: 'Read', input: { file_path: `file-${index}.ts` } }],
+        },
+      })),
+    ]);
+
+    const cfg = { ...getPreset('standard'), recentMessages: 3 };
+    const ctx = await extractClaudeContext(makeSession(filePath), cfg);
+    expect(ctx.recentMessages.map((message) => message.content)).toContain('Please fix the hidden parser bug');
+    expect(ctx.markdown).toContain('Please fix the hidden parser bug');
+  });
+
+  it('extracts current Agent tool results via toolUseResult.agentId sidecars', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-claude-agent-tool-'));
+    tempDirs.push(tmp);
+    const filePath = path.join(tmp, 'session.jsonl');
+    const sessionDir = filePath.replace(/\.jsonl$/, '');
+    const sidecarPath = path.join(sessionDir, 'subagents', 'agent-abc123.jsonl');
+
+    writeJsonl(filePath, [
+      {
+        type: 'assistant',
+        timestamp: '2026-03-03T00:00:01.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu-agent',
+              name: 'Agent',
+              input: { description: 'Investigate parser ordering', subagent_type: 'Explore' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        timestamp: '2026-03-03T00:00:02.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'toolu-agent', content: [{ type: 'text', text: 'done' }] }],
+        },
+        toolUseResult: { status: 'completed', agentId: 'abc123' },
+      },
+    ]);
+
+    writeJsonl(sidecarPath, [
+      {
+        type: 'assistant',
+        timestamp: '2026-03-03T00:00:03.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'The parser should use transcript timestamps and preserve the final user request in handoff context.',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const ctx = await extractClaudeContext(makeSession(filePath), getPreset('standard'));
+
+    expect(ctx.sessionNotes?.subagentResults?.[0]).toMatchObject({
+      taskId: 'abc123',
+      description: 'Investigate parser ordering',
+      status: 'completed',
+    });
+    expect(ctx.sessionNotes?.subagentResults?.[0].result).toContain('transcript timestamps');
   });
 });

--- a/src/__tests__/claude-task-reconciliation.test.ts
+++ b/src/__tests__/claude-task-reconciliation.test.ts
@@ -229,4 +229,58 @@ describe('Claude task reconciliation', () => {
     });
     expect(ctx.sessionNotes?.subagentResults?.[0].result).toContain('transcript timestamps');
   });
+
+  it('does not mark completed Agent sidecars without substantial text as incomplete', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-claude-agent-completed-'));
+    tempDirs.push(tmp);
+    const filePath = path.join(tmp, 'session.jsonl');
+    const sessionDir = filePath.replace(/\.jsonl$/, '');
+    const sidecarPath = path.join(sessionDir, 'subagents', 'agent-completed123.jsonl');
+
+    writeJsonl(filePath, [
+      {
+        type: 'assistant',
+        timestamp: '2026-03-03T00:00:01.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu-agent-completed',
+              name: 'Agent',
+              input: { description: 'Check completed sidecar' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        timestamp: '2026-03-03T00:00:02.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'toolu-agent-completed', content: [{ type: 'text', text: '' }] },
+          ],
+        },
+        toolUseResult: { agentId: 'completed123' },
+      },
+    ]);
+
+    writeJsonl(sidecarPath, [
+      {
+        type: 'assistant',
+        timestamp: '2026-03-03T00:00:03.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] },
+      },
+    ]);
+
+    const ctx = await extractClaudeContext(makeSession(filePath), getPreset('standard'));
+
+    expect(ctx.sessionNotes?.subagentResults?.[0]).toMatchObject({
+      taskId: 'completed123',
+      description: 'Check completed sidecar',
+      status: 'completed',
+    });
+    expect(ctx.pendingTasks).not.toContain('Incomplete subagent: Check completed sidecar');
+  });
 });

--- a/src/__tests__/codex-parser.test.ts
+++ b/src/__tests__/codex-parser.test.ts
@@ -153,4 +153,137 @@ describe('codex parser hardening', () => {
     expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 0, read: 17 });
     expect(context.sessionNotes?.thinkingTokens).toBe(9);
   });
+
+  it('extracts plaintext compacted payload.message as compact summary', async () => {
+    const home = makeCodexHome();
+    const originalPath = writeRollout(
+      home,
+      path.join('sessions', '2026', '04', '15'),
+      'rollout-2026-04-15T10-00-00-compact-session-id.jsonl',
+      [
+        {
+          timestamp: '2026-04-15T10:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'compact-session-id', cwd: '/tmp/project' },
+        },
+        {
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'compacted',
+          payload: {
+            message: 'Keep the parser findings and pending fixes.',
+            replacement_history: [{ content: 'do not include this injected content' }],
+          },
+        },
+      ],
+    );
+
+    const { extractCodexContext } = await loadCodexParser(home);
+    const context = await extractCodexContext({
+      id: 'compact-session-id',
+      source: 'codex',
+      cwd: '/tmp/project',
+      lines: 2,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-04-15T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-15T10:00:01.000Z'),
+      originalPath,
+    });
+
+    expect(context.sessionNotes?.compactSummary).toBe('Keep the parser findings and pending fixes.');
+    expect(context.sessionNotes?.compactSummary).not.toContain('injected');
+  });
+
+  it('tracks namespaced edit_file function calls as edits and modified files', async () => {
+    const home = makeCodexHome();
+    const originalPath = writeRollout(
+      home,
+      path.join('sessions', '2026', '04', '15'),
+      'rollout-2026-04-15T10-00-00-edit-file-session-id.jsonl',
+      [
+        {
+          timestamp: '2026-04-15T10:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'edit-file-session-id', cwd: '/tmp/project' },
+        },
+        {
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'edit_file',
+            namespace: 'mcp__morph__',
+            call_id: 'call-edit',
+            arguments: JSON.stringify({
+              path: 'src/parsers/codex.ts',
+              code_edit: '// ... existing code ...\nconst fixed = true;',
+            }),
+          },
+        },
+        {
+          timestamp: '2026-04-15T10:00:02.000Z',
+          type: 'response_item',
+          payload: { type: 'function_call_output', call_id: 'call-edit', output: 'updated' },
+        },
+      ],
+    );
+
+    const { extractCodexContext } = await loadCodexParser(home);
+    const context = await extractCodexContext({
+      id: 'edit-file-session-id',
+      source: 'codex',
+      cwd: '/tmp/project',
+      lines: 3,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-04-15T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-15T10:00:02.000Z'),
+      originalPath,
+    });
+
+    expect(context.filesModified).toContain('src/parsers/codex.ts');
+    const editSummary = context.toolSummaries.find((summary) => summary.name === 'mcp__morph__edit_file');
+    expect(editSummary?.samples[0].data).toMatchObject({
+      category: 'edit',
+      filePath: 'src/parsers/codex.ts',
+    });
+  });
+
+  it('summarizes write_stdin chars payloads', async () => {
+    const home = makeCodexHome();
+    const originalPath = writeRollout(
+      home,
+      path.join('sessions', '2026', '04', '15'),
+      'rollout-2026-04-15T10-00-00-stdin-session-id.jsonl',
+      [
+        {
+          timestamp: '2026-04-15T10:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'stdin-session-id', cwd: '/tmp/project' },
+        },
+        {
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'write_stdin',
+            arguments: JSON.stringify({ chars: 'y\n' }),
+          },
+        },
+      ],
+    );
+
+    const { extractCodexContext } = await loadCodexParser(home);
+    const context = await extractCodexContext({
+      id: 'stdin-session-id',
+      source: 'codex',
+      cwd: '/tmp/project',
+      lines: 2,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-04-15T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-15T10:00:01.000Z'),
+      originalPath,
+    });
+
+    const stdinSummary = context.toolSummaries.find((summary) => summary.name === 'write_stdin');
+    expect(stdinSummary?.samples[0].summary).toContain('y');
+  });
 });

--- a/src/__tests__/copilot-parser.test.ts
+++ b/src/__tests__/copilot-parser.test.ts
@@ -371,4 +371,125 @@ describe('copilot parser regressions', () => {
       stdoutTail: 'M src/parsers/copilot.ts\n<exited with exit code 0>',
     });
   });
+
+  it('keeps conversation messages when the raw event tail contains only tool execution events', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-home-'));
+    const copilotHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-config-'));
+    tmpDirs.push(fakeHome, copilotHome);
+
+    const toolEvents = Array.from({ length: 12 }, (_, index) => [
+      {
+        type: 'tool.execution_start',
+        id: `evt-tool-start-${index}`,
+        timestamp: `2026-04-15T10:01:${String(index).padStart(2, '0')}.000Z`,
+        parentId: 'evt-003',
+        data: {
+          toolCallId: `tool-${index}`,
+          toolName: 'bash',
+          arguments: { command: `echo ${index}` },
+        },
+      },
+      {
+        type: 'tool.execution_complete',
+        id: `evt-tool-complete-${index}`,
+        timestamp: `2026-04-15T10:02:${String(index).padStart(2, '0')}.000Z`,
+        parentId: `evt-tool-start-${index}`,
+        data: {
+          toolCallId: `tool-${index}`,
+          success: true,
+          result: { content: `done ${index}` },
+        },
+      },
+    ]).flat();
+
+    const sessionDir = createCopilotSession({
+      copilotHome,
+      sessionId: 'tail-tool-events-session',
+      events: [
+        {
+          type: 'session.start',
+          id: 'evt-001',
+          timestamp: '2026-04-15T10:00:00.000Z',
+          parentId: null,
+          data: { sessionId: 'tail-tool-events-session', selectedModel: 'claude-sonnet-4' },
+        },
+        {
+          type: 'user.message',
+          id: 'evt-002',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          parentId: 'evt-001',
+          data: { content: 'Keep this user turn' },
+        },
+        {
+          type: 'assistant.message',
+          id: 'evt-003',
+          timestamp: '2026-04-15T10:00:02.000Z',
+          parentId: 'evt-002',
+          data: { content: 'I will run follow-up commands.' },
+        },
+        ...toolEvents,
+      ],
+    });
+
+    const { extractCopilotContext } = await loadCopilotParserWithHome(fakeHome);
+    const context = await extractCopilotContext(makeSession(sessionDir, 'tail-tool-events-session'));
+
+    expect(context.recentMessages.map((message) => message.content)).toContain('Keep this user turn');
+    expect(context.recentMessages.map((message) => message.content)).toContain('I will run follow-up commands.');
+  });
+
+  it('classifies lowercase create tool executions as writes', async () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-home-'));
+    const copilotHome = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-config-'));
+    tmpDirs.push(fakeHome, copilotHome);
+
+    const sessionDir = createCopilotSession({
+      copilotHome,
+      sessionId: 'lowercase-create-session',
+      events: [
+        {
+          type: 'session.start',
+          id: 'evt-001',
+          timestamp: '2026-04-15T10:00:00.000Z',
+          parentId: null,
+          data: { sessionId: 'lowercase-create-session', selectedModel: 'claude-sonnet-4' },
+        },
+        {
+          type: 'tool.execution_start',
+          id: 'evt-002',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          parentId: 'evt-001',
+          data: {
+            toolCallId: 'tool-create',
+            toolName: 'create',
+            arguments: {
+              path: 'src/new-file.ts',
+              file_text: 'export const value = 1;',
+            },
+          },
+        },
+        {
+          type: 'tool.execution_complete',
+          id: 'evt-003',
+          timestamp: '2026-04-15T10:00:02.000Z',
+          parentId: 'evt-002',
+          data: {
+            toolCallId: 'tool-create',
+            success: true,
+            result: { content: 'created' },
+          },
+        },
+      ],
+    });
+
+    const { extractCopilotContext } = await loadCopilotParserWithHome(fakeHome);
+    const context = await extractCopilotContext(makeSession(sessionDir, 'lowercase-create-session'));
+    const createSummary = context.toolSummaries.find((summary) => summary.name === 'create');
+
+    expect(context.filesModified).toContain('src/new-file.ts');
+    expect(createSummary?.samples[0].data).toMatchObject({
+      category: 'write',
+      filePath: 'src/new-file.ts',
+    });
+  });
 });

--- a/src/__tests__/droid-parser.test.ts
+++ b/src/__tests__/droid-parser.test.ts
@@ -1,0 +1,112 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const tmpDirs: string[] = [];
+
+function makeHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'droid-parser-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function writeJsonl(filePath: string, rows: unknown[]): string {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+  return filePath;
+}
+
+function makeRows(opts: { id: string; cwd?: string; first?: string; last?: string; fillerCount?: number }): unknown[] {
+  const fillerCount = opts.fillerCount ?? 0;
+  return [
+    {
+      type: 'session_start',
+      id: opts.id,
+      title: 'Droid parser regression',
+      sessionTitle: 'Droid parser regression',
+      cwd: opts.cwd ?? '/tmp/droid-project',
+    },
+    {
+      type: 'message',
+      id: `${opts.id}-first`,
+      timestamp: opts.first ?? '2026-04-15T10:00:00.000Z',
+      message: { role: 'user', content: [{ type: 'text', text: 'Patch Droid parser' }] },
+    },
+    ...Array.from({ length: fillerCount }, (_, index) => ({
+      type: 'message',
+      id: `${opts.id}-filler-${index}`,
+      timestamp: `2026-04-15T10:01:${String(index % 60).padStart(2, '0')}.000Z`,
+      message: { role: 'assistant', content: [{ type: 'text', text: `filler ${index}` }] },
+    })),
+    {
+      type: 'message',
+      id: `${opts.id}-last`,
+      timestamp: opts.last ?? '2026-04-15T10:05:00.000Z',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
+    },
+  ];
+}
+
+async function loadDroidParser(home: string): Promise<typeof import('../parsers/droid.js')> {
+  vi.resetModules();
+  vi.stubEnv('HOME', home);
+  return import('../parsers/droid.js');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+
+describe('droid parser hardening', () => {
+  it('discovers sessions from .factory/projects', async () => {
+    const home = makeHome();
+    const id = '11111111-1111-4111-8111-111111111111';
+    writeJsonl(path.join(home, '.factory', 'projects', 'tmp-droid-project', `${id}.jsonl`), makeRows({ id }));
+
+    const { parseDroidSessions } = await loadDroidParser(home);
+    const sessions = await parseDroidSessions();
+
+    expect(sessions.map((session) => session.id)).toContain(id);
+    expect(sessions[0].originalPath).toContain(path.join('.factory', 'projects'));
+  });
+
+  it('dedupes the same session id across projects and sessions, preferring projects on timestamp ties', async () => {
+    const home = makeHome();
+    const id = '22222222-2222-4222-8222-222222222222';
+    const rows = makeRows({ id, last: '2026-04-15T10:05:00.000Z' });
+    writeJsonl(path.join(home, '.factory', 'projects', 'tmp-droid-project', `${id}.jsonl`), rows);
+    writeJsonl(path.join(home, '.factory', 'sessions', 'tmp-droid-project', `${id}.jsonl`), rows);
+
+    const { parseDroidSessions } = await loadDroidParser(home);
+    const sessions = await parseDroidSessions();
+
+    expect(sessions.filter((session) => session.id === id)).toHaveLength(1);
+    expect(sessions[0].originalPath).toContain(path.join('.factory', 'projects'));
+  });
+
+  it('uses full transcript timestamps beyond the first 100 lines', async () => {
+    const home = makeHome();
+    const olderId = '33333333-3333-4333-8333-333333333333';
+    const newerId = '44444444-4444-4444-8444-444444444444';
+    writeJsonl(
+      path.join(home, '.factory', 'projects', 'tmp-droid-project', `${olderId}.jsonl`),
+      makeRows({ id: olderId, last: '2026-04-15T10:05:00.000Z' }),
+    );
+    writeJsonl(
+      path.join(home, '.factory', 'projects', 'tmp-droid-project', `${newerId}.jsonl`),
+      makeRows({ id: newerId, fillerCount: 120, last: '2026-04-15T11:30:00.000Z' }),
+    );
+
+    const { parseDroidSessions } = await loadDroidParser(home);
+    const sessions = await parseDroidSessions();
+
+    expect(sessions[0].id).toBe(newerId);
+    expect(sessions[0].updatedAt.toISOString()).toBe('2026-04-15T11:30:00.000Z');
+  });
+});

--- a/src/__tests__/droid-parser.test.ts
+++ b/src/__tests__/droid-parser.test.ts
@@ -109,4 +109,19 @@ describe('droid parser hardening', () => {
     expect(sessions[0].id).toBe(newerId);
     expect(sessions[0].updatedAt.toISOString()).toBe('2026-04-15T11:30:00.000Z');
   });
+
+  it('keeps lightweight discovery bounded and preserves sessions with zero line counts', async () => {
+    const home = makeHome();
+    const id = '55555555-5555-4555-8555-555555555555';
+    writeJsonl(
+      path.join(home, '.factory', 'projects', 'tmp-droid-project', `${id}.jsonl`),
+      makeRows({ id, fillerCount: 120, last: '2026-04-15T11:30:00.000Z' }),
+    );
+
+    const { parseDroidSessions } = await loadDroidParser(home);
+    const sessions = await parseDroidSessions({ lightweight: true });
+
+    expect(sessions.map((session) => session.id)).toContain(id);
+    expect(sessions.find((session) => session.id === id)?.lines).toBe(0);
+  });
 });

--- a/src/__tests__/e2e-conversions.test.ts
+++ b/src/__tests__/e2e-conversions.test.ts
@@ -13,46 +13,63 @@
 
 import { execSync } from 'child_process';
 import * as fs from 'fs';
-import { WHICH_CMD } from '../utils/platform.js';
 import * as path from 'path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
+  extractAmpContext,
+  extractAntigravityContext,
   extractClaudeContext,
+  extractClineContext,
   extractCodexContext,
   extractCopilotContext,
+  extractCrushContext,
   extractCursorContext,
   extractDroidContext,
   extractGeminiContext,
-  extractOpenCodeContext,
-  extractAmpContext,
-  extractKiroContext,
-  extractCrushContext,
-  extractClineContext,
-  extractRooCodeContext,
   extractKiloCodeContext,
-  extractAntigravityContext,
   extractKimiContext,
+  extractKiroContext,
+  extractOpenCodeContext,
   extractQwenCodeContext,
+  extractRooCodeContext,
+  parseAmpSessions,
+  parseAntigravitySessions,
   parseClaudeSessions,
+  parseClineSessions,
   parseCodexSessions,
   parseCopilotSessions,
+  parseCrushSessions,
   parseCursorSessions,
   parseDroidSessions,
   parseGeminiSessions,
-  parseOpenCodeSessions,
-  parseAmpSessions,
-  parseKiroSessions,
-  parseCrushSessions,
-  parseClineSessions,
-  parseRooCodeSessions,
   parseKiloCodeSessions,
-  parseAntigravitySessions,
   parseKimiSessions,
+  parseKiroSessions,
+  parseOpenCodeSessions,
   parseQwenCodeSessions,
+  parseRooCodeSessions,
 } from '../parsers/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
+import { WHICH_CMD } from '../utils/platform.js';
 
-const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor', 'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi', 'qwen-code'];
+const ALL_SOURCES: SessionSource[] = [
+  'claude',
+  'copilot',
+  'gemini',
+  'codex',
+  'opencode',
+  'droid',
+  'cursor',
+  'amp',
+  'kiro',
+  'crush',
+  'cline',
+  'roo-code',
+  'kilo-code',
+  'antigravity',
+  'kimi',
+  'qwen-code',
+];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   claude: parseClaudeSessions,

--- a/src/__tests__/env-cache-invalidation.test.ts
+++ b/src/__tests__/env-cache-invalidation.test.ts
@@ -14,7 +14,7 @@ import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 // Create the fake home eagerly so it's ready before any mock evaluates
 const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-env-test-'));
@@ -64,9 +64,27 @@ function makeSession(id: string, source = 'claude'): Record<string, unknown> {
   };
 }
 
+function currentFingerprint(): string {
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const adapter of Object.values(adapters) as Array<{ envVar?: string }>) {
+    if (adapter.envVar && !seen.has(adapter.envVar)) {
+      seen.add(adapter.envVar);
+      const val = process.env[adapter.envVar] || '';
+      parts.push(`${adapter.envVar}=${val}`);
+    }
+  }
+  const hash = createHash('sha256').update(parts.sort().join('|')).digest('hex');
+  return `#env:${hash}`;
+}
+
 afterEach(() => {
   // Clean the index file between tests
-  try { fs.unlinkSync(indexFilePath()); } catch (_) { /* file may not exist */ }
+  try {
+    fs.unlinkSync(indexFilePath());
+  } catch (_) {
+    /* file may not exist */
+  }
   vi.unstubAllEnvs();
 });
 
@@ -81,37 +99,14 @@ describe('env fingerprint cache invalidation (issue #18)', () => {
     // Compute what the real module would write — import adapters to derive env vars
     // The simplest way: write an index via the fingerprint the module itself expects.
     // We write a fingerprint that matches the current env (all env vars unset in test).
-    const seen = new Set<string>();
-    const parts: string[] = [];
-    for (const adapter of Object.values(adapters) as Array<{ envVar?: string }>) {
-      if (adapter.envVar && !seen.has(adapter.envVar)) {
-        seen.add(adapter.envVar);
-        const val = process.env[adapter.envVar] || '';
-        parts.push(`${adapter.envVar}=${val}`);
-      }
-    }
-    const hash = createHash('sha256').update(parts.sort().join('|')).digest('hex');
-    const fingerprint = `#env:${hash}`;
-
-    writeIndex(fingerprint, [makeSession('sess-1')]);
+    writeIndex(currentFingerprint(), [makeSession('sess-1')]);
 
     expect(indexNeedsRebuild()).toBe(false);
   });
 
   it('indexNeedsRebuild returns true when CLAUDE_CONFIG_DIR changes', () => {
     // Write index with current fingerprint (CLAUDE_CONFIG_DIR unset)
-    const seen = new Set<string>();
-    const parts: string[] = [];
-    for (const adapter of Object.values(adapters) as Array<{ envVar?: string }>) {
-      if (adapter.envVar && !seen.has(adapter.envVar)) {
-        seen.add(adapter.envVar);
-        const val = process.env[adapter.envVar] || '';
-        parts.push(`${adapter.envVar}=${val}`);
-      }
-    }
-    const hash = createHash('sha256').update(parts.sort().join('|')).digest('hex');
-    const fingerprint = `#env:${hash}`;
-    writeIndex(fingerprint, [makeSession('sess-1')]);
+    writeIndex(currentFingerprint(), [makeSession('sess-1')]);
 
     // Now change the env var — fingerprint should mismatch
     vi.stubEnv('CLAUDE_CONFIG_DIR', '/home/user/.claude-work');
@@ -119,11 +114,16 @@ describe('env fingerprint cache invalidation (issue #18)', () => {
     expect(indexNeedsRebuild()).toBe(true);
   });
 
+  it('indexNeedsRebuild returns true when COPILOT_HOME changes', () => {
+    writeIndex(currentFingerprint(), [makeSession('sess-1', 'copilot')]);
+
+    vi.stubEnv('COPILOT_HOME', '/home/user/.copilot-work');
+
+    expect(indexNeedsRebuild()).toBe(true);
+  });
+
   it('loadIndex skips the fingerprint line and returns only sessions', () => {
-    writeIndex('#env:CLAUDE_CONFIG_DIR=', [
-      makeSession('sess-1', 'claude'),
-      makeSession('sess-2', 'codex'),
-    ]);
+    writeIndex('#env:CLAUDE_CONFIG_DIR=', [makeSession('sess-1', 'claude'), makeSession('sess-2', 'codex')]);
 
     const sessions = loadIndex();
 
@@ -138,7 +138,6 @@ describe('env fingerprint cache invalidation (issue #18)', () => {
   });
 
   it('fingerprint line is not parseable as JSON', () => {
-    const hash = createHash('sha256').update('test').digest('hex');
-    expect(() => JSON.parse(`#env:\${hash}`)).toThrow();
+    expect(() => JSON.parse('#env:test')).toThrow();
   });
 });

--- a/src/__tests__/extract-handoffs.ts
+++ b/src/__tests__/extract-handoffs.ts
@@ -6,45 +6,62 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import {
+  extractAmpContext,
+  extractAntigravityContext,
   extractClaudeContext,
+  extractClineContext,
   extractCodexContext,
   extractCopilotContext,
+  extractCrushContext,
   extractCursorContext,
   extractDroidContext,
   extractGeminiContext,
-  extractOpenCodeContext,
-  extractAmpContext,
-  extractKiroContext,
-  extractCrushContext,
-  extractClineContext,
-  extractRooCodeContext,
   extractKiloCodeContext,
-  extractAntigravityContext,
   extractKimiContext,
+  extractKiroContext,
+  extractOpenCodeContext,
   extractQwenCodeContext,
+  extractRooCodeContext,
+  parseAmpSessions,
+  parseAntigravitySessions,
   parseClaudeSessions,
+  parseClineSessions,
   parseCodexSessions,
   parseCopilotSessions,
+  parseCrushSessions,
   parseCursorSessions,
   parseDroidSessions,
   parseGeminiSessions,
-  parseOpenCodeSessions,
-  parseAmpSessions,
-  parseKiroSessions,
-  parseCrushSessions,
-  parseClineSessions,
-  parseRooCodeSessions,
   parseKiloCodeSessions,
-  parseAntigravitySessions,
   parseKimiSessions,
+  parseKiroSessions,
+  parseOpenCodeSessions,
   parseQwenCodeSessions,
+  parseRooCodeSessions,
 } from '../parsers/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 
 const RESULTS_DIR = path.join(process.env.HOME || '~', '.continues', 'e2e-test-results');
 fs.mkdirSync(RESULTS_DIR, { recursive: true });
 
-const ALL_SOURCES: SessionSource[] = ['claude', 'copilot', 'gemini', 'codex', 'opencode', 'droid', 'cursor', 'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi', 'qwen-code'];
+const ALL_SOURCES: SessionSource[] = [
+  'claude',
+  'copilot',
+  'gemini',
+  'codex',
+  'opencode',
+  'droid',
+  'cursor',
+  'amp',
+  'kiro',
+  'crush',
+  'cline',
+  'roo-code',
+  'kilo-code',
+  'antigravity',
+  'kimi',
+  'qwen-code',
+];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   claude: parseClaudeSessions,

--- a/src/__tests__/forward-flags.test.ts
+++ b/src/__tests__/forward-flags.test.ts
@@ -264,4 +264,47 @@ describe('cross-tool forwarding', () => {
     expect(command).not.toContain('--yolo');
     expect(command).not.toContain('--approval-mode yolo');
   });
+
+  it('uses current native resume commands for codex and droid', () => {
+    const codexSession: UnifiedSession = {
+      id: 'codex-session-id',
+      source: 'codex',
+      cwd: '/tmp/project',
+      lines: 10,
+      bytes: 120,
+      createdAt: new Date('2026-02-20T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-20T00:00:00.000Z'),
+      originalPath: '/tmp/codex.jsonl',
+    };
+    const droidSession: UnifiedSession = {
+      ...codexSession,
+      id: 'droid-session-id',
+      source: 'droid',
+      originalPath: '/tmp/droid.jsonl',
+    };
+
+    expect(adapters.codex.nativeResumeArgs(codexSession)).toEqual(['resume', 'codex-session-id']);
+    expect(adapters.codex.resumeCommandDisplay(codexSession)).toBe('codex resume codex-session-id');
+    expect(getResumeCommand(codexSession)).toBe('codex resume codex-session-id');
+
+    expect(adapters.droid.nativeResumeArgs(droidSession)).toEqual(['--resume', 'droid-session-id']);
+    expect(adapters.droid.resumeCommandDisplay(droidSession)).toBe('droid --resume droid-session-id');
+    expect(getResumeCommand(droidSession)).toBe('droid --resume droid-session-id');
+  });
+
+  it('rejects invalid runtime targets before formatting forwarding commands', () => {
+    const session: UnifiedSession = {
+      id: 'abc123456789',
+      source: 'claude',
+      cwd: '/tmp/project',
+      lines: 10,
+      bytes: 120,
+      createdAt: new Date('2026-02-20T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-20T00:00:00.000Z'),
+      originalPath: '/tmp/session.jsonl',
+    };
+
+    expect(() => resolveCrossToolForwarding('not-a-tool' as never)).toThrow('Unknown target: not-a-tool');
+    expect(() => getResumeCommand(session, 'not-a-tool' as never)).toThrow('Unknown target: not-a-tool');
+  });
 });

--- a/src/__tests__/forward-flags.test.ts
+++ b/src/__tests__/forward-flags.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { UnknownSourceError } from '../errors.js';
 import { adapters } from '../parsers/registry.js';
 import type { UnifiedSession } from '../types/index.js';
 import { getDefaultHandoffInitArgs, getResumeCommand, resolveCrossToolForwarding } from '../utils/resume.js';
@@ -320,7 +321,9 @@ describe('cross-tool forwarding', () => {
       originalPath: '/tmp/session.jsonl',
     };
 
-    expect(() => resolveCrossToolForwarding('not-a-tool' as never)).toThrow('Unknown target: not-a-tool');
-    expect(() => getResumeCommand(session, 'not-a-tool' as never)).toThrow('Unknown target: not-a-tool');
+    expect(() => resolveCrossToolForwarding('not-a-tool' as never)).toThrow(UnknownSourceError);
+    expect(() => resolveCrossToolForwarding('not-a-tool' as never)).toThrow('Unknown source: "not-a-tool"');
+    expect(() => getResumeCommand(session, 'not-a-tool' as never)).toThrow(UnknownSourceError);
+    expect(() => getResumeCommand(session, 'not-a-tool' as never)).toThrow('Unknown source: "not-a-tool"');
   });
 });

--- a/src/__tests__/index-source-cache.test.ts
+++ b/src/__tests__/index-source-cache.test.ts
@@ -1,0 +1,90 @@
+import * as fs from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionSource, UnifiedSession } from '../types/index.js';
+
+const testState = vi.hoisted(() => ({
+  fakeHome: `/tmp/continues-index-source-test-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  parseClaude: vi.fn(),
+  parseCodex: vi.fn(),
+}));
+
+vi.mock('../utils/parser-helpers.js', () => ({
+  homeDir: () => testState.fakeHome,
+}));
+
+vi.mock('../parsers/registry.js', () => ({
+  adapters: {
+    claude: {
+      name: 'claude',
+      envVar: 'CLAUDE_CONFIG_DIR',
+      parseSessions: testState.parseClaude,
+      supportsCwdLookup: true,
+    },
+    codex: {
+      name: 'codex',
+      envVar: 'CODEX_HOME',
+      parseSessions: testState.parseCodex,
+    },
+  },
+}));
+
+const { getSessionsByCwd, getSessionsBySource } = await import('../utils/index.js');
+
+function makeSession(id: string, source: SessionSource, cwd = '/tmp/project'): UnifiedSession {
+  return {
+    id,
+    source,
+    cwd,
+    lines: 0,
+    bytes: 100,
+    createdAt: new Date('2026-04-15T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-15T00:00:00.000Z'),
+    originalPath: `/tmp/${id}.jsonl`,
+    summary: `${source} session`,
+  };
+}
+
+describe('source-scoped session index', () => {
+  beforeEach(() => {
+    fs.rmSync(testState.fakeHome, { recursive: true, force: true });
+    testState.parseClaude.mockReset();
+    testState.parseCodex.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(testState.fakeHome, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it('source lookups rebuild only the requested source when no cache exists', async () => {
+    testState.parseClaude.mockResolvedValue([makeSession('claude-1', 'claude')]);
+    testState.parseCodex.mockResolvedValue([makeSession('codex-1', 'codex')]);
+
+    const sessions = await getSessionsBySource('claude');
+
+    expect(sessions.map((session) => session.id)).toEqual(['claude-1']);
+    expect(testState.parseClaude).toHaveBeenCalledWith({ lightweight: true });
+    expect(testState.parseCodex).not.toHaveBeenCalled();
+  });
+
+  it('source lookups reuse the source cache on repeated calls', async () => {
+    testState.parseClaude.mockResolvedValue([makeSession('claude-1', 'claude')]);
+
+    await getSessionsBySource('claude');
+    const sessions = await getSessionsBySource('claude');
+
+    expect(sessions.map((session) => session.id)).toEqual(['claude-1']);
+    expect(testState.parseClaude).toHaveBeenCalledTimes(1);
+  });
+
+  it('cwd lookups call only adapters that support direct cwd lookup', async () => {
+    testState.parseClaude.mockResolvedValue([makeSession('claude-1', 'claude', '/tmp/project/subdir')]);
+    testState.parseCodex.mockResolvedValue([makeSession('codex-1', 'codex', '/tmp/project')]);
+
+    const sessions = await getSessionsByCwd('/tmp/project');
+
+    expect(sessions.map((session) => session.id)).toEqual(['claude-1']);
+    expect(testState.parseClaude).toHaveBeenCalledWith({ cwd: '/tmp/project', lightweight: true });
+    expect(testState.parseCodex).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/index-source-cache.test.ts
+++ b/src/__tests__/index-source-cache.test.ts
@@ -13,6 +13,7 @@ vi.mock('../utils/parser-helpers.js', () => ({
 }));
 
 vi.mock('../parsers/registry.js', () => ({
+  ALL_TOOLS: ['claude', 'codex'],
   adapters: {
     claude: {
       name: 'claude',
@@ -28,7 +29,7 @@ vi.mock('../parsers/registry.js', () => ({
   },
 }));
 
-const { getSessionsByCwd, getSessionsBySource } = await import('../utils/index.js');
+const { getAllSessions, getSessionsByCwd, getSessionsBySource } = await import('../utils/index.js');
 
 function makeSession(id: string, source: SessionSource, cwd = '/tmp/project'): UnifiedSession {
   return {
@@ -77,14 +78,29 @@ describe('source-scoped session index', () => {
     expect(testState.parseClaude).toHaveBeenCalledTimes(1);
   });
 
-  it('cwd lookups call only adapters that support direct cwd lookup', async () => {
+  it('full rebuild clears stale per-source caches for tools with zero sessions', async () => {
+    testState.parseCodex.mockResolvedValue([makeSession('codex-old', 'codex')]);
+    await getSessionsBySource('codex');
+
+    testState.parseClaude.mockResolvedValue([makeSession('claude-1', 'claude')]);
+    testState.parseCodex.mockResolvedValue([]);
+    await getAllSessions(true);
+
+    testState.parseCodex.mockClear();
+    const sessions = await getSessionsBySource('codex');
+
+    expect(sessions).toEqual([]);
+    expect(testState.parseCodex).not.toHaveBeenCalled();
+  });
+
+  it('stale cwd lookups rebuild the full index and include adapters without direct cwd lookup', async () => {
     testState.parseClaude.mockResolvedValue([makeSession('claude-1', 'claude', '/tmp/project/subdir')]);
     testState.parseCodex.mockResolvedValue([makeSession('codex-1', 'codex', '/tmp/project')]);
 
     const sessions = await getSessionsByCwd('/tmp/project');
 
-    expect(sessions.map((session) => session.id)).toEqual(['claude-1']);
-    expect(testState.parseClaude).toHaveBeenCalledWith({ cwd: '/tmp/project', lightweight: true });
-    expect(testState.parseCodex).not.toHaveBeenCalled();
+    expect(sessions.map((session) => session.id)).toEqual(['claude-1', 'codex-1']);
+    expect(testState.parseClaude).toHaveBeenCalledWith();
+    expect(testState.parseCodex).toHaveBeenCalledWith();
   });
 });

--- a/src/__tests__/pick.test.ts
+++ b/src/__tests__/pick.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionSource, UnifiedSession } from '../types/index.js';
+
+const testState = vi.hoisted(() => ({
+  checkSingleToolAutoResume: vi.fn(),
+  getAllSessions: vi.fn(),
+  getSessionsByCwd: vi.fn(),
+  getSessionsBySource: vi.fn(),
+  nativeResume: vi.fn(),
+  resume: vi.fn(),
+  select: vi.fn(),
+  selectTargetTool: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  cancel: vi.fn(),
+  intro: vi.fn(),
+  isCancel: vi.fn(() => false),
+  log: {
+    error: vi.fn(),
+    info: vi.fn(),
+    step: vi.fn(),
+  },
+  outro: vi.fn(),
+  select: testState.select,
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('../display/banner.js', () => ({
+  showBanner: vi.fn(async () => false),
+}));
+
+vi.mock('../display/star-prompt.js', () => ({
+  maybePromptGithubStar: vi.fn(async () => undefined),
+}));
+
+vi.mock('../utils/index.js', () => ({
+  getAllSessions: testState.getAllSessions,
+  getSessionsByCwd: testState.getSessionsByCwd,
+  getSessionsBySource: testState.getSessionsBySource,
+}));
+
+vi.mock('../utils/resume.js', () => ({
+  getResumeCommand: vi.fn(() => 'continues resume selected'),
+  nativeResume: testState.nativeResume,
+  resolveCrossToolForwarding: vi.fn(() => ({ warnings: [] })),
+  resume: testState.resume,
+}));
+
+vi.mock('../commands/_shared.js', () => ({
+  checkSingleToolAutoResume: testState.checkSingleToolAutoResume,
+  selectTargetTool: testState.selectTargetTool,
+  showForwardingWarnings: vi.fn(async () => undefined),
+}));
+
+const { interactivePick } = await import('../commands/pick.js');
+
+function makeSession(id: string, source: SessionSource, cwd = process.cwd()): UnifiedSession {
+  const now = new Date('2026-04-15T00:00:00.000Z');
+  return {
+    id,
+    source,
+    cwd,
+    lines: 1,
+    bytes: 100,
+    createdAt: now,
+    updatedAt: now,
+    originalPath: `/tmp/${id}.jsonl`,
+  };
+}
+
+describe('interactivePick cwd fallback', () => {
+  beforeEach(() => {
+    process.exitCode = undefined;
+    testState.checkSingleToolAutoResume.mockReset();
+    testState.getAllSessions.mockReset();
+    testState.getSessionsByCwd.mockReset();
+    testState.getSessionsBySource.mockReset();
+    testState.nativeResume.mockReset();
+    testState.resume.mockReset();
+    testState.select.mockReset();
+    testState.selectTargetTool.mockReset();
+  });
+
+  it('auto-resumes a single cwd session found after full fallback loading', async () => {
+    const session = makeSession('only-cwd-session', 'codex');
+    testState.getSessionsByCwd.mockResolvedValue([]);
+    testState.getAllSessions.mockResolvedValue([session]);
+    testState.checkSingleToolAutoResume.mockResolvedValue(true);
+
+    await interactivePick({}, { isTTY: true, supportsColor: false, version: '0.0.0-test' });
+
+    expect(testState.getAllSessions).toHaveBeenCalledTimes(1);
+    expect(testState.checkSingleToolAutoResume).toHaveBeenCalledWith(session, testState.nativeResume);
+    expect(testState.select).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/resume-command-debug.test.ts
+++ b/src/__tests__/resume-command-debug.test.ts
@@ -59,6 +59,9 @@ describe('resumeCommand debug prompt option', () => {
   const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {
     // Silence command output during tests.
   });
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+    // Silence error output during tests.
+  });
 
   afterEach(() => {
     findSessionMock.mockReset();
@@ -67,6 +70,8 @@ describe('resumeCommand debug prompt option', () => {
     getResumeCommandMock.mockClear();
     resolveCrossToolForwardingMock.mockClear();
     logSpy.mockClear();
+    errorSpy.mockClear();
+    chdirSpy.mockClear();
     process.exitCode = undefined;
   });
 
@@ -84,5 +89,20 @@ describe('resumeCommand debug prompt option', () => {
     expect(output).not.toContain('Session:');
     expect(output).not.toContain('Command:');
     expect(chdirSpy).toHaveBeenCalledWith('/tmp/project');
+  });
+
+  it('rejects invalid --in targets before resolving forwarding or resuming', async () => {
+    findSessionMock.mockResolvedValue(makeSession());
+
+    await resumeCommand('resume-debug-test', { in: 'not-a-tool', noTui: true } as never, {
+      isTTY: false,
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(resolveCrossToolForwardingMock).not.toHaveBeenCalled();
+    expect(getResumeCommandMock).not.toHaveBeenCalled();
+    expect(resumeMock).not.toHaveBeenCalled();
+    expect(chdirSpy).not.toHaveBeenCalledWith('/tmp/project');
+    expect(errorSpy.mock.calls.map((call) => call.join(' ')).join('\n')).toContain('Unknown target tool: not-a-tool');
   });
 });

--- a/src/__tests__/resume-debug-prompt.test.ts
+++ b/src/__tests__/resume-debug-prompt.test.ts
@@ -93,4 +93,15 @@ describe('crossToolResume debug prompt mode', () => {
     expect(output).toContain('Read `.continues-handoff.md` first, then continue the work.');
     expect(spawnMock).not.toHaveBeenCalled();
   });
+
+  it('rejects invalid runtime targets before extracting context or writing handoff files', async () => {
+    const session = makeSession(cwd);
+
+    await expect(crossToolResume(session, 'not-a-tool' as never)).rejects.toThrow('Unknown target: not-a-tool');
+
+    expect(extractContextMock).not.toHaveBeenCalled();
+    expect(saveContextMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(cwd, '.continues-handoff.md'))).toBe(false);
+  });
 });

--- a/src/__tests__/resume-debug-prompt.test.ts
+++ b/src/__tests__/resume-debug-prompt.test.ts
@@ -97,7 +97,7 @@ describe('crossToolResume debug prompt mode', () => {
   it('rejects invalid runtime targets before extracting context or writing handoff files', async () => {
     const session = makeSession(cwd);
 
-    await expect(crossToolResume(session, 'not-a-tool' as never)).rejects.toThrow('Unknown target: not-a-tool');
+    await expect(crossToolResume(session, 'not-a-tool' as never)).rejects.toThrow('Unknown source: "not-a-tool"');
 
     expect(extractContextMock).not.toHaveBeenCalled();
     expect(saveContextMock).not.toHaveBeenCalled();

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../types/content-blocks.js';
 import {
   ClaudeMessageSchema,
+  CodexCompactedSchema,
   CodexEventMsgSchema,
   CodexMessageSchema,
   CodexResponseItemSchema,
@@ -47,8 +48,22 @@ describe('TOOL_NAMES', () => {
 
   it('includes all known tools', () => {
     const expected: SessionSource[] = [
-      'claude', 'codex', 'copilot', 'gemini', 'opencode', 'droid', 'cursor',
-      'amp', 'kiro', 'crush', 'cline', 'roo-code', 'kilo-code', 'antigravity', 'kimi', 'qwen-code',
+      'claude',
+      'codex',
+      'copilot',
+      'gemini',
+      'opencode',
+      'droid',
+      'cursor',
+      'amp',
+      'kiro',
+      'crush',
+      'cline',
+      'roo-code',
+      'kilo-code',
+      'antigravity',
+      'kimi',
+      'qwen-code',
     ];
     expect([...TOOL_NAMES]).toEqual(expected);
   });
@@ -69,14 +84,17 @@ describe('Canonical tool name sets', () => {
     expect(READ_TOOLS.has('read_file')).toBe(true);
   });
 
-  it('WRITE_TOOLS contains Write and create_file', () => {
+  it('WRITE_TOOLS contains Write and create aliases', () => {
     expect(WRITE_TOOLS.has('Write')).toBe(true);
+    expect(WRITE_TOOLS.has('create')).toBe(true);
     expect(WRITE_TOOLS.has('create_file')).toBe(true);
   });
 
-  it('EDIT_TOOLS contains Edit and apply_diff', () => {
+  it('EDIT_TOOLS contains Edit, apply_diff, and Morph edit aliases', () => {
     expect(EDIT_TOOLS.has('Edit')).toBe(true);
     expect(EDIT_TOOLS.has('apply_diff')).toBe(true);
+    expect(EDIT_TOOLS.has('mcp__morph__edit_file')).toBe(true);
+    expect(EDIT_TOOLS.has('morph___edit_file')).toBe(true);
   });
 });
 
@@ -305,6 +323,15 @@ describe('CodexMessageSchema (discriminated union)', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts compacted', () => {
+    const result = CodexCompactedSchema.safeParse({
+      timestamp: '2025-01-01T00:00:00Z',
+      type: 'compacted',
+      payload: { message: 'Compacted session summary' },
+    });
+    expect(result.success).toBe(true);
+  });
+
   it('discriminates correctly in union', () => {
     const meta = {
       timestamp: '2025-01-01T00:00:00Z',
@@ -314,6 +341,16 @@ describe('CodexMessageSchema (discriminated union)', () => {
     const result = CodexMessageSchema.safeParse(meta);
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.type).toBe('session_meta');
+  });
+
+  it('discriminates compacted in union', () => {
+    const result = CodexMessageSchema.safeParse({
+      timestamp: '2025-01-01T00:00:00Z',
+      type: 'compacted',
+      payload: { message: 'Compacted session summary' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.type).toBe('compacted');
   });
 
   it('rejects unknown type in union', () => {

--- a/src/__tests__/shared-utils.test.ts
+++ b/src/__tests__/shared-utils.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../utils/content.js';
 import { countDiffStats, extractStdoutTail, formatEditDiff, formatNewFileDiff } from '../utils/diff.js';
 import { findFiles, listSubdirectories } from '../utils/fs-helpers.js';
-import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
+import { getFileStats, readJsonlFile, scanJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { extractRepo, trimMessages } from '../utils/parser-helpers.js';
 import {
   type AnthropicMessage,
@@ -154,6 +154,40 @@ describe('scanJsonlHead', () => {
     );
 
     expect(visited).toEqual([0]);
+  });
+});
+
+describe('scanJsonlFile', () => {
+  it('streams every valid JSONL line', async () => {
+    const dir = makeTmpDir();
+    const file = path.join(dir, 'test.jsonl');
+    const lines = Array.from({ length: 120 }, (_, i) => JSON.stringify({ i }));
+    fs.writeFileSync(file, `${lines.join('\n')}\n`);
+
+    const visited: number[] = [];
+    await scanJsonlFile(file, (parsed) => {
+      visited.push((parsed as { i: number }).i);
+      return 'continue';
+    });
+
+    expect(visited.at(0)).toBe(0);
+    expect(visited.at(-1)).toBe(119);
+    expect(visited).toHaveLength(120);
+  });
+
+  it('supports early stop via visitor', async () => {
+    const dir = makeTmpDir();
+    const file = path.join(dir, 'test.jsonl');
+    fs.writeFileSync(file, '{"type":"a"}\n{"type":"b"}\n{"type":"c"}\n');
+
+    const visited: string[] = [];
+    await scanJsonlFile(file, (parsed) => {
+      const p = parsed as { type: string };
+      visited.push(p.type);
+      return p.type === 'b' ? 'stop' : 'continue';
+    });
+
+    expect(visited).toEqual(['a', 'b']);
   });
 });
 
@@ -421,6 +455,72 @@ describe('extractAnthropicToolData', () => {
     expect(filesModified).toContain('/tmp/edited-by-morph.ts');
   });
 
+  it('tracks files modified by morph___edit_file', () => {
+    const messages: AnthropicMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu1',
+            name: 'morph___edit_file',
+            input: { path: '/tmp/edited-by-morph-alias.ts', instruction: 'edit file', code_edit: '...' },
+          },
+        ],
+      },
+    ];
+
+    const { filesModified, summaries } = extractAnthropicToolData(messages);
+    expect(filesModified).toContain('/tmp/edited-by-morph-alias.ts');
+    expect(summaries[0].samples[0].data).toMatchObject({
+      category: 'edit',
+      filePath: '/tmp/edited-by-morph-alias.ts',
+    });
+  });
+
+  it('builds edit diff data from Droid old_str/new_str inputs', () => {
+    const messages: AnthropicMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu1',
+            name: 'Edit',
+            input: { path: '/tmp/droid-edit.ts', old_str: 'old value', new_str: 'new value' },
+          },
+        ],
+      },
+    ];
+
+    const { filesModified, summaries } = extractAnthropicToolData(messages);
+    expect(filesModified).toContain('/tmp/droid-edit.ts');
+    expect(summaries[0].samples[0].data).toMatchObject({
+      category: 'edit',
+      filePath: '/tmp/droid-edit.ts',
+      diffStats: { added: 1, removed: 1 },
+    });
+  });
+
+  it('tracks ApplyPatch file paths from patch input text', () => {
+    const patch = ['*** Begin Patch', '*** Update File: src/example.ts', '@@', '-old', '+new', '*** End Patch'].join(
+      '\n',
+    );
+    const messages: AnthropicMessage[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tu1', name: 'ApplyPatch', input: { input: patch } }],
+      },
+    ];
+
+    const { filesModified, summaries } = extractAnthropicToolData(messages);
+    expect(filesModified).toContain('src/example.ts');
+    expect(summaries[0].samples[0].data).toMatchObject({
+      category: 'edit',
+      filePath: 'src/example.ts',
+    });
+  });
+
   it('handles empty messages', () => {
     const { summaries, filesModified } = extractAnthropicToolData([]);
     expect(summaries).toEqual([]);
@@ -549,6 +649,7 @@ describe('classifyToolName', () => {
     expect(classifyToolName('Write')).toBe('write');
     expect(classifyToolName('Edit')).toBe('edit');
     expect(classifyToolName('apply_diff')).toBe('edit');
+    expect(classifyToolName('create')).toBe('write');
     expect(classifyToolName('create_file')).toBe('write');
   });
 

--- a/src/__tests__/shared-utils.test.ts
+++ b/src/__tests__/shared-utils.test.ts
@@ -6,7 +6,9 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getPreset } from '../config/index.js';
+import { logger } from '../logger.js';
 import type { ConversationMessage } from '../types/index.js';
 import { classifyToolName } from '../types/tool-names.js';
 import {
@@ -17,7 +19,7 @@ import {
   isSystemContent,
 } from '../utils/content.js';
 import { countDiffStats, extractStdoutTail, formatEditDiff, formatNewFileDiff } from '../utils/diff.js';
-import { findFiles, listSubdirectories } from '../utils/fs-helpers.js';
+import { findFiles, listSubdirectories, mapConcurrent } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { extractRepo, trimMessages } from '../utils/parser-helpers.js';
 import {
@@ -189,6 +191,26 @@ describe('scanJsonlFile', () => {
 
     expect(visited).toEqual(['a', 'b']);
   });
+
+  it('skips malformed lines without logging parser error objects', async () => {
+    const dir = makeTmpDir();
+    const file = path.join(dir, 'test.jsonl');
+    fs.writeFileSync(file, '{"i":1}\nnot-json\n{"i":2}\n');
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {
+      // keep test output quiet
+    });
+
+    const visited: number[] = [];
+    await scanJsonlFile(file, (parsed) => {
+      visited.push((parsed as { i: number }).i);
+      return 'continue';
+    });
+
+    expect(visited).toEqual([1, 2]);
+    expect(debugSpy).toHaveBeenCalledWith('jsonl: skipping invalid line at index', 1, 'in', file);
+    expect(debugSpy.mock.calls[0]).toHaveLength(4);
+    debugSpy.mockRestore();
+  });
 });
 
 describe('getFileStats', () => {
@@ -278,6 +300,17 @@ describe('listSubdirectories', () => {
 
   it('returns empty for non-existent directory', () => {
     expect(listSubdirectories('/tmp/nonexistent-dir')).toEqual([]);
+  });
+});
+
+describe('mapConcurrent', () => {
+  it('preserves input order while mapping concurrently', async () => {
+    const result = await mapConcurrent([3, 1, 2], 2, async (value, index) => {
+      await new Promise((resolve) => setTimeout(resolve, (3 - index) * 2));
+      return `${index}:${value}`;
+    });
+
+    expect(result).toEqual(['0:3', '1:1', '2:2']);
   });
 });
 
@@ -519,6 +552,60 @@ describe('extractAnthropicToolData', () => {
       category: 'edit',
       filePath: 'src/example.ts',
     });
+  });
+
+  it('strips tab timestamp suffixes from unified diff file paths', () => {
+    const patch = [
+      '--- a/src/example.ts\t2026-04-27 10:00:00',
+      '+++ b/src/example.ts\t2026-04-27 10:01:00',
+      '@@',
+      '-old',
+      '+new',
+    ].join('\n');
+    const messages: AnthropicMessage[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tu1', name: 'ApplyPatch', input: { patch } }],
+      },
+    ];
+
+    const { filesModified, summaries } = extractAnthropicToolData(messages);
+
+    expect(filesModified).toContain('src/example.ts');
+    expect(filesModified.some((filePath) => filePath.includes('\t'))).toBe(false);
+    expect(summaries[0].samples[0].data).toMatchObject({
+      category: 'edit',
+      filePath: 'src/example.ts',
+    });
+  });
+
+  it('caps stored patch diffs at the edit max chars limit', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: src/big.ts',
+      '@@',
+      ...Array.from({ length: 40 }, (_, index) => `+line ${index}`),
+      '*** End Patch',
+    ].join('\n');
+    const config = {
+      ...getPreset('minimal'),
+      edit: { ...getPreset('minimal').edit, maxChars: 80 },
+    };
+    const messages: AnthropicMessage[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tu1', name: 'ApplyPatch', input: { input: patch } }],
+      },
+    ];
+
+    const { summaries } = extractAnthropicToolData(messages, config);
+    const sample = summaries[0].samples[0].data;
+
+    expect(sample).toMatchObject({ category: 'edit', filePath: 'src/big.ts' });
+    if (sample?.category === 'edit') {
+      expect(sample.diff?.length).toBeLessThanOrEqual(80);
+      expect(sample.diff).toContain('...');
+    }
   });
 
   it('handles empty messages', () => {

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -1,13 +1,14 @@
 /**
  * `continues dump <source|all> <directory>` — bulk export sessions to files.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+
 import chalk from 'chalk';
+import * as fs from 'fs';
 import ora from 'ora';
-import { getPreset, loadConfig } from '../config/index.js';
+import * as path from 'path';
 import type { VerbosityConfig } from '../config/index.js';
-import { adapters, ALL_TOOLS } from '../parsers/registry.js';
+import { getPreset, loadConfig } from '../config/index.js';
+import { ALL_TOOLS, adapters } from '../parsers/registry.js';
 import type { SessionSource, UnifiedSession } from '../types/index.js';
 import { getAllSessions, getSessionsBySource } from '../utils/index.js';
 

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -5,13 +5,14 @@
  *
  * Designed for verifying that nothing is silently dropped during extraction.
  */
+
+import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
-import chalk from 'chalk';
-import { getPreset, loadConfig } from '../config/index.js';
 import type { VerbosityConfig } from '../config/index.js';
+import { getPreset, loadConfig } from '../config/index.js';
 import { adapters } from '../parsers/registry.js';
-import type { SessionContext, ReasoningStep, UnifiedSession } from '../types/index.js';
+import type { ReasoningStep, SessionContext, UnifiedSession } from '../types/index.js';
 import { classifyToolName } from '../types/tool-names.js';
 import { findSession } from '../utils/index.js';
 import { readJsonlFile } from '../utils/jsonl.js';
@@ -139,9 +140,7 @@ interface ToolResultFileInfo {
  * Analyze raw JSONL messages for event distribution, content blocks,
  * and tool call categories.
  */
-function analyzeRawMessages(
-  messages: Array<Record<string, unknown>>,
-): {
+function analyzeRawMessages(messages: Array<Record<string, unknown>>): {
   events: RawEventCounts;
   blocks: ContentBlockCounts;
   tools: ToolCategoryCounts;
@@ -299,13 +298,7 @@ function computeMarkdownStats(ctx: SessionContext): MarkdownStats {
 
 function renderHeader(sessionId: string): string {
   const line = '═'.repeat(66);
-  return [
-    '',
-    chalk.bold(line),
-    chalk.bold(`  SESSION INSPECTION: ${sessionId}`),
-    chalk.bold(line),
-    '',
-  ].join('\n');
+  return ['', chalk.bold(line), chalk.bold(`  SESSION INSPECTION: ${sessionId}`), chalk.bold(line), ''].join('\n');
 }
 
 function renderSourceFiles(
@@ -317,9 +310,7 @@ function renderSourceFiles(
 ): string {
   const lines: string[] = [chalk.cyan.bold('📂 Source Files')];
 
-  lines.push(
-    `  Main JSONL:   ${chalk.gray(session.originalPath)} (${mainLines} lines, ${formatBytes(mainSize)})`,
-  );
+  lines.push(`  Main JSONL:   ${chalk.gray(session.originalPath)} (${mainLines} lines, ${formatBytes(mainSize)})`);
 
   if (subagentFiles.length > 0) {
     const totalSubLines = subagentFiles.reduce((s, f) => s + f.lines, 0);
@@ -337,9 +328,7 @@ function renderSourceFiles(
     const totalSize = toolResultFiles.reduce((s, f) => s + f.size, 0);
     lines.push(`  Tool Results: ${toolResultFiles.length} files (${formatBytes(totalSize)} total)`);
     for (const f of toolResultFiles) {
-      lines.push(
-        `    ${pad(f.name, 45)} ${rpad(f.lines, 5)} lines  (${formatBytes(f.size)})`,
-      );
+      lines.push(`    ${pad(f.name, 45)} ${rpad(f.lines, 5)} lines  (${formatBytes(f.size)})`);
     }
   }
 
@@ -363,9 +352,7 @@ function renderEventDistribution(events: RawEventCounts, source: string): string
   for (const [type, count] of sorted) {
     const frac = count / events.total;
     const pct = (frac * 100).toFixed(1);
-    lines.push(
-      `  ${bar(frac)}  ${pad(type + ':', maxLabel + 1)} ${rpad(count, 6)}  (${rpad(pct, 5)}%)`,
-    );
+    lines.push(`  ${bar(frac)}  ${pad(type + ':', maxLabel + 1)} ${rpad(count, 6)}  (${rpad(pct, 5)}%)`);
   }
 
   lines.push(`  ${' '.repeat(30)}  ${pad('TOTAL:', maxLabel + 1)} ${rpad(events.total, 6)}`);
@@ -402,9 +389,7 @@ function renderToolCategories(tools: ToolCategoryCounts): string {
 
   for (const [category, count] of sorted) {
     const barWidth = Math.max(1, Math.round((count / maxCount) * 20));
-    lines.push(
-      `  ${pad(category + ':', maxLabel + 1)} ${rpad(count, 5)}  ${'█'.repeat(barWidth)}`,
-    );
+    lines.push(`  ${pad(category + ':', maxLabel + 1)} ${rpad(count, 5)}  ${'█'.repeat(barWidth)}`);
   }
 
   lines.push(`  ${pad('TOTAL:', maxLabel + 1)} ${rpad(tools.total, 5)}`);
@@ -415,20 +400,13 @@ function renderToolCategories(tools: ToolCategoryCounts): string {
 function renderSubagentAnalysis(subagents: SubagentFileInfo[]): string {
   if (subagents.length === 0) return '';
 
-  const lines: string[] = [
-    chalk.cyan.bold(`🔍 Subagent Analysis (${subagents.length} found)`),
-  ];
-  lines.push(
-    `  ${pad('Name', 30)} ${pad('Status', 12)} ${rpad('Tools', 5)}  ${rpad('Lines', 5)}`,
-  );
+  const lines: string[] = [chalk.cyan.bold(`🔍 Subagent Analysis (${subagents.length} found)`)];
+  lines.push(`  ${pad('Name', 30)} ${pad('Status', 12)} ${rpad('Tools', 5)}  ${rpad('Lines', 5)}`);
 
   for (const s of subagents) {
-    const statusColored =
-      s.status === 'completed' ? chalk.green(pad(s.status, 12)) : chalk.red(pad(s.status, 12));
+    const statusColored = s.status === 'completed' ? chalk.green(pad(s.status, 12)) : chalk.red(pad(s.status, 12));
     const shortName = s.name.replace(/\.jsonl$/, '');
-    lines.push(
-      `  ${pad(shortName, 30)} ${statusColored} ${rpad(s.toolCallCount, 5)}  ${rpad(s.lines, 5)}`,
-    );
+    lines.push(`  ${pad(shortName, 30)} ${statusColored} ${rpad(s.toolCallCount, 5)}  ${rpad(s.lines, 5)}`);
   }
 
   lines.push('');
@@ -438,9 +416,7 @@ function renderSubagentAnalysis(subagents: SubagentFileInfo[]): string {
 function renderReasoningChain(steps: ReasoningStep[]): string {
   if (!steps || steps.length === 0) return '';
 
-  const lines: string[] = [
-    chalk.cyan.bold(`🧠 Reasoning Chain (${steps.length} steps extracted)`),
-  ];
+  const lines: string[] = [chalk.cyan.bold(`🧠 Reasoning Chain (${steps.length} steps extracted)`)];
 
   for (const step of steps) {
     const thought = step.thought.length > 60 ? step.thought.slice(0, 57) + '...' : step.thought;
@@ -492,8 +468,7 @@ function renderConversionSummary(
   const ratio = rawInput > 0 ? ((markdownBytes / rawInput) * 100).toFixed(1) : '0.0';
 
   // Count content events (non-progress)
-  const contentEvents =
-    (events.byType.get('assistant') || 0) + (events.byType.get('user') || 0);
+  const contentEvents = (events.byType.get('assistant') || 0) + (events.byType.get('user') || 0);
 
   const subagentsCaptured = context.sessionNotes?.subagentResults?.length || 0;
   const reasoningCaptured = context.sessionNotes?.reasoningSteps?.length || 0;
@@ -709,10 +684,7 @@ export async function inspectSession(
 
   // 6. Write markdown if requested
   if (opts.writeMd !== undefined && opts.writeMd !== false) {
-    const mdPath =
-      typeof opts.writeMd === 'string'
-        ? opts.writeMd
-        : `inspect-${session.id.slice(0, 8)}.md`;
+    const mdPath = typeof opts.writeMd === 'string' ? opts.writeMd : `inspect-${session.id.slice(0, 8)}.md`;
     fs.writeFileSync(mdPath, context.markdown, 'utf8');
     console.log(chalk.green(`Markdown written to ${mdPath}`));
   }
@@ -745,9 +717,7 @@ export async function inspectSession(
   const output: string[] = [];
 
   output.push(renderHeader(session.id));
-  output.push(
-    renderSourceFiles(session, mainLines, mainSize, subagentFiles, toolResultFiles),
-  );
+  output.push(renderSourceFiles(session, mainLines, mainSize, subagentFiles, toolResultFiles));
   output.push(renderEventDistribution(events, session.source));
   if (rawMessages.length === 0 && rawEventNote) {
     output.push(chalk.gray(`  ${rawEventNote}\n`));
@@ -770,16 +740,7 @@ export async function inspectSession(
   }
 
   output.push(renderMarkdownOutput(markdownStats, presetName));
-  output.push(
-    renderConversionSummary(
-      mainSize,
-      subagentFiles,
-      toolResultFiles,
-      events,
-      markdownStats,
-      context,
-    ),
-  );
+  output.push(renderConversionSummary(mainSize, subagentFiles, toolResultFiles, events, markdownStats, context));
 
   console.log(output.join('\n'));
 }

--- a/src/commands/pick.ts
+++ b/src/commands/pick.ts
@@ -46,11 +46,16 @@ export async function interactivePick(
     let cwdSessions: UnifiedSession[] = [];
     let allSessionsLoaded = false;
 
+    const refreshCwdSessions = (): void => {
+      cwdSessions = options.all ? [] : sessions.filter((sess) => matchesCwd(sess.cwd, currentDir));
+    };
+
     const loadAllSessions = async (message = 'Loading all sessions...'): Promise<UnifiedSession[]> => {
       if (allSessionsLoaded) return sessions;
       const loading = clack.spinner();
       loading.start(message);
       sessions = await getAllSessions(options.rebuild);
+      refreshCwdSessions();
       allSessionsLoaded = true;
       loading.stop();
       return sessions;
@@ -67,6 +72,7 @@ export async function interactivePick(
         sessions = cwdSessions;
       } else {
         sessions = await getAllSessions(options.rebuild);
+        refreshCwdSessions();
         allSessionsLoaded = true;
       }
     }

--- a/src/commands/pick.ts
+++ b/src/commands/pick.ts
@@ -6,7 +6,7 @@ import { showNoSessionsHelp } from '../display/help.js';
 import { maybePromptGithubStar } from '../display/star-prompt.js';
 import type { SessionSource, UnifiedSession } from '../types/index.js';
 import type { HandoffForwardingOptions } from '../utils/forward-flags.js';
-import { getAllSessions, getSessionsBySource } from '../utils/index.js';
+import { getAllSessions, getSessionsByCwd, getSessionsBySource } from '../utils/index.js';
 import { getResumeCommand, nativeResume, resolveCrossToolForwarding, resume } from '../utils/resume.js';
 import { matchesCwd } from '../utils/slug.js';
 import { checkSingleToolAutoResume, selectTargetTool, showForwardingWarnings } from './_shared.js';
@@ -40,14 +40,35 @@ export async function interactivePick(
     await maybePromptGithubStar();
     clack.intro(chalk.bold('continue') + chalk.cyan.bold('s') + chalk.gray(' — session picker'));
 
+    const currentDir = process.cwd();
+    const dirName = currentDir.split('/').pop() || currentDir;
+    let sessions: UnifiedSession[] = [];
+    let cwdSessions: UnifiedSession[] = [];
+    let allSessionsLoaded = false;
+
+    const loadAllSessions = async (message = 'Loading all sessions...'): Promise<UnifiedSession[]> => {
+      if (allSessionsLoaded) return sessions;
+      const loading = clack.spinner();
+      loading.start(message);
+      sessions = await getAllSessions(options.rebuild);
+      allSessionsLoaded = true;
+      loading.stop();
+      return sessions;
+    };
+
     const s = clack.spinner();
     s.start('Loading sessions...');
-
-    let sessions: UnifiedSession[];
     if (options.source) {
       sessions = await getSessionsBySource(options.source as SessionSource, options.rebuild);
+      cwdSessions = options.all ? [] : sessions.filter((sess) => matchesCwd(sess.cwd, currentDir));
     } else {
-      sessions = await getAllSessions(options.rebuild);
+      cwdSessions = options.all ? [] : await getSessionsByCwd(currentDir, options.rebuild);
+      if (cwdSessions.length > 0) {
+        sessions = cwdSessions;
+      } else {
+        sessions = await getAllSessions(options.rebuild);
+        allSessionsLoaded = true;
+      }
     }
 
     s.stop();
@@ -58,12 +79,7 @@ export async function interactivePick(
       return;
     }
 
-    // Check for sessions matching current working directory (includes subdirectories)
-    const currentDir = process.cwd();
-    const cwdSessions = options.all ? [] : sessions.filter((sess) => matchesCwd(sess.cwd, currentDir));
     const hasCwdSessions = cwdSessions.length > 0;
-
-    const dirName = currentDir.split('/').pop() || currentDir;
 
     if (!options.all && !hasCwdSessions && sessions.length > 0) {
       clack.log.info(chalk.gray(`No sessions in ${dirName}, showing all`));
@@ -156,7 +172,7 @@ export async function interactivePick(
           if (scope === 'cwd') {
             filterOptions.push({
               value: 'scope-toggle',
-              label: chalk.dim(`Show all sessions (${sessions.length})`),
+              label: chalk.dim(allSessionsLoaded ? `Show all sessions (${sessions.length})` : 'Show all sessions'),
             });
           } else {
             filterOptions.push({
@@ -179,7 +195,12 @@ export async function interactivePick(
 
         // Scope toggle: flip and re-render
         if (toolFilter === 'scope-toggle') {
-          scope = scope === 'cwd' ? 'all' : 'cwd';
+          if (scope === 'cwd') {
+            await loadAllSessions();
+            scope = 'all';
+          } else {
+            scope = 'cwd';
+          }
           continue;
         }
 

--- a/src/commands/resume-cmd.ts
+++ b/src/commands/resume-cmd.ts
@@ -2,7 +2,7 @@ import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import ora from 'ora';
 import { formatSessionColored } from '../display/format.js';
-import type { SessionSource } from '../types/index.js';
+import { isSessionSource, type SessionSource, TOOL_NAMES } from '../types/index.js';
 import type { HandoffForwardingOptions } from '../utils/forward-flags.js';
 import { findSession, formatSession, getAllSessions } from '../utils/index.js';
 import { getResumeCommand, resolveCrossToolForwarding, resume } from '../utils/resume.js';
@@ -54,7 +54,16 @@ export async function resumeCommand(
       return;
     }
 
-    const target = options.in as SessionSource | undefined;
+    if (options.in && !isSessionSource(options.in)) {
+      console.error(
+        chalk.red('Error:'),
+        `Unknown target tool: ${options.in}. Expected one of: ${TOOL_NAMES.join(', ')}.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const target: SessionSource | undefined = options.in && isSessionSource(options.in) ? options.in : undefined;
     const mode = options.reference ? ('reference' as const) : ('inline' as const);
     const contextOptions = {
       preset: options.preset,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,4 +2,4 @@
  * Config module — re-exports verbosity configuration system.
  */
 export type { PresetName, VerbosityConfig } from './verbosity.js';
-export { VerbosityConfigSchema, getPreset, loadConfig, mergeConfig } from './verbosity.js';
+export { getPreset, loadConfig, mergeConfig, VerbosityConfigSchema } from './verbosity.js';

--- a/src/config/verbosity.ts
+++ b/src/config/verbosity.ts
@@ -17,8 +17,8 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { z } from 'zod';
 import YAML from 'yaml';
+import { z } from 'zod';
 import { logger } from '../logger.js';
 
 // ── Zod Schema ──────────────────────────────────────────────────────────────
@@ -513,7 +513,10 @@ function parseUserConfig(raw: unknown): VerbosityConfig {
   }
 
   // Validation failed — log issues and return the base preset
-  logger.warn('Config validation errors, falling back to preset defaults:', result.error.issues.map((i) => i.message).join('; '));
+  logger.warn(
+    'Config validation errors, falling back to preset defaults:',
+    result.error.issues.map((i) => i.message).join('; '),
+  );
   return base;
 }
 

--- a/src/display/star-prompt.ts
+++ b/src/display/star-prompt.ts
@@ -4,14 +4,14 @@
  * State persisted in ~/.continues/star-prompt.json.
  */
 
-import { readFile, writeFile, mkdir } from 'fs/promises';
-import { existsSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
-import { spawnSync } from 'child_process';
-import { SHELL_OPTION } from '../utils/platform.js';
-import chalk from 'chalk';
 import * as clack from '@clack/prompts';
+import chalk from 'chalk';
+import { spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import { SHELL_OPTION } from '../utils/platform.js';
 
 const REPO = 'yigitkonur/cli-continues';
 
@@ -34,10 +34,7 @@ async function hasBeenPrompted(): Promise<boolean> {
 async function markPrompted(): Promise<void> {
   const dir = join(homedir(), '.continues');
   await mkdir(dir, { recursive: true });
-  await writeFile(
-    statePath(),
-    JSON.stringify({ prompted_at: new Date().toISOString() }, null, 2),
-  );
+  await writeFile(statePath(), JSON.stringify({ prompted_at: new Date().toISOString() }, null, 2));
 }
 
 function isGhInstalled(): boolean {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,8 @@
  * Replaces anonymous Error throws with machine-readable error types.
  */
 
+import { TOOL_NAMES } from './types/tool-names.js';
+
 /**
  * Base error for all continues errors.
  * Includes an optional `cause` for error chaining.
@@ -47,7 +49,7 @@ export class ToolNotAvailableError extends ContinuesError {
 export class UnknownSourceError extends ContinuesError {
   override readonly name = 'UnknownSourceError';
   constructor(public readonly source: string) {
-    super(`Unknown source: "${source}". Valid sources: claude, codex, copilot, gemini, opencode, droid, cursor`);
+    super(`Unknown source: "${source}". Valid sources: ${TOOL_NAMES.join(', ')}`);
   }
 }
 

--- a/src/parsers/amp.ts
+++ b/src/parsers/amp.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type {
   ConversationMessage,
@@ -8,11 +10,9 @@ import type {
   ToolUsageSummary,
   UnifiedSession,
 } from '../types/index.js';
+import { findFiles } from '../utils/fs-helpers.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
-import { findFiles } from '../utils/fs-helpers.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 import { truncate } from '../utils/tool-summarizer.js';
 
 // ── Amp Thread JSON shape ───────────────────────────────────────────────────
@@ -251,7 +251,9 @@ export async function extractAmpContext(session: UnifiedSession, config?: Verbos
         text.includes('need to')
       ) {
         // Extract the first sentence containing the keyword as the task hint
-        const sentences = extractMessageText(msg).split(/[.!\n]/).filter(Boolean);
+        const sentences = extractMessageText(msg)
+          .split(/[.!\n]/)
+          .filter(Boolean);
         for (const sentence of sentences) {
           if (pendingTasks.length >= 5) break;
           const lower = sentence.toLowerCase();

--- a/src/parsers/claude.ts
+++ b/src/parsers/claude.ts
@@ -1,13 +1,23 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type { ConversationMessage, ReasoningStep, SessionContext, SessionNotes, SubagentResult, UnifiedSession } from '../types/index.js';
+import type {
+  ConversationMessage,
+  ReasoningStep,
+  SessionContext,
+  SessionNotes,
+  SessionParseOptions,
+  UnifiedSession,
+} from '../types/index.js';
 import type { ClaudeMessage } from '../types/schemas.js';
 import { extractTextFromBlocks, isRealUserMessage } from '../utils/content.js';
-import { findFiles } from '../utils/fs-helpers.js';
-import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
+import { findFiles, mapConcurrent } from '../utils/fs-helpers.js';
+import { getFileStats, readJsonlFile, scanJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown, safePath } from '../utils/markdown.js';
-import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
+import { cleanSummary, extractRepoFromCwd, homeDir, trimMessages } from '../utils/parser-helpers.js';
+import { matchesCwd } from '../utils/slug.js';
 import {
   type AnthropicMessage,
   extractAnthropicToolData,
@@ -15,8 +25,6 @@ import {
   isThinkingTool,
 } from '../utils/tool-extraction.js';
 import { truncate } from '../utils/tool-summarizer.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 
 const CLAUDE_PROJECTS_DIR = process.env.CLAUDE_CONFIG_DIR
   ? path.join(process.env.CLAUDE_CONFIG_DIR, 'projects')
@@ -25,34 +33,51 @@ const CLAUDE_PROJECTS_DIR = process.env.CLAUDE_CONFIG_DIR
 /**
  * Find all Claude session files recursively
  */
-async function findSessionFiles(): Promise<string[]> {
-  return findFiles(CLAUDE_PROJECTS_DIR, {
-    match: (entry) =>
-      entry.name.endsWith('.jsonl') &&
-      !entry.name.includes('debug') &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i.test(entry.name),
-  });
+async function findSessionFiles(options: SessionParseOptions = {}): Promise<string[]> {
+  const roots = options.cwd
+    ? [path.join(CLAUDE_PROJECTS_DIR, options.cwd.replace(/[/.]/g, '-'))]
+    : [CLAUDE_PROJECTS_DIR];
+
+  return roots.flatMap((root) =>
+    findFiles(root, {
+      match: (entry) =>
+        entry.name.endsWith('.jsonl') &&
+        !entry.name.includes('debug') &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i.test(entry.name),
+    }),
+  );
 }
 
 /**
  * Parse session metadata and first user message
  */
-async function parseSessionInfo(filePath: string): Promise<{
+async function parseSessionInfo(
+  filePath: string,
+  options: SessionParseOptions = {},
+): Promise<{
   sessionId: string;
   cwd: string;
   gitBranch?: string;
   firstUserMessage: string;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
 }> {
   let sessionId = '';
   let cwd = '';
   let gitBranch = '';
   let firstUserMessage = '';
+  let firstTimestamp = '';
+  let lastTimestamp = '';
 
-  await scanJsonlHead(filePath, 50, (parsed) => {
+  const visitor = (parsed: unknown): 'continue' | 'stop' => {
     const msg = parsed as ClaudeMessage;
     if (msg.sessionId && !sessionId) sessionId = msg.sessionId;
     if (msg.cwd && !cwd) cwd = msg.cwd;
     if (msg.gitBranch && !gitBranch) gitBranch = msg.gitBranch;
+    if (msg.timestamp) {
+      if (!firstTimestamp) firstTimestamp = msg.timestamp;
+      lastTimestamp = msg.timestamp;
+    }
 
     if (!firstUserMessage && msg.type === 'user' && msg.message?.content) {
       const content = extractTextFromBlocks(msg.message.content);
@@ -60,33 +85,40 @@ async function parseSessionInfo(filePath: string): Promise<{
         firstUserMessage = content;
       }
     }
+    if (options.lightweight && sessionId && cwd && firstUserMessage) return 'stop';
     return 'continue';
-  });
+  };
+
+  if (options.lightweight) {
+    await scanJsonlHead(filePath, 50, visitor);
+  } else {
+    await scanJsonlFile(filePath, visitor);
+  }
 
   if (!sessionId) {
     sessionId = path.basename(filePath, '.jsonl');
   }
 
-  return { sessionId, cwd, gitBranch, firstUserMessage };
+  return { sessionId, cwd, gitBranch, firstUserMessage, firstTimestamp, lastTimestamp };
 }
 
 /**
  * Parse all Claude sessions
  */
-export async function parseClaudeSessions(): Promise<UnifiedSession[]> {
-  const files = await findSessionFiles();
-  const sessions: UnifiedSession[] = [];
-
-  for (const filePath of files) {
+export async function parseClaudeSessions(options: SessionParseOptions = {}): Promise<UnifiedSession[]> {
+  const files = await findSessionFiles(options);
+  const parsedSessions = await mapConcurrent(files, 16, async (filePath): Promise<UnifiedSession | null> => {
     try {
-      const info = await parseSessionInfo(filePath);
-      const stats = await getFileStats(filePath);
+      const info = await parseSessionInfo(filePath, options);
+      if (options.cwd && info.cwd && !matchesCwd(info.cwd, options.cwd)) return null;
+
       const fileStats = fs.statSync(filePath);
+      const stats = options.lightweight ? { lines: 0, bytes: fileStats.size } : await getFileStats(filePath);
 
       const summary = cleanSummary(info.firstUserMessage);
       const repo = extractRepoFromCwd(info.cwd);
 
-      sessions.push({
+      return {
         id: info.sessionId,
         source: 'claude',
         cwd: info.cwd,
@@ -94,18 +126,21 @@ export async function parseClaudeSessions(): Promise<UnifiedSession[]> {
         branch: info.gitBranch,
         lines: stats.lines,
         bytes: stats.bytes,
-        createdAt: fileStats.birthtime,
-        updatedAt: fileStats.mtime,
+        createdAt: !options.lightweight && info.firstTimestamp ? new Date(info.firstTimestamp) : fileStats.birthtime,
+        updatedAt: !options.lightweight && info.lastTimestamp ? new Date(info.lastTimestamp) : fileStats.mtime,
         originalPath: filePath,
         summary: summary || undefined,
-      });
+      };
     } catch (err) {
       logger.debug('claude: skipping unparseable session', filePath, err);
       // Skip files we can't parse
+      return null;
     }
-  }
+  });
 
-  return sessions.filter((s) => s.bytes > 200).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  const sessions = parsedSessions.filter((session): session is UnifiedSession => session !== null);
+  const sorted = sessions.filter((s) => s.bytes > 200).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  return options.limit ? sorted.slice(0, options.limit) : sorted;
 }
 
 /**
@@ -138,6 +173,14 @@ interface TaskStatusEntry {
   source: 'queue' | 'user_notification' | 'task_output';
 }
 
+interface AgentToolResultEntry {
+  agentId: string;
+  description: string;
+  status?: string;
+  outputFile?: string;
+  result?: string;
+}
+
 function extractTagValue(text: string, tags: string[]): string | undefined {
   for (const tag of tags) {
     const m = text.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`, 'i'));
@@ -146,10 +189,7 @@ function extractTagValue(text: string, tags: string[]): string | undefined {
   return undefined;
 }
 
-function extractTaskStatusesFromTaggedText(
-  text: string,
-  source: TaskStatusEntry['source'],
-): TaskStatusEntry[] {
+function extractTaskStatusesFromTaggedText(text: string, source: TaskStatusEntry['source']): TaskStatusEntry[] {
   const statuses: TaskStatusEntry[] = [];
   const notificationBlocks = text.match(/<task-notification>[\s\S]*?<\/task-notification>/gi);
 
@@ -194,7 +234,20 @@ function extractToolResultText(content: unknown): string {
 function isTerminalTaskStatus(status?: string): boolean {
   if (!status) return false;
   const normalized = status.toLowerCase().trim();
-  return new Set(['completed', 'complete', 'success', 'succeeded', 'done', 'failed', 'error', 'killed', 'cancelled', 'canceled', 'timeout', 'timed_out']).has(normalized);
+  return new Set([
+    'completed',
+    'complete',
+    'success',
+    'succeeded',
+    'done',
+    'failed',
+    'error',
+    'killed',
+    'cancelled',
+    'canceled',
+    'timeout',
+    'timed_out',
+  ]).has(normalized);
 }
 
 function isCompletedTaskStatus(status?: string): boolean {
@@ -254,6 +307,98 @@ function extractTaskOutputStatuses(messages: ClaudeMessage[]): TaskStatusEntry[]
   }
 
   return statuses;
+}
+
+function extractTextFromUnknownContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((item) => {
+      if (!item || typeof item !== 'object') return '';
+      const text = (item as Record<string, unknown>).text;
+      return typeof text === 'string' ? text : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function extractAgentToolResults(messages: ClaudeMessage[]): AgentToolResultEntry[] {
+  const entries: AgentToolResultEntry[] = [];
+  const agentCalls = new Map<string, { description: string }>();
+
+  for (const msg of messages) {
+    const content = msg.message?.content;
+    if (Array.isArray(content)) {
+      for (const block of content as Array<Record<string, unknown>>) {
+        if (block.type !== 'tool_use' || block.name !== 'Agent') continue;
+        const id = typeof block.id === 'string' ? block.id : '';
+        const input = block.input && typeof block.input === 'object' ? (block.input as Record<string, unknown>) : {};
+        const description = typeof input.description === 'string' ? input.description : '';
+        if (id) agentCalls.set(id, { description });
+      }
+    }
+
+    const raw = msg as Record<string, unknown>;
+    const toolUseResult = raw.toolUseResult;
+    if (!toolUseResult || typeof toolUseResult !== 'object' || Array.isArray(toolUseResult)) continue;
+    const resultRecord = toolUseResult as Record<string, unknown>;
+    const agentId = typeof resultRecord.agentId === 'string' ? resultRecord.agentId : '';
+    if (!agentId) continue;
+
+    let description = typeof resultRecord.description === 'string' ? resultRecord.description : '';
+    if (!description && typeof resultRecord.prompt === 'string') description = resultRecord.prompt.split('\n')[0] || '';
+    if (!description && Array.isArray(content)) {
+      const toolUseId = content
+        .filter((block) => block.type === 'tool_result')
+        .map((block) => (block as Record<string, unknown>).tool_use_id)
+        .find((value): value is string => typeof value === 'string');
+      description = toolUseId ? agentCalls.get(toolUseId)?.description || '' : '';
+    }
+
+    const outputFile = typeof resultRecord.outputFile === 'string' ? resultRecord.outputFile : undefined;
+    const result = extractTextFromUnknownContent(resultRecord.content);
+    const status = typeof resultRecord.status === 'string' ? resultRecord.status : undefined;
+    entries.push({ agentId, description, status, outputFile, result });
+  }
+
+  return entries;
+}
+
+function normalizeSubagentStatus(
+  status: string | undefined,
+  fallback: 'completed' | 'killed',
+): 'completed' | 'killed' | 'error' {
+  if (!status) return fallback;
+  const normalized = status.toLowerCase();
+  if (isCompletedTaskStatus(normalized)) return 'completed';
+  if (['error', 'failed', 'failure'].includes(normalized)) return 'error';
+  if (['killed', 'cancelled', 'canceled', 'timeout', 'timed_out'].includes(normalized)) return 'killed';
+  return fallback;
+}
+
+function resolveSubagentPath(sessionDir: string, taskId: string, outputFile?: string): string {
+  const candidates: string[] = [];
+  if (outputFile) {
+    candidates.push(path.isAbsolute(outputFile) ? outputFile : path.join(sessionDir, outputFile));
+  }
+  candidates.push(path.join(sessionDir, 'subagents', `agent-${taskId}.jsonl`));
+  candidates.push(path.join(sessionDir, 'subagents', `${taskId}.jsonl`));
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  const subagentsDir = path.join(sessionDir, 'subagents');
+  try {
+    if (fs.existsSync(subagentsDir)) {
+      const match = fs.readdirSync(subagentsDir).find((entry) => entry.endsWith('.jsonl') && entry.includes(taskId));
+      if (match) return path.join(subagentsDir, match);
+    }
+  } catch (err) {
+    logger.debug('claude: failed to scan subagents dir', subagentsDir, err);
+  }
+
+  return candidates[0] || path.join(subagentsDir, `agent-${taskId}.jsonl`);
 }
 
 /**
@@ -320,10 +465,12 @@ function parseQueueOperations(messages: ClaudeMessage[]): QueueOperationEntry[] 
  */
 function isTerminationMessage(text: string): boolean {
   const lower = text.toLowerCase();
-  return lower.includes('out of extra usage') ||
-         lower.includes('rate limit') ||
-         lower.includes('resets ') ||
-         (text.length < 50 && (lower.includes('usage') || lower.includes('limit')));
+  return (
+    lower.includes('out of extra usage') ||
+    lower.includes('rate limit') ||
+    lower.includes('resets ') ||
+    (text.length < 50 && (lower.includes('usage') || lower.includes('limit')))
+  );
 }
 
 /**
@@ -331,7 +478,9 @@ function isTerminationMessage(text: string): boolean {
  * Skips short termination/rate-limit messages to find the real output.
  * Returns null text if the file doesn't exist, is empty, or has no substantial result.
  */
-async function extractSubagentResult(filePath: string): Promise<{ text: string | null; status: 'completed' | 'killed'; toolCallCount: number }> {
+async function extractSubagentResult(
+  filePath: string,
+): Promise<{ text: string | null; status: 'completed' | 'killed'; toolCallCount: number }> {
   try {
     if (!fs.existsSync(filePath)) {
       return { text: null, status: 'killed', toolCallCount: 0 };
@@ -411,40 +560,11 @@ function extractPendingFromThinking(messages: ClaudeMessage[], maxTasks: number)
   return tasks;
 }
 
-/**
- * Read supplementary tool result files from {session_dir}/tool-results/.
- * Returns an array of note strings describing each file found.
- */
-function readToolResultsDir(sessionDir: string): string[] {
-  const toolResultsPath = path.join(sessionDir, 'tool-results');
-  const notes: string[] = [];
-
-  try {
-    if (!fs.existsSync(toolResultsPath)) return notes;
-    const entries = fs.readdirSync(toolResultsPath, { withFileTypes: true });
-
-    for (const entry of entries) {
-      if (!entry.isFile()) continue;
-      const filePath = path.join(toolResultsPath, entry.name);
-      try {
-        const stats = fs.statSync(filePath);
-        const sizeKb = (stats.size / 1024).toFixed(1);
-        notes.push(`tool-result: ${entry.name} (${sizeKb} KB)`);
-      } catch {
-        notes.push(`tool-result: ${entry.name} (unreadable)`);
-      }
-    }
-  } catch (err) {
-    logger.debug('claude: failed to read tool-results dir', toolResultsPath, err);
-  }
-
-  return notes;
-}
-
 function hasCompactionCue(messages: ClaudeMessage[]): boolean {
   if (messages.some((m) => m.isCompactSummary)) return true;
 
-  const continuationPattern = /(continued from a previous conversation|ran out of context|summary below covers|conversation compacted)/i;
+  const continuationPattern =
+    /(continued from a previous conversation|ran out of context|summary below covers|conversation compacted)/i;
   for (const msg of messages) {
     if (msg.type !== 'user' && msg.type !== 'assistant') continue;
     const text = extractTextFromBlocks(msg.message?.content);
@@ -596,14 +716,9 @@ function extractSessionNotes(messages: ClaudeMessage[], config?: VerbosityConfig
 /**
  * Extract context from a Claude session for cross-tool continuation
  */
-export async function extractClaudeContext(
-  session: UnifiedSession,
-  config?: VerbosityConfig,
-): Promise<SessionContext> {
+export async function extractClaudeContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const cfg = config ?? getPreset('standard');
   const messages = await readJsonlFile<ClaudeMessage>(session.originalPath);
-  const recentMessages: ConversationMessage[] = [];
-
   // Extract tool data via shared utility
   const anthropicMsgs: AnthropicMessage[] = messages
     .filter((m) => m.message?.content && Array.isArray(m.message.content))
@@ -663,27 +778,18 @@ export async function extractClaudeContext(
     return true;
   });
 
-  for (const msg of conversational.slice(-(cfg.recentMessages * 2))) {
-    if (msg.type === 'user') {
-      const content = extractTextFromBlocks(msg.message?.content);
-      if (content) {
-        recentMessages.push({
-          role: 'user',
-          content: truncate(content, cfg.maxMessageChars),
-          timestamp: new Date(msg.timestamp),
-        });
-      }
-    } else if (msg.type === 'assistant') {
-      const content = extractTextFromBlocks(msg.message?.content);
-      if (content) {
-        recentMessages.push({
-          role: 'assistant',
-          content: truncate(content, cfg.maxMessageChars),
-          timestamp: new Date(msg.timestamp),
-        });
-      }
-    }
-  }
+  const recentMessages: ConversationMessage[] = conversational.flatMap((msg) => {
+    const content = extractTextFromBlocks(msg.message?.content).trim();
+    if (!content) return [];
+    const role: ConversationMessage['role'] = msg.type === 'user' ? 'user' : 'assistant';
+    return [
+      {
+        role,
+        content: truncate(content, cfg.maxMessageChars),
+        timestamp: new Date(msg.timestamp),
+      },
+    ];
+  });
 
   // ── Gap 2: Parse subagent JSONL files ─────────────────────────────────
   if (cfg.agents.claude.parseSubagents) {
@@ -692,6 +798,7 @@ export async function extractClaudeContext(
     const queueOps = parseQueueOperations(messages);
     const userTaskStatuses = extractUserTaskNotifications(messages);
     const taskOutputStatuses = extractTaskOutputStatuses(messages);
+    const agentToolResults = extractAgentToolResults(messages);
 
     // Terminal states can come from queue ops, user task notifications, or TaskOutput payloads.
     const terminalTaskIds = new Set<string>();
@@ -718,16 +825,16 @@ export async function extractClaudeContext(
     });
 
     let subagentCount = 0;
+    const processedSubagents = new Set<string>();
     for (const task of uniqueTasks) {
       if (subagentCount >= cfg.task.maxSamples) break;
       // Only local_agent tasks are backed by subagent transcript files.
       if (task.taskType && task.taskType !== 'local_agent') continue;
+      processedSubagents.add(task.taskId);
 
-      const subagentPath = path.join(sessionDir, 'subagents', `agent-${task.taskId}.jsonl`);
+      const subagentPath = resolveSubagentPath(sessionDir, task.taskId);
       const { text, status: extractedStatus, toolCallCount } = await extractSubagentResult(subagentPath);
-      const status = !text && completedTaskIds.has(task.taskId)
-        ? 'completed'
-        : extractedStatus;
+      const status = !text && completedTaskIds.has(task.taskId) ? 'completed' : extractedStatus;
 
       // Always populate structured subagentResults
       if (!sessionNotes.subagentResults) sessionNotes.subagentResults = [];
@@ -748,6 +855,37 @@ export async function extractClaudeContext(
         // Incomplete/killed subagent — add to pending tasks
         if (cfg.pendingTasks.extractFromSubagents && pendingTasks.length < cfg.pendingTasks.maxTasks) {
           pendingTasks.push(`Incomplete subagent: ${task.description}`);
+        }
+      }
+    }
+
+    for (const agent of agentToolResults) {
+      if (subagentCount >= cfg.task.maxSamples) break;
+      if (processedSubagents.has(agent.agentId)) continue;
+      processedSubagents.add(agent.agentId);
+
+      const subagentPath = resolveSubagentPath(sessionDir, agent.agentId, agent.outputFile);
+      const { text, status: extractedStatus, toolCallCount } = await extractSubagentResult(subagentPath);
+      const resultText = text || agent.result || undefined;
+      const status = normalizeSubagentStatus(agent.status, resultText ? 'completed' : extractedStatus);
+      const description = agent.description || `Agent ${agent.agentId}`;
+
+      if (!sessionNotes.subagentResults) sessionNotes.subagentResults = [];
+      sessionNotes.subagentResults.push({
+        taskId: agent.agentId,
+        description,
+        status,
+        result: resultText ? truncate(resultText, cfg.task.subagentResultChars) : undefined,
+        toolCallCount,
+      });
+
+      if (resultText) {
+        if (!sessionNotes.reasoning) sessionNotes.reasoning = [];
+        sessionNotes.reasoning.push(`Subagent "${description}": ${truncate(resultText, cfg.task.subagentResultChars)}`);
+        subagentCount++;
+      } else if (!isTerminalTaskStatus(agent.status)) {
+        if (cfg.pendingTasks.extractFromSubagents && pendingTasks.length < cfg.pendingTasks.maxTasks) {
+          pendingTasks.push(`Incomplete subagent: ${description}`);
         }
       }
     }
@@ -784,7 +922,7 @@ export async function extractClaudeContext(
     }
   }
 
-  const finalMessages = recentMessages.slice(-cfg.recentMessages);
+  const finalMessages = trimMessages(recentMessages, cfg.recentMessages);
   const dedupedPendingTasks = Array.from(new Set(pendingTasks)).slice(0, cfg.pendingTasks.maxTasks);
 
   const baseMarkdown = generateHandoffMarkdown(

--- a/src/parsers/claude.ts
+++ b/src/parsers/claude.ts
@@ -30,12 +30,16 @@ const CLAUDE_PROJECTS_DIR = process.env.CLAUDE_CONFIG_DIR
   ? path.join(process.env.CLAUDE_CONFIG_DIR, 'projects')
   : path.join(homeDir(), '.claude', 'projects');
 
+export function claudeProjectSlugFromCwd(cwd: string): string {
+  return cwd.replace(/\\/g, '/').replace(/:/g, '').replace(/[/.]/g, '-');
+}
+
 /**
  * Find all Claude session files recursively
  */
 async function findSessionFiles(options: SessionParseOptions = {}): Promise<string[]> {
   const roots = options.cwd
-    ? [path.join(CLAUDE_PROJECTS_DIR, options.cwd.replace(/[/.]/g, '-'))]
+    ? [path.join(CLAUDE_PROJECTS_DIR, claudeProjectSlugFromCwd(options.cwd))]
     : [CLAUDE_PROJECTS_DIR];
 
   return roots.flatMap((root) =>
@@ -883,7 +887,7 @@ export async function extractClaudeContext(session: UnifiedSession, config?: Ver
         if (!sessionNotes.reasoning) sessionNotes.reasoning = [];
         sessionNotes.reasoning.push(`Subagent "${description}": ${truncate(resultText, cfg.task.subagentResultChars)}`);
         subagentCount++;
-      } else if (!isTerminalTaskStatus(agent.status)) {
+      } else if (!isTerminalTaskStatus(status)) {
         if (cfg.pendingTasks.extractFromSubagents && pendingTasks.length < cfg.pendingTasks.maxTasks) {
           pendingTasks.push(`Incomplete subagent: ${description}`);
         }

--- a/src/parsers/cline.ts
+++ b/src/parsers/cline.ts
@@ -1,18 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type {
-  ConversationMessage,
-  SessionContext,
-  SessionNotes,
-  UnifiedSession,
-} from '../types/index.js';
+import type { ConversationMessage, SessionContext, SessionNotes, UnifiedSession } from '../types/index.js';
 import type { SessionSource } from '../types/tool-names.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
 import { truncate } from '../utils/tool-summarizer.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 
 // ── Extension Configs ───────────────────────────────────────────────────────
 
@@ -242,10 +237,22 @@ function extractTokenUsage(messages: ClineRawMessage[]): SessionNotes {
 
     try {
       const meta: ApiReqMeta = JSON.parse(msg.text);
-      if (meta.tokensIn) { totalIn += meta.tokensIn; found = true; }
-      if (meta.tokensOut) { totalOut += meta.tokensOut; found = true; }
-      if (meta.cacheWrites) { totalCacheWrites += meta.cacheWrites; found = true; }
-      if (meta.cacheReads) { totalCacheReads += meta.cacheReads; found = true; }
+      if (meta.tokensIn) {
+        totalIn += meta.tokensIn;
+        found = true;
+      }
+      if (meta.tokensOut) {
+        totalOut += meta.tokensOut;
+        found = true;
+      }
+      if (meta.cacheWrites) {
+        totalCacheWrites += meta.cacheWrites;
+        found = true;
+      }
+      if (meta.cacheReads) {
+        totalCacheReads += meta.cacheReads;
+        found = true;
+      }
       if (meta.cost) totalCost += meta.cost;
     } catch {
       // Malformed JSON in api_req_started — skip silently
@@ -365,10 +372,7 @@ async function parseSessionsForSource(filterSource?: ClineSource): Promise<Unifi
  * Extract full session context for cross-tool handoff.
  * Shared implementation for all three Cline-family variants.
  */
-async function extractContextShared(
-  session: UnifiedSession,
-  config?: VerbosityConfig,
-): Promise<SessionContext> {
+async function extractContextShared(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const cfg = config ?? getPreset('standard');
   const messages = readUiMessages(session.originalPath);
 
@@ -419,10 +423,7 @@ export async function parseClineSessions(): Promise<UnifiedSession[]> {
 }
 
 /** Extract context from a Cline session */
-export async function extractClineContext(
-  session: UnifiedSession,
-  config?: VerbosityConfig,
-): Promise<SessionContext> {
+export async function extractClineContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   return extractContextShared(session, config);
 }
 

--- a/src/parsers/codex.ts
+++ b/src/parsers/codex.ts
@@ -7,17 +7,20 @@ import type {
   ConversationMessage,
   SessionContext,
   SessionNotes,
+  SessionParseOptions,
   ToolUsageSummary,
   UnifiedSession,
 } from '../types/index.js';
 import type { CodexMessage, CodexSessionMeta } from '../types/schemas.js';
 import { countDiffStats, extractStdoutTail } from '../utils/diff.js';
-import { findFiles } from '../utils/fs-helpers.js';
+import { findFiles, mapConcurrent } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepo, homeDir } from '../utils/parser-helpers.js';
+import { matchesCwd } from '../utils/slug.js';
 import {
   extractExitCode,
+  fileSummary,
   mcpSummary,
   SummaryCollector,
   searchSummary,
@@ -103,31 +106,31 @@ function parseFilename(filename: string): { timestamp: Date; id: string } | null
 /**
  * Parse all Codex sessions
  */
-export async function parseCodexSessions(): Promise<UnifiedSession[]> {
+export async function parseCodexSessions(options: SessionParseOptions = {}): Promise<UnifiedSession[]> {
   const files = await findSessionFiles();
-  const sessionsById = new Map<string, UnifiedSession>();
-
-  for (const filePath of files) {
+  const parsedSessions = await mapConcurrent(files, 16, async (filePath): Promise<UnifiedSession | null> => {
     try {
       const filename = path.basename(filePath);
       const parsed = parseFilename(filename);
-      if (!parsed) continue;
+      if (!parsed) return null;
 
       const { meta, firstUserMessage } = await parseSessionInfo(filePath);
       const fileStats = fs.statSync(filePath);
       const stats =
-        fileStats.size > MAX_EXACT_LINE_COUNT_BYTES
+        options.lightweight || fileStats.size > MAX_EXACT_LINE_COUNT_BYTES
           ? { lines: 0, bytes: fileStats.size }
           : await getFileStats(filePath);
 
       const cwd = meta?.payload?.cwd || '';
+      if (options.cwd && cwd && !matchesCwd(cwd, options.cwd)) return null;
+
       const gitUrl = meta?.payload?.git?.repository_url;
       const branch = meta?.payload?.git?.branch;
       const repo = extractRepo({ gitUrl, cwd });
 
       const summary = cleanSummary(firstUserMessage);
 
-      const nextSession: UnifiedSession = {
+      return {
         id: parsed.id,
         source: 'codex',
         cwd,
@@ -140,18 +143,24 @@ export async function parseCodexSessions(): Promise<UnifiedSession[]> {
         originalPath: filePath,
         summary: summary || undefined,
       };
-
-      const existing = sessionsById.get(nextSession.id);
-      if (!existing || existing.updatedAt.getTime() < nextSession.updatedAt.getTime()) {
-        sessionsById.set(nextSession.id, nextSession);
-      }
     } catch (err) {
       logger.debug('codex: skipping unparseable session', filePath, err);
       // Skip files we can't parse
+      return null;
+    }
+  });
+
+  const sessionsById = new Map<string, UnifiedSession>();
+  for (const nextSession of parsedSessions) {
+    if (!nextSession) continue;
+    const existing = sessionsById.get(nextSession.id);
+    if (!existing || existing.updatedAt.getTime() < nextSession.updatedAt.getTime()) {
+      sessionsById.set(nextSession.id, nextSession);
     }
   }
 
-  return Array.from(sessionsById.values()).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  const sorted = Array.from(sessionsById.values()).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  return options.limit ? sorted.slice(0, options.limit) : sorted;
 }
 
 /**
@@ -190,6 +199,10 @@ const COMMON_SHELL_TOOLS = new Set([
   'bun',
   'deno',
 ]);
+
+function isCodexEditTool(name: string): boolean {
+  return name === 'edit_file' || name.endsWith('__edit_file');
+}
 
 /**
  * Track file modifications from shell command patterns (sed -i, >, tee, mv, cp)
@@ -251,8 +264,10 @@ function extractToolData(
       // function_call
       if (payload.type === 'function_call' && payload.arguments) {
         try {
-          const args = JSON.parse(payload.arguments);
-          const name = payload.name || '';
+          const args = JSON.parse(payload.arguments) as Record<string, unknown>;
+          const rawName = payload.name || '';
+          const namespace = typeof payload.namespace === 'string' ? payload.namespace : '';
+          const name = namespace && !rawName.startsWith(namespace) ? `${namespace}${rawName}` : rawName;
           const output = payload.call_id ? outputsById.get(payload.call_id) : undefined;
 
           if (name === 'exec_command' || name === 'shell_command') {
@@ -275,7 +290,20 @@ function extractToolData(
             });
             trackShellFileWrites(cmd, collector);
           } else if (name === 'write_stdin') {
-            collector.add('write_stdin', `stdin: "${truncate(String(args.input || args.data || ''), 60)}"`);
+            const stdin = String(args.chars ?? args.input ?? args.data ?? '');
+            collector.add('write_stdin', `stdin: "${truncate(stdin, 60)}"`);
+          } else if (isCodexEditTool(name)) {
+            const filePath = String(args.path ?? args.file_path ?? '');
+            const displayPath = filePath || '(unknown)';
+            const codeEdit = typeof args.code_edit === 'string' ? args.code_edit : undefined;
+            collector.add(name, withResult(fileSummary('edit', displayPath), output), {
+              data: {
+                category: 'edit',
+                filePath: displayPath,
+                ...(codeEdit ? { diff: codeEdit } : {}),
+              },
+              ...(filePath ? { filePath, isWrite: true } : {}),
+            });
           } else if (['read_mcp_resource', 'list_mcp_resources', 'list_mcp_resource_templates'].includes(name)) {
             collector.add(
               'mcp-resource',
@@ -375,6 +403,12 @@ function extractToolData(
 /**
  * Extract session notes from reasoning events, model, and token usage
  */
+function extractCodexCompactedText(payload: { message?: string } | undefined): string {
+  if (!payload) return '';
+  if (typeof payload.message === 'string' && payload.message.trim()) return payload.message;
+  return '';
+}
+
 function extractSessionNotes(messages: CodexMessage[]): SessionNotes {
   const notes: SessionNotes = {};
   const reasoning: string[] = [];
@@ -396,6 +430,12 @@ function extractSessionNotes(messages: CodexMessage[]): SessionNotes {
     // Model from turn_context
     if (msg.type === 'turn_context') {
       if (msg.payload?.model && !notes.model) notes.model = msg.payload.model;
+    }
+
+    if (msg.type === 'compacted') {
+      const summary = extractCodexCompactedText(msg.payload);
+      if (summary) notes.compactSummary = truncate(summary, 500);
+      continue;
     }
 
     if (msg.type !== 'event_msg') continue;

--- a/src/parsers/copilot.ts
+++ b/src/parsers/copilot.ts
@@ -16,7 +16,7 @@ import { classifyToolName } from '../types/tool-names.js';
 import { listSubdirectories } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
-import { homeDir } from '../utils/parser-helpers.js';
+import { homeDir, trimMessages } from '../utils/parser-helpers.js';
 import {
   extractExitCode,
   fetchSummary,
@@ -149,8 +149,8 @@ export async function extractCopilotContext(
   const recentMessages: ConversationMessage[] = [];
   const pendingTasks: string[] = [];
 
-  // Process events to extract conversation
-  for (const event of events.slice(-resolvedConfig.recentMessages * 2)) {
+  // Process all events before trimming; Copilot tails often contain only tool execution events.
+  for (const event of events) {
     if (event.type === 'user.message') {
       const content = event.data?.content || event.data?.transformedContent || '';
       if (content) {
@@ -202,7 +202,7 @@ export async function extractCopilotContext(
   // Extract tool summaries and file modifications from toolRequests across all events
   const { summaries: toolSummaries, filesModified } = extractCopilotToolSummaries(events, resolvedConfig);
 
-  const trimmed = recentMessages.slice(-resolvedConfig.recentMessages);
+  const trimmed = trimMessages(recentMessages, resolvedConfig.recentMessages);
 
   // Generate markdown for injection
   const markdown = generateHandoffMarkdown(

--- a/src/parsers/crush.ts
+++ b/src/parsers/crush.ts
@@ -1,18 +1,13 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type {
-  ConversationMessage,
-  SessionContext,
-  SessionNotes,
-  UnifiedSession,
-} from '../types/index.js';
+import type { ConversationMessage, SessionContext, SessionNotes, UnifiedSession } from '../types/index.js';
 import type { SessionSource } from '../types/tool-names.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 
 // 'crush' is not yet in TOOL_NAMES — use a type assertion until registration is added.
 const CRUSH_SOURCE: SessionSource = 'crush';
@@ -170,10 +165,7 @@ export async function parseCrushSessions(): Promise<UnifiedSession[]> {
 /**
  * Extract context from a Crush session for cross-tool continuation.
  */
-export async function extractCrushContext(
-  session: UnifiedSession,
-  config?: VerbosityConfig,
-): Promise<SessionContext> {
+export async function extractCrushContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const resolvedConfig = config ?? getPreset('standard');
 
   const msgRows = querySqlite<CrushMessageRow>(

--- a/src/parsers/droid.ts
+++ b/src/parsers/droid.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type { ConversationMessage, SessionContext, SessionNotes, UnifiedSession } from '../types/index.js';
 import type {
@@ -12,13 +14,11 @@ import type {
 } from '../types/schemas.js';
 import { DroidSettingsSchema } from '../types/schemas.js';
 import { isSystemContent } from '../utils/content.js';
-import { listSubdirectories } from '../utils/fs-helpers.js';
-import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
+import { findFiles } from '../utils/fs-helpers.js';
+import { getFileStats, readJsonlFile, scanJsonlFile } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
 import { cwdFromSlug } from '../utils/slug.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 import {
   type AnthropicMessage,
   extractAnthropicToolData,
@@ -26,28 +26,29 @@ import {
 } from '../utils/tool-extraction.js';
 import { truncate } from '../utils/tool-summarizer.js';
 
+const DROID_PROJECTS_DIR = path.join(homeDir(), '.factory', 'projects');
 const DROID_SESSIONS_DIR = path.join(homeDir(), '.factory', 'sessions');
+const DROID_SESSION_DIRS = [DROID_PROJECTS_DIR, DROID_SESSIONS_DIR];
 
 /**
  * Find all Droid session JSONL files.
- * Structure: ~/.factory/sessions/<workspace-slug>/<uuid>.jsonl
+ * Structures:
+ * - ~/.factory/projects/<workspace-slug>/<uuid>.jsonl
+ * - ~/.factory/sessions/<workspace-slug>/<uuid>.jsonl
  */
 async function findSessionFiles(): Promise<string[]> {
-  const files: string[] = [];
-  for (const wsPath of listSubdirectories(DROID_SESSIONS_DIR)) {
-    try {
-      const entries = fs.readdirSync(wsPath, { withFileTypes: true });
-      for (const entry of entries) {
-        if (entry.isFile() && entry.name.endsWith('.jsonl')) {
-          files.push(path.join(wsPath, entry.name));
-        }
-      }
-    } catch (err) {
-      logger.debug('droid: cannot read session directory', wsPath, err);
-      // Skip directories we can't read
+  const files = new Set<string>();
+  for (const root of DROID_SESSION_DIRS) {
+    for (const filePath of findFiles(root, {
+      match: (entry) =>
+        entry.name.endsWith('.jsonl') &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i.test(entry.name),
+      maxDepth: 3,
+    })) {
+      files.add(filePath);
     }
   }
-  return files;
+  return Array.from(files);
 }
 
 /**
@@ -82,19 +83,19 @@ async function parseSessionInfo(filePath: string): Promise<{
   let firstTimestamp = '';
   let lastTimestamp = '';
 
-  await scanJsonlHead(filePath, 100, (parsed) => {
+  await scanJsonlFile(filePath, (parsed) => {
     const event = parsed as DroidEvent;
 
     if (event.type === 'session_start' && !sessionStart) {
       sessionStart = event;
     }
 
-    if (event.type === 'message') {
-      if (event.timestamp) {
-        if (!firstTimestamp) firstTimestamp = event.timestamp;
-        lastTimestamp = event.timestamp;
-      }
+    if ('timestamp' in event && typeof event.timestamp === 'string') {
+      if (!firstTimestamp) firstTimestamp = event.timestamp;
+      lastTimestamp = event.timestamp;
+    }
 
+    if (event.type === 'message') {
       if (!firstUserMessage && event.message.role === 'user') {
         for (const block of event.message.content) {
           if (block.type === 'text' && block.text) {
@@ -118,7 +119,7 @@ async function parseSessionInfo(filePath: string): Promise<{
  */
 export async function parseDroidSessions(): Promise<UnifiedSession[]> {
   const files = await findSessionFiles();
-  const sessions: UnifiedSession[] = [];
+  const sessionsById = new Map<string, UnifiedSession>();
 
   for (const filePath of files) {
     try {
@@ -137,7 +138,7 @@ export async function parseDroidSessions(): Promise<UnifiedSession[]> {
       const createdAt = firstTimestamp ? new Date(firstTimestamp) : fileStats.birthtime;
       const updatedAt = lastTimestamp ? new Date(lastTimestamp) : fileStats.mtime;
 
-      sessions.push({
+      const nextSession: UnifiedSession = {
         id: sessionStart.id,
         source: 'droid',
         cwd,
@@ -149,14 +150,24 @@ export async function parseDroidSessions(): Promise<UnifiedSession[]> {
         originalPath: filePath,
         summary: summary || sessionStart.sessionTitle || undefined,
         model: settings?.model,
-      });
+      };
+
+      const existing = sessionsById.get(nextSession.id);
+      const existingTime = existing?.updatedAt.getTime() ?? 0;
+      const nextTime = nextSession.updatedAt.getTime();
+      const nextIsProjectTranscript = nextSession.originalPath.startsWith(DROID_PROJECTS_DIR);
+      if (!existing || existingTime < nextTime || (existingTime === nextTime && nextIsProjectTranscript)) {
+        sessionsById.set(nextSession.id, nextSession);
+      }
     } catch (err) {
       logger.debug('droid: skipping unparseable session', filePath, err);
       // Skip files we can't parse
     }
   }
 
-  return sessions.filter((s) => s.lines > 1).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  return Array.from(sessionsById.values())
+    .filter((s) => s.lines > 1)
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 }
 
 /**
@@ -277,7 +288,15 @@ export async function extractDroidContext(session: UnifiedSession, config?: Verb
 
   const trimmed = recentMessages.slice(-resolvedConfig.recentMessages);
 
-  const markdown = generateHandoffMarkdown(session, trimmed, filesModified, pendingTasks, toolSummaries, sessionNotes, resolvedConfig);
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    sessionNotes,
+    resolvedConfig,
+  );
 
   return {
     session: sessionNotes?.model ? { ...session, model: sessionNotes.model } : session,

--- a/src/parsers/droid.ts
+++ b/src/parsers/droid.ts
@@ -3,7 +3,13 @@ import * as path from 'path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type { ConversationMessage, SessionContext, SessionNotes, UnifiedSession } from '../types/index.js';
+import type {
+  ConversationMessage,
+  SessionContext,
+  SessionNotes,
+  SessionParseOptions,
+  UnifiedSession,
+} from '../types/index.js';
 import type {
   DroidCompactionState,
   DroidEvent,
@@ -15,7 +21,7 @@ import type {
 import { DroidSettingsSchema } from '../types/schemas.js';
 import { isSystemContent } from '../utils/content.js';
 import { findFiles } from '../utils/fs-helpers.js';
-import { getFileStats, readJsonlFile, scanJsonlFile } from '../utils/jsonl.js';
+import { getFileStats, readJsonlFile, scanJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
 import { cwdFromSlug } from '../utils/slug.js';
@@ -72,7 +78,10 @@ function readSettings(jsonlPath: string): DroidSettings | null {
 /**
  * Parse session metadata from session_start event and first user message
  */
-async function parseSessionInfo(filePath: string): Promise<{
+async function parseSessionInfo(
+  filePath: string,
+  options: SessionParseOptions = {},
+): Promise<{
   sessionStart: DroidSessionStart | null;
   firstUserMessage: string;
   firstTimestamp: string;
@@ -83,7 +92,7 @@ async function parseSessionInfo(filePath: string): Promise<{
   let firstTimestamp = '';
   let lastTimestamp = '';
 
-  await scanJsonlFile(filePath, (parsed) => {
+  const visitor = (parsed: unknown): 'continue' | 'stop' => {
     const event = parsed as DroidEvent;
 
     if (event.type === 'session_start' && !sessionStart) {
@@ -109,7 +118,13 @@ async function parseSessionInfo(filePath: string): Promise<{
     }
 
     return 'continue';
-  });
+  };
+
+  if (options.lightweight) {
+    await scanJsonlHead(filePath, 100, visitor);
+  } else {
+    await scanJsonlFile(filePath, visitor);
+  }
 
   return { sessionStart, firstUserMessage, firstTimestamp, lastTimestamp };
 }
@@ -117,17 +132,21 @@ async function parseSessionInfo(filePath: string): Promise<{
 /**
  * Parse all Droid sessions
  */
-export async function parseDroidSessions(): Promise<UnifiedSession[]> {
+export async function parseDroidSessions(options: SessionParseOptions = {}): Promise<UnifiedSession[]> {
   const files = await findSessionFiles();
   const sessionsById = new Map<string, UnifiedSession>();
+  const lightweight = options.lightweight === true;
 
   for (const filePath of files) {
     try {
-      const { sessionStart, firstUserMessage, firstTimestamp, lastTimestamp } = await parseSessionInfo(filePath);
+      const { sessionStart, firstUserMessage, firstTimestamp, lastTimestamp } = await parseSessionInfo(
+        filePath,
+        options,
+      );
       if (!sessionStart) continue;
 
       const fileStats = fs.statSync(filePath);
-      const stats = await getFileStats(filePath);
+      const stats = lightweight ? { lines: 0, bytes: fileStats.size } : await getFileStats(filePath);
       const settings = readSettings(filePath);
 
       const workspaceSlug = path.basename(path.dirname(filePath));
@@ -166,7 +185,7 @@ export async function parseDroidSessions(): Promise<UnifiedSession[]> {
   }
 
   return Array.from(sessionsById.values())
-    .filter((s) => s.lines > 1)
+    .filter((s) => lightweight || s.lines > 1)
     .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 }
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,20 +1,23 @@
+export { extractAmpContext, parseAmpSessions } from './amp.js';
+export { extractAntigravityContext, parseAntigravitySessions } from './antigravity.js';
 export { extractClaudeContext, parseClaudeSessions } from './claude.js';
+export {
+  extractClineContext,
+  extractKiloCodeContext,
+  extractRooCodeContext,
+  parseClineSessions,
+  parseKiloCodeSessions,
+  parseRooCodeSessions,
+} from './cline.js';
 export { extractCodexContext, parseCodexSessions } from './codex.js';
 export { extractCopilotContext, parseCopilotSessions } from './copilot.js';
+export { extractCrushContext, parseCrushSessions } from './crush.js';
 export { extractCursorContext, parseCursorSessions } from './cursor.js';
 export { extractDroidContext, parseDroidSessions } from './droid.js';
 export { extractGeminiContext, parseGeminiSessions } from './gemini.js';
-export { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
-export { extractAmpContext, parseAmpSessions } from './amp.js';
-export { extractKiroContext, parseKiroSessions } from './kiro.js';
-export { extractCrushContext, parseCrushSessions } from './crush.js';
-export {
-  extractClineContext, parseClineSessions,
-  extractRooCodeContext, parseRooCodeSessions,
-  extractKiloCodeContext, parseKiloCodeSessions,
-} from './cline.js';
-export { extractAntigravityContext, parseAntigravitySessions } from './antigravity.js';
 export { extractKimiContext, parseKimiSessions } from './kimi.js';
+export { extractKiroContext, parseKiroSessions } from './kiro.js';
+export { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
 export { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
 export type { ToolAdapter } from './registry.js';
 export { ALL_TOOLS, adapters, SOURCE_HELP } from './registry.js';

--- a/src/parsers/kimi.ts
+++ b/src/parsers/kimi.ts
@@ -1,6 +1,8 @@
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
-import { createHash } from 'crypto';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type {
   ConversationMessage,
@@ -9,17 +11,15 @@ import type {
   ToolUsageSummary,
   UnifiedSession,
 } from '../types/index.js';
-import type { KimiMetadata, KimiMessage } from '../types/schemas.js';
+import type { KimiMessage, KimiMetadata } from '../types/schemas.js';
 import { KimiMetadataSchema } from '../types/schemas.js';
+import { classifyToolName } from '../types/tool-names.js';
 import { extractTextFromBlocks } from '../utils/content.js';
 import { listSubdirectories } from '../utils/fs-helpers.js';
 import { readJsonlFile } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, homeDir, trimMessages } from '../utils/parser-helpers.js';
-import { classifyToolName } from '../types/tool-names.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
-import { fileSummary, mcpSummary, shellSummary, SummaryCollector, truncate } from '../utils/tool-summarizer.js';
+import { fileSummary, mcpSummary, SummaryCollector, shellSummary, truncate } from '../utils/tool-summarizer.js';
 
 const KIMI_SESSIONS_DIR = path.join(homeDir(), '.kimi', 'sessions');
 const KIMI_CONFIG_PATH = path.join(homeDir(), '.kimi', 'kimi.json');
@@ -165,7 +165,10 @@ function parseToolArgs(argsStr: string): Record<string, unknown> {
 /**
  * Extract tool usage summaries and files modified using shared SummaryCollector
  */
-function extractToolData(messages: KimiMessage[], config?: VerbosityConfig): { summaries: ToolUsageSummary[]; filesModified: string[] } {
+function extractToolData(
+  messages: KimiMessage[],
+  config?: VerbosityConfig,
+): { summaries: ToolUsageSummary[]; filesModified: string[] } {
   const collector = new SummaryCollector(config);
 
   for (const msg of messages) {
@@ -181,11 +184,11 @@ function extractToolData(messages: KimiMessage[], config?: VerbosityConfig): { s
 
       switch (category) {
         case 'write': {
-          collector.add(
-            name,
-            fileSummary('write', fp, undefined, false),
-            { data: { category: 'write', filePath: fp }, filePath: fp, isWrite: true }
-          );
+          collector.add(name, fileSummary('write', fp, undefined, false), {
+            data: { category: 'write', filePath: fp },
+            filePath: fp,
+            isWrite: true,
+          });
           break;
         }
         case 'read':

--- a/src/parsers/kiro.ts
+++ b/src/parsers/kiro.ts
@@ -1,17 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type {
-  ConversationMessage,
-  SessionContext,
-  UnifiedSession,
-} from '../types/index.js';
+import type { ConversationMessage, SessionContext, UnifiedSession } from '../types/index.js';
 import { extractTextFromBlocks } from '../utils/content.js';
 import { findFiles, listSubdirectories } from '../utils/fs-helpers.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 
 // ── Kiro Session Shape ──────────────────────────────────────────────────────
 
@@ -35,13 +31,7 @@ interface KiroSession {
 
 // ── Base Path ───────────────────────────────────────────────────────────────
 // macOS: ~/Library/Application Support/Kiro/workspace-sessions/
-const KIRO_BASE_DIR = path.join(
-  homeDir(),
-  'Library',
-  'Application Support',
-  'Kiro',
-  'workspace-sessions',
-);
+const KIRO_BASE_DIR = path.join(homeDir(), 'Library', 'Application Support', 'Kiro', 'workspace-sessions');
 
 /**
  * Find all Kiro session JSON files.
@@ -175,9 +165,7 @@ export async function extractKiroContext(session: UnifiedSession, config?: Verbo
   const filesModified: string[] = [];
   const pendingTasks: string[] = [];
 
-  const enrichedSession = sessionData?.selectedModel
-    ? { ...session, model: sessionData.selectedModel }
-    : session;
+  const enrichedSession = sessionData?.selectedModel ? { ...session, model: sessionData.selectedModel } : session;
 
   const markdown = generateHandoffMarkdown(
     enrichedSession,

--- a/src/parsers/qwen-code.ts
+++ b/src/parsers/qwen-code.ts
@@ -11,8 +11,8 @@ import type {
   ToolUsageSummary,
   UnifiedSession,
 } from '../types/index.js';
-import { QwenChatRecordSchema } from '../types/schemas.js';
 import type { QwenChatRecord, QwenContent, QwenFileDiff, QwenPart } from '../types/schemas.js';
+import { QwenChatRecordSchema } from '../types/schemas.js';
 import { classifyToolName } from '../types/tool-names.js';
 import { listSubdirectories } from '../utils/fs-helpers.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import type { VerbosityConfig } from '../config/index.js';
-import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
+import type { SessionContext, SessionParseOptions, SessionSource, UnifiedSession } from '../types/index.js';
 import { TOOL_NAMES } from '../types/tool-names.js';
 import {
   type FlagOccurrence,
@@ -48,8 +48,10 @@ export interface ToolAdapter {
   envVar?: string;
   /** CLI binary name for availability checks and spawning */
   binaryName: string;
-  /** Discover and index all sessions */
-  parseSessions: () => Promise<UnifiedSession[]>;
+  /** Discover and index sessions. Parsers may ignore unsupported options. */
+  parseSessions: (options?: SessionParseOptions) => Promise<UnifiedSession[]>;
+  /** True when parseSessions({ cwd }) can avoid a full global scan. */
+  supportsCwdLookup?: boolean;
   /** Extract full context for cross-tool handoff */
   extractContext: (session: UnifiedSession, config?: VerbosityConfig) => Promise<SessionContext>;
   /** CLI args to resume a session natively */
@@ -664,6 +666,7 @@ register({
   envVar: 'CLAUDE_CONFIG_DIR',
   binaryName: 'claude',
   parseSessions: parseClaudeSessions,
+  supportsCwdLookup: true,
   extractContext: extractClaudeContext,
   nativeResumeArgs: (s) => ['--resume', s.id],
   crossToolArgs: (prompt) => [prompt],
@@ -681,9 +684,9 @@ register({
   binaryName: 'codex',
   parseSessions: parseCodexSessions,
   extractContext: extractCodexContext,
-  nativeResumeArgs: (s) => ['-c', `experimental_resume=${s.originalPath}`],
+  nativeResumeArgs: (s) => ['resume', s.id],
   crossToolArgs: (prompt) => [prompt],
-  resumeCommandDisplay: (s) => `codex -c experimental_resume="${s.originalPath}"`,
+  resumeCommandDisplay: (s) => `codex resume ${s.id}`,
   mapHandoffFlags: mapCodexFlags,
 });
 
@@ -693,6 +696,7 @@ register({
   label: 'GitHub Copilot CLI',
   color: chalk.green,
   storagePath: '~/.copilot/session-state/',
+  envVar: 'COPILOT_HOME',
   binaryName: 'copilot',
   parseSessions: parseCopilotSessions,
   extractContext: extractCopilotContext,
@@ -739,13 +743,13 @@ register({
   name: 'droid',
   label: 'Factory Droid',
   color: chalk.red,
-  storagePath: '~/.factory/sessions/',
+  storagePath: '~/.factory/projects/ (fallback: ~/.factory/sessions/)',
   binaryName: 'droid',
   parseSessions: parseDroidSessions,
   extractContext: extractDroidContext,
-  nativeResumeArgs: (s) => ['-s', s.id],
+  nativeResumeArgs: (s) => ['--resume', s.id],
   crossToolArgs: (prompt) => ['exec', prompt],
-  resumeCommandDisplay: (s) => `droid -s ${s.id}`,
+  resumeCommandDisplay: (s) => `droid --resume ${s.id}`,
   mapHandoffFlags: mapDroidFlags,
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,11 +3,11 @@
  */
 
 // Import SessionSource locally (used by UnifiedSession below) and re-export
-import type { SessionSource, ToolSampleCategory } from './tool-names.js';
+import type { SessionSource } from './tool-names.js';
 
 // Re-export shared content block types
 export type { ContentBlock, TextBlock, ThinkingBlock, ToolResultBlock, ToolUseBlock } from './content-blocks.js';
-export { type SessionSource, type ToolSampleCategory, TOOL_NAMES } from './tool-names.js';
+export { isSessionSource, type SessionSource, TOOL_NAMES, type ToolSampleCategory } from './tool-names.js';
 
 /** Unified session metadata */
 export interface UnifiedSession {
@@ -35,6 +35,16 @@ export interface UnifiedSession {
   originalPath: string;
   /** Model used in the session */
   model?: string;
+}
+
+/** Options for session discovery/indexing. Parsers may ignore unsupported filters. */
+export interface SessionParseOptions {
+  /** Restrict discovery to sessions matching this working directory when the storage layout supports it. */
+  cwd?: string;
+  /** Stop after collecting this many sessions when the parser can do so without changing sort semantics. */
+  limit?: number;
+  /** Favor fast picker/list metadata over exact counts or full timestamp scans. */
+  lightweight?: boolean;
 }
 
 /** Conversation message in normalized format */

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -119,6 +119,7 @@ export const CodexResponseItemSchema = z
         type: z.string().optional(),
         role: z.string().optional(),
         name: z.string().optional(),
+        namespace: z.string().optional(),
         arguments: z.string().optional(),
         call_id: z.string().optional(),
         input: z.string().optional(),
@@ -150,17 +151,33 @@ export const CodexTurnContextSchema = z
   })
   .passthrough();
 
+export const CodexCompactedSchema = z
+  .object({
+    timestamp: z.string(),
+    type: z.literal('compacted'),
+    payload: z
+      .object({
+        message: z.string().optional(),
+        replacement_history: z.unknown().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
 export const CodexMessageSchema = z.discriminatedUnion('type', [
   CodexSessionMetaSchema,
   CodexEventMsgSchema,
   CodexResponseItemSchema,
   CodexTurnContextSchema,
+  CodexCompactedSchema,
 ]);
 
 export type CodexSessionMeta = z.infer<typeof CodexSessionMetaSchema>;
 export type CodexEventMsg = z.infer<typeof CodexEventMsgSchema>;
 export type CodexResponseItem = z.infer<typeof CodexResponseItemSchema>;
 export type CodexTurnContext = z.infer<typeof CodexTurnContextSchema>;
+export type CodexCompacted = z.infer<typeof CodexCompactedSchema>;
 export type CodexMessage = z.infer<typeof CodexMessageSchema>;
 
 // ── Copilot ─────────────────────────────────────────────────────────────────

--- a/src/types/tool-names.ts
+++ b/src/types/tool-names.ts
@@ -26,6 +26,10 @@ export const TOOL_NAMES = Object.freeze([
 /** Source CLI tool — derived from TOOL_NAMES, never defined manually */
 export type SessionSource = (typeof TOOL_NAMES)[number];
 
+export function isSessionSource(value: string): value is SessionSource {
+  return (TOOL_NAMES as readonly string[]).includes(value);
+}
+
 // ── Canonical Tool Name Sets ────────────────────────────────────────────────
 // Used by all parsers to classify tool invocations consistently.
 // Each set contains all known aliases for a tool category across every CLI.
@@ -47,7 +51,14 @@ export const SHELL_TOOLS: ReadonlySet<string> = new Set([
 export const READ_TOOLS: ReadonlySet<string> = new Set(['Read', 'ReadFile', 'read_file']);
 
 /** File write/create tools */
-export const WRITE_TOOLS: ReadonlySet<string> = new Set(['Write', 'WriteFile', 'write_file', 'Create', 'create_file']);
+export const WRITE_TOOLS: ReadonlySet<string> = new Set([
+  'Write',
+  'WriteFile',
+  'write_file',
+  'Create',
+  'create',
+  'create_file',
+]);
 
 /** File edit/patch tools */
 export const EDIT_TOOLS: ReadonlySet<string> = new Set([
@@ -59,6 +70,8 @@ export const EDIT_TOOLS: ReadonlySet<string> = new Set([
   'apply_patch',
   'ApplyPatch',
   'replace',
+  'mcp__morph__edit_file',
+  'morph___edit_file',
 ]);
 
 /** Search/grep tools */
@@ -90,7 +103,7 @@ export const SEARCH_TOOLS: ReadonlySet<string> = new Set(['WebSearch', 'web_sear
 export const FETCH_TOOLS: ReadonlySet<string> = new Set(['WebFetch', 'web_fetch']);
 
 /** Subagent/task tools */
-export const TASK_TOOLS: ReadonlySet<string> = new Set(['Task', 'task']);
+export const TASK_TOOLS: ReadonlySet<string> = new Set(['Task', 'task', 'Agent']);
 
 /** Task output tools */
 export const TASK_OUTPUT_TOOLS: ReadonlySet<string> = new Set(['TaskOutput']);

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -35,12 +35,7 @@ export function formatNewFileDiff(content: string, filePath: string, maxLines = 
  * Since we have the exact replacement strings (not full files),
  * we format them as a hunk with `-` and `+` lines.
  */
-export function formatEditDiff(
-  oldStr: string,
-  newStr: string,
-  filePath: string,
-  maxLines = 200,
-): DiffResult {
+export function formatEditDiff(oldStr: string, newStr: string, filePath: string, maxLines = 200): DiffResult {
   const header = `--- a/${filePath}\n+++ b/${filePath}`;
   const oldLines = oldStr.split('\n');
   const newLines = newStr.split('\n');

--- a/src/utils/fs-helpers.ts
+++ b/src/utils/fs-helpers.ts
@@ -87,3 +87,29 @@ export function listSubdirectories(dir: string): string[] {
     return [];
   }
 }
+
+/**
+ * Map items with bounded async concurrency while preserving input order.
+ */
+export async function mapConcurrent<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+
+  const workerCount = Math.max(1, Math.min(concurrency, items.length));
+  const results: Array<{ index: number; value: R }> = [];
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex++;
+      results.push({ index, value: await mapper(items[index], index) });
+    }
+  });
+
+  await Promise.all(workers);
+  return results.sort((a, b) => a.index - b.index).map((result) => result.value);
+}

--- a/src/utils/fs-helpers.ts
+++ b/src/utils/fs-helpers.ts
@@ -99,17 +99,17 @@ export async function mapConcurrent<T, R>(
   if (items.length === 0) return [];
 
   const workerCount = Math.max(1, Math.min(concurrency, items.length));
-  const results: Array<{ index: number; value: R }> = [];
+  const results = new Array<R>(items.length);
   let nextIndex = 0;
 
   const workers = Array.from({ length: workerCount }, async () => {
     while (nextIndex < items.length) {
       const index = nextIndex;
       nextIndex++;
-      results.push({ index, value: await mapper(items[index], index) });
+      results[index] = await mapper(items[index], index);
     }
   });
 
   await Promise.all(workers);
-  return results.sort((a, b) => a.index - b.index).map((result) => result.value);
+  return results;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,11 +1,12 @@
 import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
+import type { VerbosityConfig } from '../config/index.js';
 import { logger } from '../logger.js';
 import { adapters } from '../parsers/registry.js';
-import type { VerbosityConfig } from '../config/index.js';
-import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
+import type { SessionContext, SessionParseOptions, SessionSource, UnifiedSession } from '../types/index.js';
 import { homeDir } from './parser-helpers.js';
+import { matchesCwd } from './slug.js';
 
 const CONTINUES_DIR = path.join(homeDir(), '.continues');
 const INDEX_FILE = path.join(CONTINUES_DIR, 'sessions.jsonl');
@@ -21,10 +22,12 @@ const ENV_FINGERPRINT_PREFIX = '#env:';
  * Build a fingerprint of environment variables that affect parser storage paths.
  * When any of these env vars change, the cached index must be rebuilt.
  */
-function computeEnvFingerprint(): string {
+function computeEnvFingerprint(source?: SessionSource): string {
   const seen = new Set<string>();
   const parts: string[] = [];
-  for (const adapter of Object.values(adapters)) {
+  const selectedAdapters = source ? [adapters[source]] : Object.values(adapters);
+  for (const adapter of selectedAdapters) {
+    if (!adapter) continue;
     if (adapter.envVar && !seen.has(adapter.envVar)) {
       seen.add(adapter.envVar);
       const val = process.env[adapter.envVar] || '';
@@ -38,9 +41,9 @@ function computeEnvFingerprint(): string {
 /**
  * Read the env fingerprint stored in the first line of the index file.
  */
-function readStoredFingerprint(): string | null {
+function readStoredFingerprint(indexFile: string): string | null {
   try {
-    const content = fs.readFileSync(INDEX_FILE, 'utf8');
+    const content = fs.readFileSync(indexFile, 'utf8');
     const firstLine = content.slice(0, content.indexOf('\n'));
     if (firstLine.startsWith(ENV_FINGERPRINT_PREFIX)) {
       return firstLine.slice(ENV_FINGERPRINT_PREFIX.length);
@@ -50,6 +53,25 @@ function readStoredFingerprint(): string | null {
     logger.debug('index: failed to read stored fingerprint', err);
     return null;
   }
+}
+
+function sourceIndexFile(source: SessionSource): string {
+  return path.join(CONTINUES_DIR, `sessions.${source}.jsonl`);
+}
+
+function serializeSessions(sessions: UnifiedSession[]): string[] {
+  return sessions.map((s) =>
+    JSON.stringify({
+      ...s,
+      createdAt: s.createdAt.toISOString(),
+      updatedAt: s.updatedAt.toISOString(),
+    }),
+  );
+}
+
+function writeIndexFile(indexFile: string, sessions: UnifiedSession[], source?: SessionSource): void {
+  const fingerprint = `${ENV_FINGERPRINT_PREFIX}${computeEnvFingerprint(source)}`;
+  fs.writeFileSync(indexFile, fingerprint + '\n' + serializeSessions(sessions).join('\n') + '\n');
 }
 
 /**
@@ -71,15 +93,16 @@ export function ensureDirectories(): void {
 /**
  * Check if index needs rebuilding
  */
-export function indexNeedsRebuild(): boolean {
+export function indexNeedsRebuild(source?: SessionSource): boolean {
+  const indexFile = source ? sourceIndexFile(source) : INDEX_FILE;
   try {
-    const stats = fs.statSync(INDEX_FILE);
+    const stats = fs.statSync(indexFile);
     const age = Date.now() - stats.mtime.getTime();
     if (age > INDEX_TTL) return true;
 
     // Rebuild if env vars affecting storage paths have changed
-    const stored = readStoredFingerprint();
-    if (stored !== computeEnvFingerprint()) {
+    const stored = readStoredFingerprint(indexFile);
+    if (stored !== computeEnvFingerprint(source)) {
       logger.debug('index: env fingerprint changed, rebuilding');
       return true;
     }
@@ -114,26 +137,58 @@ export async function buildIndex(force = false): Promise<UnifiedSession[]> {
   allSessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 
   // Write to index file — first line is the env fingerprint
-  const lines = allSessions.map((s) =>
-    JSON.stringify({
-      ...s,
-      createdAt: s.createdAt.toISOString(),
-      updatedAt: s.updatedAt.toISOString(),
-    }),
-  );
+  writeIndexFile(INDEX_FILE, allSessions);
 
-  const fingerprint = `${ENV_FINGERPRINT_PREFIX}${computeEnvFingerprint()}`;
-  fs.writeFileSync(INDEX_FILE, fingerprint + '\n' + lines.join('\n') + '\n');
+  const sessionsBySource = new Map<SessionSource, UnifiedSession[]>();
+  for (const session of allSessions) {
+    const sourceSessions = sessionsBySource.get(session.source) ?? [];
+    sourceSessions.push(session);
+    sessionsBySource.set(session.source, sourceSessions);
+  }
+  for (const [source, sourceSessions] of sessionsBySource) {
+    writeIndexFile(sourceIndexFile(source), sourceSessions, source);
+  }
 
   return allSessions;
 }
 
 /**
+ * Build or load the index for a single source without rebuilding every adapter.
+ */
+export async function buildSourceIndex(
+  source: SessionSource,
+  force = false,
+  parseOptions: SessionParseOptions = { lightweight: true },
+): Promise<UnifiedSession[]> {
+  ensureDirectories();
+
+  if (!force && !indexNeedsRebuild(source)) {
+    return loadIndex(source);
+  }
+
+  // If the global cache is fresh, derive the source cache from it instead of parsing.
+  if (!force && !indexNeedsRebuild()) {
+    const sourceSessions = loadIndex().filter((session) => session.source === source);
+    writeIndexFile(sourceIndexFile(source), sourceSessions, source);
+    return sourceSessions;
+  }
+
+  const adapter = adapters[source];
+  if (!adapter) return [];
+
+  const sessions = await adapter.parseSessions(parseOptions);
+  sessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  writeIndexFile(sourceIndexFile(source), sessions, source);
+  return sessions;
+}
+
+/**
  * Load sessions from the index file
  */
-export function loadIndex(): UnifiedSession[] {
+export function loadIndex(source?: SessionSource): UnifiedSession[] {
+  const indexFile = source ? sourceIndexFile(source) : INDEX_FILE;
   try {
-    const content = fs.readFileSync(INDEX_FILE, 'utf8');
+    const content = fs.readFileSync(indexFile, 'utf8');
     const lines = content
       .trim()
       .split('\n')
@@ -155,7 +210,7 @@ export function loadIndex(): UnifiedSession[] {
       }
     });
   } catch (err) {
-    logger.debug('index: cannot read cache file', INDEX_FILE, err);
+    logger.debug('index: cannot read cache file', indexFile, err);
     return []; // File doesn't exist or can't be read
   }
 }
@@ -171,8 +226,27 @@ export async function getAllSessions(forceRebuild = false): Promise<UnifiedSessi
  * Get sessions filtered by source
  */
 export async function getSessionsBySource(source: SessionSource, forceRebuild = false): Promise<UnifiedSession[]> {
-  const all = await getAllSessions(forceRebuild);
-  return all.filter((s) => s.source === source);
+  return buildSourceIndex(source, forceRebuild, { lightweight: true });
+}
+
+/**
+ * Get current-working-directory sessions from sources that support direct cwd lookup.
+ */
+export async function getSessionsByCwd(cwd: string, forceRebuild = false): Promise<UnifiedSession[]> {
+  if (!forceRebuild && !indexNeedsRebuild()) {
+    return loadIndex().filter((session) => matchesCwd(session.cwd, cwd));
+  }
+
+  const cwdLookupAdapters = Object.values(adapters).filter((adapter) => adapter.supportsCwdLookup);
+  const results = await Promise.allSettled(
+    cwdLookupAdapters.map((adapter) => adapter.parseSessions({ cwd, lightweight: true })),
+  );
+
+  return results
+    .filter((result): result is PromiseFulfilledResult<UnifiedSession[]> => result.status === 'fulfilled')
+    .flatMap((result) => result.value)
+    .filter((session) => matchesCwd(session.cwd, cwd))
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 }
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,8 +2,9 @@ import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { VerbosityConfig } from '../config/index.js';
+import { UnknownSourceError } from '../errors.js';
 import { logger } from '../logger.js';
-import { adapters } from '../parsers/registry.js';
+import { ALL_TOOLS, adapters } from '../parsers/registry.js';
 import type { SessionContext, SessionParseOptions, SessionSource, UnifiedSession } from '../types/index.js';
 import { homeDir } from './parser-helpers.js';
 import { matchesCwd } from './slug.js';
@@ -145,8 +146,8 @@ export async function buildIndex(force = false): Promise<UnifiedSession[]> {
     sourceSessions.push(session);
     sessionsBySource.set(session.source, sourceSessions);
   }
-  for (const [source, sourceSessions] of sessionsBySource) {
-    writeIndexFile(sourceIndexFile(source), sourceSessions, source);
+  for (const source of ALL_TOOLS) {
+    writeIndexFile(sourceIndexFile(source), sessionsBySource.get(source) ?? [], source);
   }
 
   return allSessions;
@@ -230,23 +231,11 @@ export async function getSessionsBySource(source: SessionSource, forceRebuild = 
 }
 
 /**
- * Get current-working-directory sessions from sources that support direct cwd lookup.
+ * Get current-working-directory sessions from the complete index.
  */
 export async function getSessionsByCwd(cwd: string, forceRebuild = false): Promise<UnifiedSession[]> {
-  if (!forceRebuild && !indexNeedsRebuild()) {
-    return loadIndex().filter((session) => matchesCwd(session.cwd, cwd));
-  }
-
-  const cwdLookupAdapters = Object.values(adapters).filter((adapter) => adapter.supportsCwdLookup);
-  const results = await Promise.allSettled(
-    cwdLookupAdapters.map((adapter) => adapter.parseSessions({ cwd, lightweight: true })),
-  );
-
-  return results
-    .filter((result): result is PromiseFulfilledResult<UnifiedSession[]> => result.status === 'fulfilled')
-    .flatMap((result) => result.value)
-    .filter((session) => matchesCwd(session.cwd, cwd))
-    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  const sessions = await buildIndex(forceRebuild);
+  return sessions.filter((session) => matchesCwd(session.cwd, cwd));
 }
 
 /**
@@ -262,7 +251,7 @@ export async function findSession(id: string): Promise<UnifiedSession | null> {
  */
 export async function extractContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const adapter = adapters[session.source];
-  if (!adapter) throw new Error(`Unknown session source: ${session.source}`);
+  if (!adapter) throw new UnknownSourceError(session.source);
   return adapter.extractContext(session, config);
 }
 

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -168,6 +168,32 @@ export async function scanJsonlHead(
 }
 
 /**
+ * Scan every parsed JSONL line, calling `visitor` for each valid record.
+ * The visitor returns 'continue' to keep reading or 'stop' to abort early.
+ */
+export async function scanJsonlFile(
+  filePath: string,
+  visitor: (parsed: unknown, lineIndex: number) => 'continue' | 'stop',
+  options?: JsonlReadOptions,
+): Promise<void> {
+  if (!fs.existsSync(filePath)) return;
+
+  await scanJsonlLines(
+    filePath,
+    (line, lineIndex) => {
+      try {
+        const parsed = JSON.parse(line);
+        return visitor(parsed, lineIndex);
+      } catch (err) {
+        logger.debug('jsonl: skipping invalid line at index', lineIndex, 'in', filePath, err);
+      }
+      return 'continue';
+    },
+    options,
+  );
+}
+
+/**
  * Count lines in a file and return both count and file size in bytes.
  * Used by multiple parsers for session metadata.
  */

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -158,8 +158,8 @@ export async function scanJsonlHead(
       try {
         const parsed = JSON.parse(line);
         return visitor(parsed, lineIndex);
-      } catch (err) {
-        logger.debug('jsonl: skipping invalid line at index', lineIndex, 'in', filePath, err);
+      } catch {
+        logger.debug('jsonl: skipping invalid line at index', lineIndex, 'in', filePath);
       }
       return 'continue';
     },
@@ -184,8 +184,8 @@ export async function scanJsonlFile(
       try {
         const parsed = JSON.parse(line);
         return visitor(parsed, lineIndex);
-      } catch (err) {
-        logger.debug('jsonl: skipping invalid line at index', lineIndex, 'in', filePath, err);
+      } catch {
+        logger.debug('jsonl: skipping invalid line at index', lineIndex, 'in', filePath);
       }
       return 'continue';
     },

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,31 +1,30 @@
-import { adapters } from '../parsers/registry.js';
 import * as os from 'os';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
+import { adapters } from '../parsers/registry.js';
 import type {
   ConversationMessage,
+  ReasoningStep,
   SessionNotes,
   SubagentResult,
-  ReasoningStep,
-  StructuredToolSample,
   ToolSample,
   ToolUsageSummary,
   UnifiedSession,
 } from '../types/index.js';
 import {
-  SHELL_TOOLS,
-  READ_TOOLS,
-  WRITE_TOOLS,
-  EDIT_TOOLS,
-  GREP_TOOLS,
-  GLOB_TOOLS,
-  SEARCH_TOOLS,
-  FETCH_TOOLS,
-  TASK_TOOLS,
-  TASK_OUTPUT_TOOLS,
   ASK_TOOLS,
   classifyToolName,
+  EDIT_TOOLS,
+  FETCH_TOOLS,
+  GLOB_TOOLS,
+  GREP_TOOLS,
+  READ_TOOLS,
+  SEARCH_TOOLS,
+  SHELL_TOOLS,
+  TASK_OUTPUT_TOOLS,
+  TASK_TOOLS,
+  WRITE_TOOLS,
 } from '../types/tool-names.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 
 /** Replace home directory prefix with ~ and escape backticks for safe markdown inline code */
 const _home = os.homedir();
@@ -648,11 +647,7 @@ function renderGlobSection(tool: ToolUsageSummary, caps: DisplayCaps): string[] 
 
 // ── Compact Renderer (Search, Fetch, Task, Ask, MCP) ────────────────────────
 
-function renderCompactSection(
-  tool: ToolUsageSummary,
-  category: string,
-  caps: DisplayCaps,
-): string[] {
+function renderCompactSection(tool: ToolUsageSummary, category: string, caps: DisplayCaps): string[] {
   const label = COMPACT_LABELS[category] || tool.name;
   const errorStr = tool.errorCount ? `, ${tool.errorCount} errors` : '';
   const lines: string[] = [`### ${label} (${tool.count} calls${errorStr})`, ''];

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -12,6 +12,4 @@ export const IS_WINDOWS = process.platform === 'win32';
 export const WHICH_CMD = IS_WINDOWS ? 'where' : 'which';
 
 /** Spread into `spawn`/`spawnSync` options to enable shell on Windows */
-export const SHELL_OPTION: { shell: boolean } | Record<string, never> = IS_WINDOWS
-  ? { shell: true }
-  : {};
+export const SHELL_OPTION: { shell: boolean } | Record<string, never> = IS_WINDOWS ? { shell: true } : {};

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -31,7 +31,8 @@ export function resolveCrossToolForwarding(
   options?: HandoffForwardingOptions,
 ): ForwardResolution {
   const adapter = adapters[target];
-  return resolveTargetForwarding(target, adapter?.mapHandoffFlags, options);
+  if (!adapter) throw new Error(`Unknown target: ${target}`);
+  return resolveTargetForwarding(target, adapter.mapHandoffFlags, options);
 }
 
 function hasConfigOverride(args: string[], key: string): boolean {
@@ -127,6 +128,9 @@ export async function crossToolResume(
   forwarding?: HandoffForwardingOptions,
   contextOptions?: HandoffContextOptions,
 ): Promise<void> {
+  const adapter = adapters[target];
+  if (!adapter) throw new Error(`Unknown target: ${target}`);
+
   const context = await extractContext(session, resolveHandoffConfig(contextOptions));
   const cwd = session.cwd || process.cwd();
 
@@ -156,9 +160,6 @@ export async function crossToolResume(
     : mode === 'inline'
       ? buildInlinePrompt(context, session)
       : buildReferencePrompt(session);
-
-  const adapter = adapters[target];
-  if (!adapter) throw new Error(`Unknown target: ${target}`);
 
   if (contextOptions?.debugPrompt) {
     console.log(prompt);
@@ -327,9 +328,11 @@ export function getResumeCommand(
   forwarding?: HandoffForwardingOptions,
 ): string {
   const actualTarget = target || session.source;
+  const actualAdapter = adapters[actualTarget];
+  if (!actualAdapter) throw new Error(`Unknown target: ${actualTarget}`);
 
   if (actualTarget === session.source) {
-    return adapters[session.source].resumeCommandDisplay(session);
+    return actualAdapter.resumeCommandDisplay(session);
   }
 
   const resolved = resolveCrossToolForwarding(actualTarget, forwarding);

--- a/src/utils/resume.ts
+++ b/src/utils/resume.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset, loadConfig } from '../config/index.js';
-import { ToolNotAvailableError } from '../errors.js';
+import { ToolNotAvailableError, UnknownSourceError } from '../errors.js';
 import { logger } from '../logger.js';
 import { ALL_TOOLS, adapters } from '../parsers/registry.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
@@ -38,7 +38,7 @@ export function resolveCrossToolForwarding(
   options?: HandoffForwardingOptions,
 ): ForwardResolution {
   const adapter = adapters[target];
-  if (!adapter) throw new Error(`Unknown target: ${target}`);
+  if (!adapter) throw new UnknownSourceError(target);
   return resolveTargetForwarding(target, adapter.mapHandoffFlags, options);
 }
 
@@ -121,7 +121,7 @@ function resolveHandoffConfig(options?: HandoffContextOptions): VerbosityConfig 
 export async function nativeResume(session: UnifiedSession): Promise<void> {
   const cwd = session.cwd || process.cwd();
   const adapter = adapters[session.source];
-  if (!adapter) throw new Error(`Unknown session source: ${session.source}`);
+  if (!adapter) throw new UnknownSourceError(session.source);
   const binaryName = await requireToolBinaryName(session.source);
   await runCommand(binaryName, adapter.nativeResumeArgs(session), cwd);
 }
@@ -137,7 +137,7 @@ export async function crossToolResume(
   contextOptions?: HandoffContextOptions,
 ): Promise<void> {
   const adapter = adapters[target];
-  if (!adapter) throw new Error(`Unknown target: ${target}`);
+  if (!adapter) throw new UnknownSourceError(target);
 
   const context = await extractContext(session, resolveHandoffConfig(contextOptions));
   const cwd = session.cwd || process.cwd();
@@ -352,7 +352,7 @@ export function getResumeCommand(
 ): string {
   const actualTarget = target || session.source;
   const actualAdapter = adapters[actualTarget];
-  if (!actualAdapter) throw new Error(`Unknown target: ${actualTarget}`);
+  if (!actualAdapter) throw new UnknownSourceError(actualTarget);
 
   if (actualTarget === session.source) {
     return actualAdapter.resumeCommandDisplay(session);

--- a/src/utils/tool-extraction.ts
+++ b/src/utils/tool-extraction.ts
@@ -2,6 +2,9 @@
  * Shared tool extraction for parsers using Anthropic-style content blocks
  * (tool_use / tool_result). Used by Claude, Droid, and Cursor parsers.
  */
+
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
 import type {
   AskSampleData,
   EditSampleData,
@@ -13,13 +16,10 @@ import type {
   ReasoningSampleData,
   SearchSampleData,
   ShellSampleData,
-  StructuredToolSample,
   TaskSampleData,
   ToolUsageSummary,
   WriteSampleData,
 } from '../types/index.js';
-import type { VerbosityConfig } from '../config/index.js';
-import { getPreset } from '../config/index.js';
 import {
   ASK_TOOLS,
   EDIT_TOOLS,
@@ -144,7 +144,7 @@ export function extractAnthropicToolData(
       const entry = tu.id ? toolResultMap.get(tu.id) : undefined;
       const result = entry?.text;
       const isError = entry?.isError ?? false;
-      const fp = (input.file_path as string) || (input.path as string) || '';
+      const fp = getInputString(input, 'file_path') || getInputString(input, 'path');
 
       if (SHELL_TOOLS.has(name)) {
         const cmd = (input.command as string) || (input.cmd as string) || '';
@@ -179,11 +179,11 @@ export function extractAnthropicToolData(
           filePath: fp,
         });
       } else if (WRITE_TOOLS.has(name)) {
-        const content = (input.content as string) || '';
+        const content = getInputString(input, 'content') || getInputString(input, 'file_text');
         let diff: string | undefined;
         let diffStats: { added: number; removed: number } | undefined;
         // Derive isNewFile from context: tool name hints, result text, or leave undefined
-        const isNewFile = ['Create', 'create_file'].includes(name)
+        const isNewFile = ['Create', 'create', 'create_file'].includes(name)
           ? true
           : result && /\b(created|new file|overwr)/i.test(result)
             ? /\b(created|new file)\b/i.test(result)
@@ -211,31 +211,39 @@ export function extractAnthropicToolData(
           isError,
         });
       } else if (EDIT_TOOLS.has(name)) {
-        const oldStr = (input.old_string as string) || '';
-        const newStr = (input.new_string as string) || '';
+        const oldStr = getInputString(input, 'old_string') || getInputString(input, 'old_str');
+        const newStr = getInputString(input, 'new_string') || getInputString(input, 'new_str');
+        const patchText =
+          getInputString(input, 'input') || getInputString(input, 'patch') || getInputString(input, 'content');
+        const patchFiles = patchText ? extractPatchFilePaths(patchText) : [];
+        const targetPath = fp || patchFiles[0] || '';
         let diff: string | undefined;
         let diffStats: { added: number; removed: number } | undefined;
 
         if (oldStr || newStr) {
-          const diffResult = formatEditDiff(oldStr, newStr, fp, 200);
+          const diffResult = formatEditDiff(oldStr, newStr, targetPath, 200);
           diff = diffResult.diff;
+          diffStats = countDiffStats(diff);
+        } else if (patchText && patchFiles.length > 0) {
+          diff = patchText;
           diffStats = countDiffStats(diff);
         }
 
         const editErrorMsg = isError && result ? result.slice(0, config.edit.maxChars) : undefined;
         const data: EditSampleData = {
           category: 'edit',
-          filePath: fp,
+          filePath: targetPath,
           ...(diff ? { diff } : {}),
           ...(diffStats ? { diffStats } : {}),
           ...(editErrorMsg ? { errorMessage: editErrorMsg } : {}),
         };
-        collector.add(name, withResult(fileSummary('edit', fp, diffStats), result?.slice(0, 80)), {
+        collector.add(name, withResult(fileSummary('edit', targetPath, diffStats), result?.slice(0, 80)), {
           data,
-          filePath: fp,
+          filePath: targetPath,
           isWrite: true,
           isError,
         });
+        for (const patchFile of patchFiles) collector.trackFile(patchFile);
       } else if (GREP_TOOLS.has(name)) {
         const pattern = (input.pattern as string) || (input.query as string) || '';
         const targetPath = (input.path as string) || '';
@@ -308,11 +316,12 @@ export function extractAnthropicToolData(
           const thought = truncate((input.thought as string) || '', maxChars);
           const outcome = truncate((input.outcome as string) || '', maxChars);
           const rawNextAction = input.next_action;
-          const nextAction = typeof rawNextAction === 'string'
-            ? truncate(rawNextAction, maxChars)
-            : rawNextAction
-              ? truncate(JSON.stringify(rawNextAction), maxChars)
-              : undefined;
+          const nextAction =
+            typeof rawNextAction === 'string'
+              ? truncate(rawNextAction, maxChars)
+              : rawNextAction
+                ? truncate(JSON.stringify(rawNextAction), maxChars)
+                : undefined;
           const stepNumber = typeof input.step_number === 'number' ? input.step_number : undefined;
 
           const data: ReasoningSampleData = {
@@ -333,16 +342,11 @@ export function extractAnthropicToolData(
             ...(params ? { params } : {}),
             ...(result ? { result: result.slice(0, config.mcp.resultChars) } : {}),
           };
-          collector.add(name, mcpSummary(name, JSON.stringify(input).slice(0, config.mcp.paramChars), result?.slice(0, 80)), { data });
-
-          // Some MCP tools mutate local files (e.g. mcp__morph__edit_file).
-          // Track those paths in filesModified so handoff reflects all edits.
-          if (name === 'mcp__morph__edit_file') {
-            const mcpPath = (input.path as string) || (input.file_path as string) || '';
-            if (mcpPath) {
-              collector.trackFile(mcpPath);
-            }
-          }
+          collector.add(
+            name,
+            mcpSummary(name, JSON.stringify(input).slice(0, config.mcp.paramChars), result?.slice(0, 80)),
+            { data },
+          );
         }
       } else {
         // Generic/unknown tool — treat as MCP-like
@@ -353,9 +357,13 @@ export function extractAnthropicToolData(
           ...(params ? { params } : {}),
           ...(result ? { result: result.slice(0, config.mcp.resultChars) } : {}),
         };
-        collector.add(name, withResult(`${name}(${JSON.stringify(input).slice(0, config.mcp.paramChars)})`, result?.slice(0, 80)), {
-          data,
-        });
+        collector.add(
+          name,
+          withResult(`${name}(${JSON.stringify(input).slice(0, config.mcp.paramChars)})`, result?.slice(0, 80)),
+          {
+            data,
+          },
+        );
       }
     }
   }
@@ -370,11 +378,27 @@ export function isThinkingTool(name: string): boolean {
   return name.toLowerCase().includes('think');
 }
 
+function getInputString(input: Record<string, unknown>, key: string): string {
+  const value = input[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function extractPatchFilePaths(patch: string): string[] {
+  const paths = new Set<string>();
+  for (const line of patch.split('\n')) {
+    const match = line.match(/^\*\*\* (?:Add|Update|Delete) File: (.+)$/) || line.match(/^[-+]{3}\s+(?:[ab]\/)?(.+)$/);
+    if (!match?.[1]) continue;
+    const filePath = match[1].trim();
+    if (filePath && filePath !== '/dev/null') paths.add(filePath);
+  }
+  return Array.from(paths);
+}
+
 /** Truncate each param value to maxChars and format as compact string */
 function truncateParams(input: Record<string, unknown>, maxChars = 100): string {
   const parts: string[] = [];
   for (const [key, val] of Object.entries(input)) {
-    const str = typeof val === 'string' ? val : JSON.stringify(val) ?? '';
+    const str = typeof val === 'string' ? val : (JSON.stringify(val) ?? '');
     parts.push(`${key}=${truncate(str, maxChars)}`);
   }
   return parts.join(', ');
@@ -382,19 +406,15 @@ function truncateParams(input: Record<string, unknown>, maxChars = 100): string 
 
 /** Parse match count from grep result text — returns undefined if ambiguous */
 function parseMatchCount(result: string): number | undefined {
-  const m =
-    result.match(/(?:found|matched)\s+(\d+)/i) ||
-    result.match(/(\d+)\s+(?:match|result|hit)/i);
-  if (m) return parseInt(m[1]);
+  const m = result.match(/(?:found|matched)\s+(\d+)/i) || result.match(/(\d+)\s+(?:match|result|hit)/i);
+  if (m) return parseInt(m[1], 10);
   return undefined;
 }
 
 /** Parse file count from glob result text — returns undefined if ambiguous */
 function parseFileCount(result: string): number | undefined {
-  const m =
-    result.match(/(?:found|returned)\s+(\d+)/i) ||
-    result.match(/(\d+)\s+(?:file|match|result|entr)/i);
-  if (m) return parseInt(m[1]);
+  const m = result.match(/(?:found|returned)\s+(\d+)/i) || result.match(/(\d+)\s+(?:file|match|result|entr)/i);
+  if (m) return parseInt(m[1], 10);
   return undefined;
 }
 

--- a/src/utils/tool-extraction.ts
+++ b/src/utils/tool-extraction.ts
@@ -225,7 +225,7 @@ export function extractAnthropicToolData(
           diff = diffResult.diff;
           diffStats = countDiffStats(diff);
         } else if (patchText && patchFiles.length > 0) {
-          diff = patchText;
+          diff = truncate(patchText, config.edit.maxChars);
           diffStats = countDiffStats(diff);
         }
 
@@ -386,7 +386,9 @@ function getInputString(input: Record<string, unknown>, key: string): string {
 function extractPatchFilePaths(patch: string): string[] {
   const paths = new Set<string>();
   for (const line of patch.split('\n')) {
-    const match = line.match(/^\*\*\* (?:Add|Update|Delete) File: (.+)$/) || line.match(/^[-+]{3}\s+(?:[ab]\/)?(.+)$/);
+    const match =
+      line.match(/^\*\*\* (?:Add|Update|Delete) File: ([^\t\r\n]+)/) ||
+      line.match(/^[-+]{3}\s+(?:[ab]\/)?([^\t\r\n]+)/);
     if (!match?.[1]) continue;
     const filePath = match[1].trim();
     if (filePath && filePath !== '/dev/null') paths.add(filePath);

--- a/src/utils/tool-summarizer.ts
+++ b/src/utils/tool-summarizer.ts
@@ -3,9 +3,10 @@
  * Each parser normalizes its raw tool events and uses these utilities
  * for consistent, concise summaries across all 7 CLIs.
  */
-import type { StructuredToolSample, ToolSample, ToolUsageSummary } from '../types/index.js';
+
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
+import type { StructuredToolSample, ToolSample, ToolUsageSummary } from '../types/index.js';
 
 // ── Formatting Helpers ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
# fix(parsers): close P1 resume, extraction, and loading gaps

## Summary
This PR fixes the P1 parser/resume issues captured in the new audit note and adds a faster session-loading path for source-filtered and cwd-local workflows. It corrects native resume commands, validates cross-tool targets before handoff extraction, strengthens Claude/Codex/Copilot/Droid parsing, and adds regression coverage for the previously fragile cases. It also includes a mechanical Biome formatting pass so the touched code stays consistent after the behavioral fixes.

## Context / Why now
`continues` depends on local tool storage formats that have shifted across Claude, Codex, Copilot, and Droid. The audit in `agent-docs/2026-04-27-p1-parser-debug-audit.md` records the concrete P1 failures: obsolete native resume args, stale cache invalidation, missing compact summaries, dropped tail conversation, missed file edits, timestamp/recency bugs, and expensive all-source session loading. The goal here is to make resume/handoff behavior correct first, then reduce picker/source-list latency without adding runtime dependencies or writing to source tool storage.

## The 5 items

### Item 1: Audit record and focused regression coverage
- Files: `agent-docs/*`, parser/resume/cache/shared utility tests under `src/__tests__/`.
- What: Added an agent-readable audit note for the P1 findings and tests for Claude, Codex, Copilot, Droid, forwarding flags, resume debug paths, env cache invalidation, source-scoped index loading, schemas, and shared JSONL/tool utilities.
- Why this shape: The parser formats are external and time-sensitive, so the PR records the evidence and locks the fixes with direct fixtures instead of relying on broad e2e tests that require developer-local session files.
- Verified by: targeted Vitest runs, full `pnpm test`, and `pnpm run check`.

### Item 2: Resume command correctness and earlier target validation
- Files: `src/parsers/registry.ts`, `src/commands/resume-cmd.ts`, `src/utils/resume.ts`, `src/types/tool-names.ts`.
- What: Updated Codex native resume to `codex resume <id>`, Droid native resume to `droid --resume <id>`, added `COPILOT_HOME` to cache fingerprinting, and reject invalid `--in` targets before context extraction or handoff file writes.
- Why this shape: Failing before extraction avoids writing `.continues-handoff.md` or global context cache for an invalid target. Keeping command definitions in the registry preserves the existing adapter-driven design.
- Verified by: `resume-command-debug.test.ts`, `resume-debug-prompt.test.ts`, `forward-flags.test.ts`, and full tests.

### Item 3: Parser extraction and recency fixes
- Files: `src/parsers/claude.ts`, `src/parsers/codex.ts`, `src/parsers/copilot.ts`, `src/parsers/droid.ts`, `src/utils/tool-extraction.ts`, `src/types/schemas.ts`, `src/utils/jsonl.ts`.
- What: Claude now preserves recent real conversation when tool/thinking rows dominate the tail, uses transcript timestamps for ordering, and extracts Agent sidecar results. Codex now handles compacted rollout records, namespaced edit tools, and `write_stdin.chars`. Copilot parses through noisy tails before trimming and recognizes lowercase `create` as a write. Droid now discovers documented project roots, dedupes fallback sessions, uses true latest timestamps, and captures patch/edit forms through shared Anthropic-style extraction.
- Why this shape: Most fixes are parser-local, but edit/write classification belongs in shared utilities so the same vocabulary applies across tool families.
- Verified by: parser-specific tests for Claude/Codex/Copilot/Droid plus `shared-utils.test.ts`.

### Item 4: Faster source and cwd session loading
- Files: `src/utils/index.ts`, `src/commands/pick.ts`, `src/utils/fs-helpers.ts`, `src/types/index.ts`, `src/parsers/claude.ts`, `src/parsers/codex.ts`, `src/__tests__/index-source-cache.test.ts`.
- What: Added `SessionParseOptions`, source-scoped cache files, `getSessionsByCwd()`, adapter `supportsCwdLookup`, bounded parser concurrency, and lightweight Claude/Codex parser paths that skip exact line counts/full timestamp scans for picker/list metadata.
- Why this shape: The immediate latency problem came from rebuilding every source and reading too much metadata for picker display. A source-scoped cache and cwd-first picker path remove that global work without introducing native binaries or new dependencies.
- Verified by: `index-source-cache.test.ts`; local timing check showed Codex source lightweight rebuild found 1589 sessions in about 398ms.

### Item 5: Mechanical formatting and display cleanup
- Files: `src/commands/dump.ts`, `src/commands/inspect.ts`, `src/config/*`, `src/display/star-prompt.ts`, parsers for Amp/Cline/Crush/Kimi/Kiro/Qwen, `src/utils/diff.ts`, `src/utils/markdown.ts`, `src/utils/platform.ts`, `src/utils/tool-summarizer.ts`, `src/__tests__/e2e-conversions.test.ts`, `src/__tests__/extract-handoffs.ts`.
- What: Applied Biome-safe formatting and small consistency cleanups around output helpers, parser exports, inspection rendering, and test scripts.
- Why this shape: The functional parser fixes touched adjacent utility surfaces; the mechanical commit keeps formatting churn separate from the behavioral commit for review.
- Verified by: `pnpm run check`.

## Files touched

| File | +/- | Purpose |
|---|---:|---|
| `agent-docs/2026-04-27-p1-parser-debug-audit.md` | +100/-0 | Source-backed audit of P1 parser/resume issues and fix status |
| `agent-docs/README.md` | +11/-0 | Index for follow-up agent notes |
| `src/__tests__/claude-parser.test.ts` | +103/-0 | Claude parser regression coverage |
| `src/__tests__/claude-task-reconciliation.test.ts` | +89/-1 | Claude task/subagent reconciliation coverage |
| `src/__tests__/codex-parser.test.ts` | +133/-0 | Codex compaction/edit/stdin coverage |
| `src/__tests__/copilot-parser.test.ts` | +121/-0 | Copilot noisy-tail/write coverage |
| `src/__tests__/droid-parser.test.ts` | +112/-0 | Droid roots/dedupe/recency coverage |
| `src/__tests__/e2e-conversions.test.ts` | +33/-16 | Biome-safe formatting/cleanup in e2e helper |
| `src/__tests__/env-cache-invalidation.test.ts` | +32/-33 | Env fingerprint regression cleanup plus Copilot env coverage |
| `src/__tests__/extract-handoffs.ts` | +32/-15 | Formatting/cleanup for handoff extraction helper |
| `src/__tests__/forward-flags.test.ts` | +43/-0 | Registry/native command and forwarding validation coverage |
| `src/__tests__/index-source-cache.test.ts` | +90/-0 | Source-scoped cache and cwd lookup regression coverage |
| `src/__tests__/resume-command-debug.test.ts` | +20/-0 | Invalid target and debug prompt command coverage |
| `src/__tests__/resume-debug-prompt.test.ts` | +11/-0 | Debug-prompt handoff coverage |
| `src/__tests__/schemas.test.ts` | +41/-4 | Schema updates for newly observed fields |
| `src/__tests__/shared-utils.test.ts` | +102/-1 | JSONL/tool extraction/shared helper coverage |
| `src/commands/dump.ts` | +5/-4 | Formatting/cleanup |
| `src/commands/inspect.ts` | +19/-58 | Inspection rendering cleanup |
| `src/commands/pick.ts` | +32/-11 | Cwd-first loading and lazy global session loading |
| `src/commands/resume-cmd.ts` | +11/-2 | Validate `--in` before extraction/writes |
| `src/config/index.ts` | +1/-1 | Formatting consistency |
| `src/config/verbosity.ts` | +5/-2 | Formatting consistency |
| `src/display/star-prompt.ts` | +6/-9 | Formatting consistency |
| `src/parsers/amp.ts` | +6/-4 | Formatting consistency |
| `src/parsers/claude.ts` | +241/-103 | Claude metadata loading, recency, tail trimming, Agent result extraction |
| `src/parsers/cline.ts` | +21/-20 | Formatting consistency |
| `src/parsers/codex.ts` | +57/-17 | Lightweight parsing, compacted records, edit/stdin extraction |
| `src/parsers/copilot.ts` | +4/-4 | Parse-before-trim and write classification support |
| `src/parsers/crush.ts` | +4/-12 | Formatting consistency |
| `src/parsers/droid.ts` | +48/-29 | Root discovery, dedupe, recency, model/settings handling |
| `src/parsers/index.ts` | +13/-10 | Export formatting consistency |
| `src/parsers/kimi.ts` | +15/-12 | Formatting consistency |
| `src/parsers/kiro.ts` | +5/-17 | Formatting consistency |
| `src/parsers/qwen-code.ts` | +1/-1 | Formatting consistency |
| `src/parsers/registry.ts` | +12/-8 | Parse options contract, native command fixes, env metadata |
| `src/types/index.ts` | +12/-2 | `SessionParseOptions` and source guard export |
| `src/types/schemas.ts` | +17/-0 | Schema support for observed parser fields |
| `src/types/tool-names.ts` | +15/-2 | Tool classification/source guard updates |
| `src/utils/diff.ts` | +1/-6 | Formatting consistency |
| `src/utils/fs-helpers.ts` | +26/-0 | Bounded concurrency helper |
| `src/utils/index.ts` | +98/-24 | Source-scoped indexes, cwd lookup, cache fingerprinting |
| `src/utils/jsonl.ts` | +26/-0 | Whole-file JSONL scanner helper |
| `src/utils/markdown.ts` | +13/-18 | Formatting/rendering cleanup |
| `src/utils/platform.ts` | +1/-3 | Formatting consistency |
| `src/utils/resume.ts` | +8/-5 | Earlier adapter validation and command display guard |
| `src/utils/tool-extraction.ts` | +59/-39 | Shared edit/write/patch extraction improvements |
| `src/utils/tool-summarizer.ts` | +2/-1 | Formatting/lint cleanup |

## Verification

- Automated: `pnpm exec vitest run src/__tests__/index-source-cache.test.ts src/__tests__/env-cache-invalidation.test.ts` passed.
- Automated: `pnpm exec tsc --noEmit` passed.
- Automated: `pnpm test` passed: 20 test files, 768 passed, 2 skipped.
- Automated: `pnpm run check` passed with exit 0.
- Manual/local timing: `getSessionsBySource('codex', true)` returned 1589 sessions in about 398ms on this machine using the lightweight source path.
- Not verified: live resume against every external CLI binary. The PR verifies command construction and parser behavior, but does not launch all target tools because that depends on locally installed/authenticated CLIs.

## Weaknesses and open questions

1. **Important: source-scoped lightweight indexes set some `lines` values to `0`.** Picker/list display does not currently need exact line counts, but API consumers calling `getSessionsBySource()` might have been using `lines` as a proxy for transcript length. Reviewer: should source-scoped list APIs prefer exact counts even if that reintroduces latency, or is lightweight metadata the correct default?
2. **Important: direct cwd lookup is currently opt-in and only Claude advertises `supportsCwdLookup`.** This keeps the risky path narrow, but users with Codex-heavy workspaces still need source/global fallback for cwd filtering. Reviewer: please explain in depth whether we should add Codex cwd lookup now despite its filename/date tree layout, or keep this PR’s conservative rollout.
3. **Minor: the PR includes a mechanical formatting commit after the behavioral parser commit.** That keeps functional review cleaner by commit, but it broadens the file list. Reviewer: focus behavioral review on `fix(parsers): close P1 resume and extraction gaps`; the `chore(lint)` commit should be checked for accidental semantic drift.

## Request to the reviewer

Please review the parser correctness changes first, especially Claude `Agent` sidecar extraction, Codex compacted/edit handling, and Droid root dedupe/recency. The design question I want pushed on is the lightweight index trade-off: if `getSessionsBySource()` is considered a library API rather than a picker/list helper, please explain in depth what metadata accuracy contract it should preserve.

## Follow-ups (not in scope)

- Add direct cwd lookup support for more adapters after checking each storage layout carefully.
- Launch live native resumes for every supported CLI on a machine with all tools installed/authenticated.
- Add benchmark fixtures for very large rollout directories instead of relying on local timing checks.
- Split or prune old excluded e2e/stress helpers; this PR only formats touched helper code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes P1 resume, extraction, and loading gaps so session handoffs work reliably across `claude`, `codex`, `copilot`, `droid`, and now improves `opencode` handoff extraction and `cursor` resume fallbacks. Speeds up session loading with source-scoped caching, `cwd` lookup, and fixes native resume commands without probing binaries in debug mode.

- **Bug Fixes**
  - Validate `--in` targets early; reject unknown tools and block `.continues-handoff.md` writes.
  - Keep resume debug prompt from probing the target binary; clearer resume command display.
  - `claude`: order by transcript timestamps, keep last real user message when tail is tool-only, extract Agent sidecar outputs.
  - `codex`: read plaintext compacted `payload.message`, handle MCP-namespaced `edit_file`, and `write_stdin.chars`.
  - `copilot`: parse all events before trimming so the last user message survives tool-only tails.
  - `droid`: discover `.factory/projects` and `.factory/sessions`, dedupe ids, scan full transcripts for true recency.
  - `cursor`: support `cursor-agent` binary fallback and preview fallback display on resume.
  - Shared extraction: recognize lowercase `create`, Morph edit aliases, `old_str`/`new_str`, and patch variants.

- **New Features**
  - Source-scoped caches with env fingerprints (incl. `COPILOT_HOME`); targeted discovery with bounded concurrent parsing.
  - Direct `cwd` lookup where supported (e.g., `claude`) and a lightweight index path for faster pickers.
  - Rich `opencode` handoff extraction added.
  - More regression tests for parsers, forwarding, picker flows, env cache invalidation, and source-scoped indexes; Biome formatting to keep `pnpm run check` green.

<sup>Written for commit 3fa356120f7c674758e372d920f8f521607353cb. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/43?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

