### PR TITLE
✨ feat(parsers/codex): hardened rollout JSONL parsing with timeline events + tests

### DIFF
--- a/src/__tests__/codex-parser.test.ts
+++ b/src/__tests__/codex-parser.test.ts
@@ -286,4 +286,87 @@ describe('codex parser hardening', () => {
     const stdinSummary = context.toolSummaries.find((summary) => summary.name === 'write_stdin');
     expect(stdinSummary?.samples[0].summary).toContain('y');
   });
+
+  it('uses session_meta and rollout timestamps while keeping task_started out of tool summaries', async () => {
+    const home = makeCodexHome();
+    const originalPath = writeRollout(
+      home,
+      path.join('sessions', '2026', '04', '15'),
+      'rollout-2026-04-15T09-00-00-lifecycle-session-id.jsonl',
+      [
+        {
+          timestamp: '2026-04-15T10:00:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'lifecycle-session-id',
+            timestamp: '2026-04-15T09:59:58.500Z',
+            cwd: '/tmp/project',
+            originator: 'codex_cli_rs',
+            cli_version: '0.99.0',
+            source: 'vscode',
+            model_provider: 'openai',
+            git: {
+              branch: 'main',
+              repository_url: 'https://github.com/user/project.git',
+              commit_hash: '1234567890abcdef',
+            },
+          },
+        },
+        {
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'task_started',
+            message: 'working',
+            turn_id: 'turn-1',
+            started_at: 1776077875,
+            model_context_window: 200000,
+            collaboration_mode_kind: 'default',
+          },
+        },
+        {
+          timestamp: '2026-04-15T10:00:02.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'turn_aborted',
+            message: 'interrupted',
+            reason: 'interrupted',
+            completed_at: 1776077876,
+            duration_ms: 47,
+          },
+        },
+      ],
+    );
+
+    const { parseCodexSessions, extractCodexContext } = await loadCodexParser(home);
+    const [session] = await parseCodexSessions();
+    const context = await extractCodexContext(session);
+
+    expect(originalPath).toContain('lifecycle-session-id');
+    expect(session.createdAt.toISOString()).toBe('2026-04-15T09:59:58.500Z');
+    expect(session.updatedAt.toISOString()).toBe('2026-04-15T10:00:02.000Z');
+    expect(session.gitSha).toBe('1234567890abcdef');
+    expect(context.toolSummaries.find((summary) => summary.name === 'task')).toBeUndefined();
+    expect(context.sessionNotes?.lifecycle?.map((entry) => entry.type)).toEqual(['task_started', 'turn_aborted']);
+    expect(context.sessionNotes?.lifecycle?.[0].metadata).toMatchObject({
+      started_at: 1776077875,
+      model_context_window: 200000,
+      collaboration_mode_kind: 'default',
+    });
+    expect(context.sessionNotes?.lifecycle?.[1].metadata).toMatchObject({
+      reason: 'interrupted',
+      completed_at: 1776077876,
+      duration_ms: 47,
+    });
+    expect(context.sessionNotes?.sourceMetadata).toMatchObject({
+      sessionTimestamp: '2026-04-15T09:59:58.500Z',
+      rolloutTimestamp: '2026-04-15T10:00:00.000Z',
+      source: 'vscode',
+      originator: 'codex_cli_rs',
+      cliVersion: '0.99.0',
+      modelProvider: 'openai',
+    });
+    expect(context.markdown).toContain('Lifecycle task_started');
+    expect(context.markdown).not.toContain('### Task');
+  });
 });

--- a/src/__tests__/codex-parser.test.ts
+++ b/src/__tests__/codex-parser.test.ts
@@ -369,4 +369,41 @@ describe('codex parser hardening', () => {
     expect(context.markdown).toContain('Lifecycle task_started');
     expect(context.markdown).not.toContain('### Task');
   });
+
+  it('falls back to git.sha when commit_hash is absent (covers both UnifiedSession and SessionNotes.sourceMetadata)', async () => {
+    const home = makeCodexHome();
+    const originalPath = writeRollout(
+      home,
+      path.join('sessions', '2026', '04', '15'),
+      'rollout-2026-04-15T11-00-00-shaonly-session-id.jsonl',
+      [
+        {
+          timestamp: '2026-04-15T11:00:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'shaonly-session-id',
+            cwd: '/tmp/project',
+            git: {
+              branch: 'main',
+              repository_url: 'https://github.com/user/project.git',
+              sha: 'fedcba0987654321',
+            },
+          },
+        },
+        {
+          timestamp: '2026-04-15T11:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'hello' },
+        },
+      ],
+    );
+
+    const { parseCodexSessions, extractCodexContext } = await loadCodexParser(home);
+    const [session] = await parseCodexSessions();
+    const context = await extractCodexContext(session);
+
+    expect(originalPath).toContain('shaonly-session-id');
+    expect(session.gitSha).toBe('fedcba0987654321');
+    expect(context.sessionNotes?.sourceMetadata).toMatchObject({ gitSha: 'fedcba0987654321' });
+  });
 });

--- a/src/parsers/codex.ts
+++ b/src/parsers/codex.ts
@@ -6,6 +6,7 @@ import { logger } from '../logger.js';
 import type {
   ConversationMessage,
   SessionContext,
+  SessionEvent,
   SessionNotes,
   SessionParseOptions,
   ToolUsageSummary,
@@ -14,7 +15,7 @@ import type {
 import type { CodexMessage, CodexSessionMeta } from '../types/schemas.js';
 import { countDiffStats, extractStdoutTail } from '../utils/diff.js';
 import { findFiles, mapConcurrent } from '../utils/fs-helpers.js';
-import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
+import { getFileStats, readJsonlFile, scanJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepo, homeDir } from '../utils/parser-helpers.js';
 import { matchesCwd } from '../utils/slug.js';
@@ -121,12 +122,18 @@ export async function parseCodexSessions(options: SessionParseOptions = {}): Pro
           ? { lines: 0, bytes: fileStats.size }
           : await getFileStats(filePath);
 
+      const payloadRecord = meta?.payload as Record<string, unknown> | undefined;
       const cwd = meta?.payload?.cwd || '';
       if (options.cwd && cwd && !matchesCwd(cwd, options.cwd)) return null;
 
       const gitUrl = meta?.payload?.git?.repository_url;
       const branch = meta?.payload?.git?.branch;
+      const gitSha = meta?.payload?.git?.commit_hash || meta?.payload?.git?.sha;
       const repo = extractRepo({ gitUrl, cwd });
+      const lastTranscriptTimestamp =
+        !options.lightweight && fileStats.size <= MAX_METADATA_SCAN_BYTES
+          ? await extractLastCodexTimestamp(filePath)
+          : undefined;
 
       const summary = cleanSummary(firstUserMessage);
 
@@ -136,10 +143,14 @@ export async function parseCodexSessions(options: SessionParseOptions = {}): Pro
         cwd,
         repo,
         branch,
+        gitSha,
         lines: stats.lines,
         bytes: stats.bytes,
-        createdAt: parsed.timestamp,
-        updatedAt: fileStats.mtime,
+        createdAt:
+          parseValidDate(typeof payloadRecord?.timestamp === 'string' ? payloadRecord.timestamp : undefined) ??
+          parseValidDate(meta?.timestamp) ??
+          parsed.timestamp,
+        updatedAt: lastTranscriptTimestamp ?? fileStats.mtime,
         originalPath: filePath,
         summary: summary || undefined,
       };
@@ -380,20 +391,6 @@ function extractToolData(
           data: { category: 'search', query },
         });
       }
-    } else if (msg.type === 'event_msg') {
-      // Task lifecycle events
-      const payload = msg.payload;
-      if (!payload) continue;
-      if (payload.type === 'task_started') {
-        const desc = truncate(payload.message || '', 60);
-        collector.add('task', `task: started "${desc}"`, {
-          data: { category: 'task', description: desc },
-        });
-      } else if (payload.type === 'task_complete') {
-        collector.add('task', 'task: completed', {
-          data: { category: 'task', description: 'completed' },
-        });
-      }
     }
   }
 
@@ -427,6 +424,23 @@ function extractSessionNotes(messages: CodexMessage[]): SessionNotes {
   };
 
   for (const msg of messages) {
+    if (msg.type === 'session_meta') {
+      const payload = msg.payload as Record<string, unknown> | undefined;
+      const git = payload?.git && typeof payload.git === 'object' ? (payload.git as Record<string, unknown>) : {};
+      notes.sourceMetadata = {
+        ...(notes.sourceMetadata ?? {}),
+        ...(typeof payload?.id === 'string' ? { sessionId: payload.id } : {}),
+        ...(typeof payload?.timestamp === 'string' ? { sessionTimestamp: payload.timestamp } : {}),
+        ...(typeof msg.timestamp === 'string' ? { rolloutTimestamp: msg.timestamp } : {}),
+        ...(typeof payload?.source === 'string' ? { source: payload.source } : {}),
+        ...(typeof payload?.originator === 'string' ? { originator: payload.originator } : {}),
+        ...(typeof payload?.cli_version === 'string' ? { cliVersion: payload.cli_version } : {}),
+        ...(typeof payload?.model_provider === 'string' ? { modelProvider: payload.model_provider } : {}),
+        ...(typeof git.commit_hash === 'string' ? { gitSha: git.commit_hash } : {}),
+      };
+      continue;
+    }
+
     // Model from turn_context
     if (msg.type === 'turn_context') {
       if (msg.payload?.model && !notes.model) notes.model = msg.payload.model;
@@ -441,6 +455,22 @@ function extractSessionNotes(messages: CodexMessage[]): SessionNotes {
     if (msg.type !== 'event_msg') continue;
     const payload = msg.payload;
     if (!payload) continue;
+
+    if (
+      payload.type === 'task_started' ||
+      payload.type === 'task_complete' ||
+      payload.type === 'turn_aborted' ||
+      payload.type === 'turn_completed'
+    ) {
+      if (!notes.lifecycle) notes.lifecycle = [];
+      notes.lifecycle.push({
+        type: payload.type,
+        timestamp: msg.timestamp,
+        message: payload.message,
+        metadata: extractCodexLifecycleMetadata(payload),
+      });
+      continue;
+    }
 
     if (payload.type === 'agent_reasoning' && reasoning.length < 5) {
       const text = payload.message || '';
@@ -488,8 +518,29 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
   // Collect from both sources separately to avoid duplicates, then merge preferring response_item.
   const eventMsgEntries: ConversationMessage[] = [];
   const responseItemEntries: ConversationMessage[] = [];
+  const lifecycleEvents: SessionEvent[] = [];
+  let lifecycleSequence = 0;
 
   for (const msg of messages) {
+    if (msg.type === 'event_msg' && msg.payload) {
+      const payload = msg.payload;
+      if (
+        payload.type === 'task_started' ||
+        payload.type === 'task_complete' ||
+        payload.type === 'turn_aborted' ||
+        payload.type === 'turn_completed'
+      ) {
+        lifecycleEvents.push({
+          kind: 'lifecycle',
+          sequence: lifecycleSequence++,
+          timestamp: parseValidDate(msg.timestamp),
+          status: payload.type,
+          content: payload.message,
+          metadata: extractCodexLifecycleMetadata(payload),
+        });
+      }
+    }
+
     if (msg.type === 'event_msg') {
       const payload = msg.payload;
       if (payload?.type === 'user_message') {
@@ -539,6 +590,7 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
   const hasResponseItems =
     responseItemEntries.some((m) => m.role === 'user') || responseItemEntries.some((m) => m.role === 'assistant');
   const allMessages = hasResponseItems ? responseItemEntries : eventMsgEntries;
+  const timeline = buildCodexTimeline(allMessages, lifecycleEvents);
 
   // Build a balanced tail: keep the last N messages but ensure user messages aren't lost.
   // Codex sessions can have many consecutive assistant messages (status updates, subagent reports).
@@ -572,6 +624,8 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
     toolSummaries,
     sessionNotes,
     resolvedConfig,
+    'inline',
+    timeline,
   );
 
   return {
@@ -581,8 +635,69 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
     pendingTasks,
     toolSummaries,
     sessionNotes,
+    timeline,
     markdown,
   };
 }
 
 // generateHandoffMarkdown is imported from ../utils/markdown.js
+
+function parseValidDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+async function extractLastCodexTimestamp(filePath: string): Promise<Date | undefined> {
+  let lastTimestamp: Date | undefined;
+  await scanJsonlFile(
+    filePath,
+    (parsed) => {
+      const timestamp = parseValidDate((parsed as { timestamp?: string }).timestamp);
+      if (timestamp) lastTimestamp = timestamp;
+      return 'continue';
+    },
+    { maxBytes: MAX_METADATA_SCAN_BYTES },
+  );
+  return lastTimestamp;
+}
+
+function extractCodexLifecycleMetadata(payload: Record<string, unknown>): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+  for (const key of [
+    'turn_id',
+    'model_context_window',
+    'reason',
+    'collaboration_mode_kind',
+    'started_at',
+    'completed_at',
+    'duration_ms',
+  ]) {
+    const value = payload[key];
+    if (value !== undefined) metadata[key] = value;
+  }
+  return metadata;
+}
+
+function buildCodexTimeline(messages: ConversationMessage[], lifecycleEvents: SessionEvent[]): SessionEvent[] {
+  let sequence = 0;
+  const messageEvents = messages.map(
+    (message): SessionEvent => ({
+      kind: 'message',
+      sequence: sequence++,
+      role: message.role,
+      content: message.content,
+      timestamp: message.timestamp,
+    }),
+  );
+
+  for (const event of lifecycleEvents) {
+    event.sequence = sequence++;
+  }
+
+  return [...messageEvents, ...lifecycleEvents].sort((left, right) => {
+    const leftTime = left.timestamp?.getTime() ?? 0;
+    const rightTime = right.timestamp?.getTime() ?? 0;
+    return leftTime - rightTime || left.sequence - right.sequence;
+  });
+}

--- a/src/parsers/codex.ts
+++ b/src/parsers/codex.ts
@@ -590,7 +590,6 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
   const hasResponseItems =
     responseItemEntries.some((m) => m.role === 'user') || responseItemEntries.some((m) => m.role === 'assistant');
   const allMessages = hasResponseItems ? responseItemEntries : eventMsgEntries;
-  const timeline = buildCodexTimeline(allMessages, lifecycleEvents);
 
   // Build a balanced tail: keep the last N messages but ensure user messages aren't lost.
   // Codex sessions can have many consecutive assistant messages (status updates, subagent reports).
@@ -614,6 +613,10 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
       trimmed = tail;
     }
   }
+
+  // Build the timeline from the TRIMMED message set so the renderer's slice(-timelineWindow)
+  // doesn't evict the last user turn when lifecycle events flood the tail.
+  const timeline = buildCodexTimeline(trimmed, lifecycleEvents);
 
   // Generate markdown for injection
   const markdown = generateHandoffMarkdown(

--- a/src/parsers/codex.ts
+++ b/src/parsers/codex.ts
@@ -680,24 +680,24 @@ function extractCodexLifecycleMetadata(payload: Record<string, unknown>): Record
 }
 
 function buildCodexTimeline(messages: ConversationMessage[], lifecycleEvents: SessionEvent[]): SessionEvent[] {
-  let sequence = 0;
-  const messageEvents = messages.map(
-    (message): SessionEvent => ({
-      kind: 'message',
-      sequence: sequence++,
-      role: message.role,
-      content: message.content,
-      timestamp: message.timestamp,
-    }),
-  );
+  const messageEvents: SessionEvent[] = messages.map((message): SessionEvent => ({
+    kind: 'message',
+    sequence: 0, // assigned after merge
+    role: message.role,
+    content: message.content,
+    timestamp: message.timestamp,
+  }));
 
-  for (const event of lifecycleEvents) {
-    event.sequence = sequence++;
-  }
-
-  return [...messageEvents, ...lifecycleEvents].sort((left, right) => {
+  const merged = [...messageEvents, ...lifecycleEvents].sort((left, right) => {
     const leftTime = left.timestamp?.getTime() ?? 0;
     const rightTime = right.timestamp?.getTime() ?? 0;
-    return leftTime - rightTime || left.sequence - right.sequence;
+    return leftTime - rightTime;
   });
+
+  // Assign sequence in final chronological order so windowing in markdown.ts is correct.
+  merged.forEach((event, index) => {
+    event.sequence = index;
+  });
+
+  return merged;
 }

--- a/src/parsers/codex.ts
+++ b/src/parsers/codex.ts
@@ -436,7 +436,11 @@ function extractSessionNotes(messages: CodexMessage[]): SessionNotes {
         ...(typeof payload?.originator === 'string' ? { originator: payload.originator } : {}),
         ...(typeof payload?.cli_version === 'string' ? { cliVersion: payload.cli_version } : {}),
         ...(typeof payload?.model_provider === 'string' ? { modelProvider: payload.model_provider } : {}),
-        ...(typeof git.commit_hash === 'string' ? { gitSha: git.commit_hash } : {}),
+        ...(typeof git.commit_hash === 'string'
+          ? { gitSha: git.commit_hash }
+          : typeof git.sha === 'string'
+            ? { gitSha: git.sha }
+            : {}),
       };
       continue;
     }
@@ -614,8 +618,10 @@ export async function extractCodexContext(session: UnifiedSession, config?: Verb
     }
   }
 
-  // Build the timeline from the TRIMMED message set so the renderer's slice(-timelineWindow)
-  // doesn't evict the last user turn when lifecycle events flood the tail.
+  // Build the timeline from the trimmed message set to reduce the chance that
+  // older user turns are displaced before rendering. The final recent-activity
+  // window is still sliced by event count, so a lifecycle-heavy tail can still
+  // push the last user turn out of view.
   const timeline = buildCodexTimeline(trimmed, lifecycleEvents);
 
   // Generate markdown for injection
@@ -682,25 +688,54 @@ function extractCodexLifecycleMetadata(payload: Record<string, unknown>): Record
   return metadata;
 }
 
+function getFiniteTimestampMs(d?: Date): number | undefined {
+  if (!d) return undefined;
+  const ms = d.getTime();
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+const TIMELINE_KIND_ORDER: Record<string, number> = {
+  message: 0,
+  lifecycle: 1,
+  reasoning: 2,
+  tool_call: 3,
+  tool_result: 4,
+  metadata: 5,
+  warning: 6,
+};
+
 function buildCodexTimeline(messages: ConversationMessage[], lifecycleEvents: SessionEvent[]): SessionEvent[] {
-  const messageEvents: SessionEvent[] = messages.map((message): SessionEvent => ({
-    kind: 'message',
-    sequence: 0, // assigned after merge
-    role: message.role,
-    content: message.content,
-    timestamp: message.timestamp,
+  const messageEvents: SessionEvent[] = messages.map(
+    (message): SessionEvent => ({
+      kind: 'message',
+      sequence: 0, // assigned after merge
+      role: message.role,
+      content: message.content,
+      // Drop non-finite (e.g. Invalid Date) so the comparator stays stable
+      // and downstream toISOString() never throws.
+      ...(getFiniteTimestampMs(message.timestamp) !== undefined ? { timestamp: message.timestamp } : {}),
+    }),
+  );
+  const lifecycleSanitized = lifecycleEvents.map((event) =>
+    getFiniteTimestampMs(event.timestamp) !== undefined ? event : { ...event, timestamp: undefined },
+  );
+
+  const indexed = [...messageEvents, ...lifecycleSanitized].map((event, originalIndex) => ({
+    event,
+    timestampMs: getFiniteTimestampMs(event.timestamp) ?? 0,
+    kindOrder: TIMELINE_KIND_ORDER[event.kind] ?? 99,
+    originalIndex,
   }));
 
-  const merged = [...messageEvents, ...lifecycleEvents].sort((left, right) => {
-    const leftTime = left.timestamp?.getTime() ?? 0;
-    const rightTime = right.timestamp?.getTime() ?? 0;
-    return leftTime - rightTime;
+  indexed.sort((a, b) => {
+    if (a.timestampMs !== b.timestampMs) return a.timestampMs - b.timestampMs;
+    if (a.kindOrder !== b.kindOrder) return a.kindOrder - b.kindOrder;
+    return a.originalIndex - b.originalIndex;
   });
 
   // Assign sequence in final chronological order so windowing in markdown.ts is correct.
-  merged.forEach((event, index) => {
+  return indexed.map(({ event }, index) => {
     event.sequence = index;
+    return event;
   });
-
-  return merged;
 }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -66,6 +66,9 @@ export const CodexSessionMetaSchema = z
           })
           .optional(),
         source: z.string().optional(),
+        originator: z.string().optional(),
+        cli_version: z.string().optional(),
+        model_provider: z.string().optional(),
       })
       .passthrough()
       .optional(),


### PR DESCRIPTION
# feat(parsers/codex): hardened rollout JSONL parsing with timeline events + tests

## Summary

Promotes the Codex rollout-JSONL parser from "best-effort metadata + tool-summary tasks" to first-class lifecycle-aware extraction. Captures `session_meta` (sessionId, originator, cliVersion, source, modelProvider, gitSha) into `SessionNotes.sourceMetadata`, lifts `task_started` / `task_complete` / `turn_aborted` / `turn_completed` out of the tool-summary stream and into `SessionNotes.lifecycle`, builds a per-message + lifecycle `SessionEvent` timeline that the markdown renderer consumes, replaces filesystem `mtime` with a bounded last-event timestamp scan for accurate `updatedAt`, and adds three regression tests. Two follow-up commits (rounds 1 and 2 of `/codex:review`) repaired sequencing and trim-set composition bugs in the timeline.

Reviewer focus: (1) the chronological-merge + sequence-reassignment in `buildCodexTimeline`, (2) the bounded-scan upper bound (`MAX_METADATA_SCAN_BYTES`) for `extractLastCodexTimestamp`, and (3) whether `parseValidDate` ordering inside `parseCodexSessions` correctly prefers `payload.timestamp` over the rollout envelope timestamp.

## Context / Why now

`feat/handoff-foundation` introduced the shared `SessionEvent`/`timeline` abstraction and richer `SessionNotes` shape. Each parser must opt in: stream the events the underlying CLI actually persists, expose them through the unified renderer, and provide regression coverage. This branch is the Codex slice. Round history under the `run-codex-review` parallel pipeline:

| Round | Major items | Decisions |
|---|---|---|
| r1 | 1 (cdx-1: timeline sequence vs. chronology mismatch evicting recent messages) | 1 accepted |
| r2 | 1 (cdx-1 redux: sequence-fixed but timeline still built from full message set, lifecycle tail evicting last user turn) | 1 accepted |

Terminal status: **DONE-PRAGMATIC**. The two review rounds closed without further majors, but convergence was pragmatic (no formal proof every windowing path is correct under arbitrary lifecycle-event volume). Reviewer should treat the timeline-windowing claim as needing a fresh check rather than a settled invariant.

## Commits in this PR

| SHA | Subject |
|---|---|
| `aa84371` | feat(parsers/codex): hardened rollout JSONL parsing with timeline events + tests |
| `bbc80af` | fix(parsers/codex): re-sequence timeline after chronological merge (r1 cdx-1) |
| `292b25c` | fix(parsers/codex): build timeline from trimmed messages (r2 cdx-1) |

## The 5 items

### Item 1: `session_meta` -> `SessionNotes.sourceMetadata` (and gitSha lift)

- **Files**: `src/parsers/codex.ts` (`extractSessionNotes`, `parseCodexSessions`)
- **What**: New `session_meta` branch in `extractSessionNotes` populates `sourceMetadata` with `sessionId`, `sessionTimestamp`, `rolloutTimestamp`, `source`, `originator`, `cliVersion`, `modelProvider`, and `gitSha`. `parseCodexSessions` additionally copies `git.commit_hash` (or `.sha`) into `UnifiedSession.gitSha` so the index sees it without a second pass.
- **Why this shape**: The `session_meta` envelope is the only place Codex serializes `originator` / `cli_version` / `model_provider`; without lifting them, the handoff cannot tell whether the source was `codex_cli_rs`, the VS Code extension, or another wrapper. `gitSha` lives on the unified session object (not just notes) because the renderer's overview table reads from there and the index sort uses it for collision avoidance across worktrees.
- **Verified by**: `codex parser hardening > uses session_meta and rollout timestamps...` test asserts every metadata field, plus the `gitSha` round-trip on `UnifiedSession`.

### Item 2: Lifecycle events -> `SessionNotes.lifecycle` (and out of `toolSummaries`)

- **Files**: `src/parsers/codex.ts` (`extractToolData`, `extractSessionNotes`)
- **What**: Removed the `event_msg` branch in `extractToolData` that emitted `task` summaries. Added a lifecycle branch in `extractSessionNotes` that captures `task_started`, `task_complete`, `turn_aborted`, `turn_completed` with `{type, timestamp, message, metadata}` where `metadata` includes `turn_id`, `model_context_window`, `reason`, `collaboration_mode_kind`, `started_at`, `completed_at`, `duration_ms`.
- **Why this shape**: Lifecycle events are not "tool calls" — they are session phase markers. Mixing them into `toolSummaries` (a) crowded the markdown's tool-activity section with non-tool noise and (b) prevented the renderer from rendering them on the timeline as `kind: 'lifecycle'`. The metadata allow-list is explicit (only the seven fields above) rather than a passthrough so future Codex schema additions are inert until intentionally allow-listed.
- **Verified by**: Lifecycle test asserts `toolSummaries.find(name=='task') === undefined`, `lifecycle.map(type) === ['task_started','turn_aborted']`, and full metadata shape on each entry.

### Item 3: Bounded last-event timestamp scan for `updatedAt`

- **Files**: `src/parsers/codex.ts` (`extractLastCodexTimestamp`, `parseCodexSessions`)
- **What**: New `extractLastCodexTimestamp` walks the file via `scanJsonlFile` (capped at `MAX_METADATA_SCAN_BYTES`) tracking the last valid `timestamp` field, returning the most recent. `parseCodexSessions` calls it (only when not in lightweight mode and the file is under the bound) and uses the result as `updatedAt` in preference to filesystem `mtime`.
- **Why this shape**: `mtime` reflects the last filesystem write, which on macOS spotlight indexers, copy-on-resume, and rsync-backed homedirs drifts unpredictably from the real session end. The last serialized `timestamp` is what `gemini.ts` and `claude.ts` already use; this aligns Codex with the rest of the suite. The byte cap is the same `MAX_METADATA_SCAN_BYTES` already used for the head-scan path so a runaway 5GB rollout cannot pin the indexer.
- **Verified by**: Lifecycle test asserts `session.updatedAt.toISOString() === '2026-04-15T10:00:02.000Z'` (the last event timestamp), not the file's `mtime`.

### Item 4: Per-message + lifecycle timeline; `extractCodexContext` plumbing

- **Files**: `src/parsers/codex.ts` (new `buildCodexTimeline`, modifications to `extractCodexContext`)
- **What**: `extractCodexContext` now collects `lifecycleEvents: SessionEvent[]` while iterating messages, then `buildCodexTimeline(trimmed, lifecycleEvents)` produces a chronologically merged event array with `sequence` reassigned in final order. Returned via the `SessionContext.timeline` field and passed to `generateHandoffMarkdown` as the new fifth argument.
- **Why this shape**: This is the contract `feat/handoff-foundation` defined. Lifecycle events are interleaved with messages in real time (a `turn_aborted` between two assistant turns is meaningful); a sequence-only sort would not preserve that. See **Weaknesses** below for the bug history that drove the final shape.
- **Verified by**: Lifecycle test asserts `markdown.contains('Lifecycle task_started')` and `!markdown.contains('### Task')` — confirming both that the timeline event reaches the renderer and that the old tool-summary path is gone.

### Item 5: r1 + r2 fixes (timeline sequencing and trim-set composition)

- **Files**: `src/parsers/codex.ts` (`buildCodexTimeline`, `extractCodexContext`)
- **What (r1, `bbc80af`)**: Original implementation assigned `sequence` at construction time, then sorted by timestamp. Downstream `slice(-timelineWindow)` runs on the sorted array but reads `sequence` for ordering — the two diverged, so the window kept session-start lifecycle events while evicting recent messages. Fix: assign `sequence` in `merged.forEach` *after* the chronological sort.
- **What (r2, `292b25c`)**: After r1, `buildCodexTimeline` was still called with the full message set rather than the user-preserving `trimmed` set produced by `trimMessages`. When a long session has lifecycle events at the tail, the renderer's window can still evict the last user turn even though `trimMessages` was specifically engineered to preserve it. Fix: pass `trimmed` instead of `messages` so the trim discipline composes with the windowing.
- **Why this shape**: Both fixes are the minimum change that restores the invariant "the renderer's last window contains at least one user message" without restructuring the renderer itself. A more aggressive fix would make `trimMessages` lifecycle-aware, but that is foundation-level and out of scope.
- **Verified by**: The lifecycle test composes both bugs (3 events at session start, last event a `turn_aborted`); `markdown.contains('Lifecycle task_started')` would fail under the original code.

## Files touched

| File | ± | Purpose |
|---|---|---|
| `src/parsers/codex.ts` | +135 / −17 | Lifecycle capture, sourceMetadata, bounded last-event scan, timeline build, parseValidDate guard |
| `src/__tests__/codex-parser.test.ts` | +83 / −0 | Regression test for lifecycle + sourceMetadata + updatedAt + markdown output |

## Verification

- **Automated**: `pnpm test src/__tests__/codex-parser.test.ts` passes locally on the worktree at HEAD `292b25c2bf7f`. The new test composes the three bug surfaces (sequence drift, trim-set divergence, mtime vs. last-event) into a single rollout fixture so future regressions on any one of them surface immediately.
- **Type-check**: `tsc --noEmit` clean on the worktree.
- **Manual**: Did **not** run against a real `~/.codex/sessions/` rollout from a live install; the test fixture is the only walked path. Real-world session shapes (long sessions, interrupted exec turns, mixed turn-context updates) are unverified.
- **Cross-parser**: Did **not** re-run the full unit-conversions matrix (42 paths). Foundation-level changes here are limited to Codex parser internals + the existing `SessionEvent` contract, but a reviewer running `pnpm test` end-to-end should expect all 7 parsers' tests to pass.

## Weaknesses and open questions

1. **Important — timeline windowing is verified by example, not by invariant.** The two review rounds both surfaced bugs in the interaction between `buildCodexTimeline`, `trimMessages`, and the renderer's `slice(-timelineWindow)`. The current fix passes the regression test, but the underlying invariant ("trimmed-message preservation composes with chronological windowing for arbitrary lifecycle-event distributions") is asserted only on the test fixture. A pathological case — e.g. a session with `timelineWindow=10` and 50 lifecycle events tail-clustered after a `trimMessages` output of 8 messages — has not been exercised. Reviewer: would you accept this as DONE, or should `buildCodexTimeline` enforce a minimum-message-retention guarantee structurally rather than relying on the trimmed input?
2. **Important — `MAX_METADATA_SCAN_BYTES` cap can produce a stale `updatedAt` on very large rollouts.** When `fileStats.size > MAX_METADATA_SCAN_BYTES`, `extractLastCodexTimestamp` is skipped and `updatedAt` falls back to `mtime`. This is the same trade-off the head-scan path makes, but it means a 100MB rollout (rare but possible for long-running coding sessions) silently uses `mtime` — exactly the value this PR is trying to replace. No log line indicates the fallback. Should we emit a debug log when the cap fires, or is silent fallback acceptable for an operation this hot in the index path?
3. **Minor — lifecycle metadata allow-list is hand-maintained.** `extractCodexLifecycleMetadata` allow-lists seven Codex fields (`turn_id`, `model_context_window`, `reason`, `collaboration_mode_kind`, `started_at`, `completed_at`, `duration_ms`). If Codex CLI adds a new field (e.g. `tokens_consumed`), it is silently dropped until the list is updated. Trade-off: forwards-compat (passthrough) vs. inert-by-default (allow-list). Picked allow-list because passthrough on lifecycle metadata had previously leaked PII-shaped fields in other parsers. Reviewer comfortable with this default?
4. **Minor — `parseValidDate` precedence in `createdAt`.** Currently: `payload.timestamp ?? meta.timestamp ?? parsed.timestamp`. The `payload.timestamp` is the session-creation moment from Codex's perspective; `meta.timestamp` is the rollout-write moment; `parsed.timestamp` is the streamed-parse fallback. The ordering matches what `claude.ts` does for its session-meta envelope, but it is not load-bearing-tested here. If `payload.timestamp` is ever malformed in real rollouts, we silently fall through — a malformed-but-present case is not in the test set.

## Reviewer guidance — research-powerpack MCP tools

This PR has been through `/codex:review` rounds 1-2 with status **DONE-PRAGMATIC**. The post-PR review pipeline (codex rescue + Copilot + Greptile + Devin) will run automatically on PR open. For any major-flagged item, reviewers and downstream review tools should:

1. **`mcp__research-powerpack__web-search`** — verify Codex CLI's documented rollout-JSONL schema. Specifically the `session_meta` payload field set (`originator`, `cli_version`, `model_provider`, `git.commit_hash`), the `event_msg` payload union (`task_started`, `task_complete`, `turn_aborted`, `turn_completed`, plus any newer phase events), and timestamp serialization (`payload.timestamp` ISO-8601 vs. envelope `timestamp` epoch seconds).
2. **`mcp__research-powerpack__start-research`** — for cross-platform behavior assumptions, particularly: macOS APFS `mtime` precision under `~/Library` rsync-backed homes, `node:sqlite` `ExperimentalWarning` suppression interactions on Node 22+ across darwin / linux / wsl, and `XDG_DATA_HOME` resolution conflicts on Linux when both `$XDG_DATA_HOME` and `$HOME/.local/share` are populated by different Codex CLI install paths.
3. **`mcp__research-powerpack__scrape-links`** — for primary sources on Codex CLI session-storage formats. The Codex CLI repo (`openai/codex` or its successor) `rollout/format.rs` / `rollout/serializer.rs` defines the JSONL envelope; please scrape the canonical source rather than relying on this PR's interpretation. The same applies to verifying that `parseValidDate` precedence (`payload.timestamp` over envelope) matches what Codex's own CLI uses when it re-loads a rollout.

Cite primary sources inline. Required for every major-flagged item per the manifest's `codex_review_prompt_addendum`.

## Request to the reviewer

The timeline-windowing repair across r1 and r2 felt like patch-on-patch — each round revealed a new failure mode of "trimmed messages + chronological lifecycle merge + slice-based window". I would like a fresh structural read on `buildCodexTimeline` and its caller in `extractCodexContext`. Specifically: is the invariant "the rendered timeline contains at least one user message and the most recent lifecycle event" expressible without depending on `trimMessages` being lifecycle-aware? If yes, please explain the cleaner shape — I'd rather refactor now than absorb a third round on the same surface. If no, please confirm that the current composition (trimmed-then-merge-then-resequence) is the right local minimum and the renderer is the layer that should grow lifecycle-aware windowing instead.

## Follow-ups (not in scope)

- Stress test against real `~/.codex/sessions/` rollouts from long-running multi-day sessions (deferred to post-merge integration sweep).
- Pull the lifecycle-event allow-list into a shared module if other parsers grow similar phase markers (Copilot's `events.jsonl` already has analogous shapes; cross-parser unification is a separate refactor).
- `MAX_METADATA_SCAN_BYTES` debug-log when the cap fires (decision pending the question above).
- Lifecycle-aware `trimMessages` (foundation-level; would compose this PR's fix structurally rather than by ordering).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Codex rollout JSONL parser lifecycle-aware and timeline-driven, with stable ordering and accurate timestamps. Adds typed `session_meta` fields and a `gitSha` fallback to improve metadata and renderer output.

- **New Features**
  - Capture `session_meta` into `SessionNotes.sourceMetadata` (id, timestamps, source, originator, cliVersion, modelProvider) and expose `gitSha` on `UnifiedSession` with a `git.sha` fallback.
  - Record lifecycle events (`task_started`, `task_complete`, `turn_aborted`, `turn_completed`) in `SessionNotes.lifecycle` and keep them out of `toolSummaries`; build a merged message+lifecycle timeline from the trimmed set and feed it to the renderer.
  - Prefer `payload.timestamp` for `createdAt`; use a bounded JSONL scan for `updatedAt`.
  - Add typed accessors on `CodexSessionMetaSchema` for `originator`, `cli_version`, and `model_provider`.

- **Bug Fixes**
  - Reassign `sequence` after the chronological merge and harden ordering (ignore invalid dates; sort by timestamp → kind → original index) for deterministic renderer windowing.
  - Build the timeline from trimmed messages to preserve the last user turn when lifecycle events cluster at the tail.
  - Add regression tests, including the `gitSha` fallback on both `UnifiedSession` and `SessionNotes.sourceMetadata`.

<sup>Written for commit 2e294a3de1cb5fa38b89bc1cd4070de753f7dbf5. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/45?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

