### PR TITLE
✨ feat(parsers/amp): harden thread JSON parsing with timeline events + tests

### DIFF
--- a/src/__tests__/amp-parser.test.ts
+++ b/src/__tests__/amp-parser.test.ts
@@ -24,6 +24,8 @@ function makeAmpFixture(): { root: string; xdgDataHome: string; threadPath: stri
         env: {
           initial: {
             tags: ['model:claude-opus-4-5'],
+            installationID: 'inst-test-do-not-leak',
+            deviceFingerprint: 'fp-test-do-not-leak',
             trees: [
               {
                 uri: pathToFileURL(projectCwd).href,

--- a/src/__tests__/amp-parser.test.ts
+++ b/src/__tests__/amp-parser.test.ts
@@ -1,0 +1,105 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const tempDirs: string[] = [];
+
+function makeAmpFixture(): { root: string; xdgDataHome: string; threadPath: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'amp-parser-'));
+  tempDirs.push(root);
+  const xdgDataHome = path.join(root, 'xdg-data');
+  const threadsDir = path.join(xdgDataHome, 'amp', 'threads');
+  const projectCwd = path.join(os.homedir(), 'amp-project');
+  fs.mkdirSync(threadsDir, { recursive: true });
+  const threadPath = path.join(threadsDir, 'thread-amp-battle.json');
+  fs.writeFileSync(
+    threadPath,
+    JSON.stringify(
+      {
+        id: 'thread-amp-battle',
+        title: 'Repair Amp parser',
+        created: Date.parse('2026-04-15T10:00:00.000Z'),
+        env: {
+          initial: {
+            tags: ['model:claude-opus-4-5'],
+            trees: [
+              {
+                uri: pathToFileURL(projectCwd).href,
+                repository: {
+                  url: 'https://github.com/user/amp-project.git',
+                  ref: 'refs/heads/parser-fixes',
+                  sha: 'abcdef1234567890',
+                },
+              },
+            ],
+          },
+        },
+        messages: [
+          {
+            role: 'user',
+            messageId: 1,
+            meta: { sentAt: Date.parse('2026-04-15T10:00:01.000Z') },
+            content: [{ type: 'text', text: 'Fix Amp metadata extraction' }],
+          },
+          {
+            role: 'assistant',
+            messageId: 2,
+            meta: { sentAt: Date.parse('2026-04-15T10:00:03.000Z') },
+            content: [{ type: 'text', text: 'Amp metadata extraction is fixed.' }],
+          },
+        ],
+        usageLedger: {
+          events: [{ model: 'claude-opus-4-5', tokens: { input: 12, output: 8 } }],
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+  return { root, xdgDataHome, threadPath };
+}
+
+async function loadAmpParser(xdgDataHome: string): Promise<typeof import('../parsers/amp.js')> {
+  vi.resetModules();
+  vi.stubEnv('XDG_DATA_HOME', xdgDataHome);
+  return import('../parsers/amp.js');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe('amp parser hardening', () => {
+  it('extracts cwd, repo, branch, git SHA, and per-message timestamps from thread metadata', async () => {
+    const fixture = makeAmpFixture();
+    const { parseAmpSessions, extractAmpContext } = await loadAmpParser(fixture.xdgDataHome);
+
+    const [session] = await parseAmpSessions();
+    const context = await extractAmpContext(session);
+
+    expect(session).toMatchObject({
+      id: 'thread-amp-battle',
+      cwd: path.join(os.homedir(), 'amp-project'),
+      repo: 'user/amp-project',
+      branch: 'parser-fixes',
+      gitSha: 'abcdef1234567890',
+      model: 'claude-opus-4-5',
+    });
+    expect(context.recentMessages.map((message) => message.timestamp?.toISOString())).toEqual([
+      '2026-04-15T10:00:01.000Z',
+      '2026-04-15T10:00:03.000Z',
+    ]);
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 12, output: 8 });
+    expect(context.markdown).toContain('~/amp-project');
+    expect(context.markdown).not.toContain('installationID');
+    expect(context.markdown).not.toContain('deviceFingerprint');
+  });
+});

--- a/src/parsers/amp.ts
+++ b/src/parsers/amp.ts
@@ -1,18 +1,21 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type {
   ConversationMessage,
   SessionContext,
+  SessionEvent,
   SessionNotes,
   ToolUsageSummary,
   UnifiedSession,
 } from '../types/index.js';
+import { extractTextFromBlocks } from '../utils/content.js';
 import { findFiles } from '../utils/fs-helpers.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
-import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
+import { cleanSummary, extractRepo, homeDir } from '../utils/parser-helpers.js';
 import { truncate } from '../utils/tool-summarizer.js';
 
 // ── Amp Thread JSON shape ───────────────────────────────────────────────────
@@ -28,6 +31,9 @@ interface AmpMessage {
   role: 'user' | 'assistant';
   messageId: number;
   content: AmpContentBlock[];
+  meta?: {
+    sentAt?: number;
+  };
 }
 
 interface AmpUsageEvent {
@@ -50,6 +56,14 @@ interface AmpThread {
   env?: {
     initial?: {
       tags?: string[];
+      trees?: Array<{
+        uri?: string;
+        repository?: {
+          url?: string;
+          ref?: string;
+          sha?: string;
+        };
+      }>;
     };
   };
 }
@@ -69,36 +83,30 @@ function findSessionFiles(): string[] {
 }
 
 /**
- * Parse a single Amp thread file. Returns null on any parse error.
+ * Read and parse a thread file in a single pass — returns the parsed thread plus
+ * the raw text so callers can derive line counts without re-reading the file.
  */
-function parseThreadFile(filePath: string): AmpThread | null {
+function readThreadFile(filePath: string): { thread: AmpThread; raw: string } | null {
   try {
-    const content = fs.readFileSync(filePath, 'utf8');
-    const data = JSON.parse(content);
-
-    // Minimal validation: must have id, created timestamp, and messages array
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const data = JSON.parse(raw);
     if (typeof data.id !== 'string' || typeof data.created !== 'number' || !Array.isArray(data.messages)) {
       logger.debug('amp: thread validation failed — missing id, created, or messages', filePath);
       return null;
     }
-
-    return data as AmpThread;
+    return { thread: data as AmpThread, raw };
   } catch (err) {
     logger.debug('amp: failed to parse thread file', filePath, err);
     return null;
   }
 }
 
-/**
- * Concatenate text from an Amp message's content blocks
- */
+function parseThreadFile(filePath: string): AmpThread | null {
+  return readThreadFile(filePath)?.thread ?? null;
+}
+
 function extractMessageText(message: AmpMessage): string {
-  if (!message.content || !Array.isArray(message.content)) return '';
-  return message.content
-    .filter((block) => block.type === 'text' && typeof block.text === 'string')
-    .map((block) => block.text!)
-    .join('\n')
-    .trim();
+  return extractTextFromBlocks(message.content).trim();
 }
 
 /**
@@ -129,6 +137,21 @@ function extractModel(thread: AmpThread): string | undefined {
   return undefined;
 }
 
+function extractAmpMetadata(thread: AmpThread): Pick<UnifiedSession, 'cwd' | 'repo' | 'branch' | 'gitSha'> {
+  const firstTree = thread.env?.initial?.trees?.[0];
+  const cwd = firstTree?.uri?.startsWith('file://') ? fileURLToPath(firstTree.uri) : '';
+  const repo = extractRepo({ gitUrl: firstTree?.repository?.url, cwd });
+  const ref = firstTree?.repository?.ref;
+  const branch = ref?.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+
+  return {
+    cwd,
+    ...(repo ? { repo } : {}),
+    ...(branch ? { branch } : {}),
+    ...(firstTree?.repository?.sha ? { gitSha: firstTree.repository.sha } : {}),
+  };
+}
+
 /**
  * Extract session notes: model info and token usage from usageLedger
  */
@@ -137,6 +160,13 @@ function extractSessionNotes(thread: AmpThread): SessionNotes {
 
   const model = extractModel(thread);
   if (model) notes.model = model;
+  const metadata = extractAmpMetadata(thread);
+  notes.sourceMetadata = {
+    ...(metadata.cwd ? { cwd: metadata.cwd } : {}),
+    ...(metadata.repo ? { repo: metadata.repo } : {}),
+    ...(metadata.branch ? { branch: metadata.branch } : {}),
+    ...(metadata.gitSha ? { gitSha: metadata.gitSha } : {}),
+  };
 
   // Accumulate token usage from ledger events, skipping title-generation
   const events = thread.usageLedger?.events;
@@ -175,22 +205,23 @@ export async function parseAmpSessions(): Promise<UnifiedSession[]> {
 
   for (const filePath of files) {
     try {
-      const thread = parseThreadFile(filePath);
-      if (!thread || !thread.id) continue;
+      const parsed = readThreadFile(filePath);
+      if (!parsed || !parsed.thread.id) continue;
+      const { thread, raw } = parsed;
 
       const firstUserMessage = extractFirstUserMessage(thread);
       const summary = cleanSummary(thread.title || firstUserMessage);
-
+      const metadata = extractAmpMetadata(thread);
       const fileStats = fs.statSync(filePath);
-      const content = fs.readFileSync(filePath, 'utf8');
-      const lines = content.split('\n').length;
 
       sessions.push({
         id: thread.id,
         source: 'amp',
-        cwd: '',
-        repo: '',
-        lines,
+        cwd: metadata.cwd || '',
+        repo: metadata.repo,
+        branch: metadata.branch,
+        gitSha: metadata.gitSha,
+        lines: raw.split('\n').length,
         bytes: fileStats.size,
         createdAt: new Date(thread.created),
         updatedAt: new Date(fileStats.mtimeMs),
@@ -222,6 +253,17 @@ export async function extractAmpContext(session: UnifiedSession, config?: Verbos
 
   if (thread) {
     sessionNotes = extractSessionNotes(thread);
+    const metadata = extractAmpMetadata(thread);
+    const enrichedSession: UnifiedSession = {
+      ...session,
+      cwd: session.cwd || metadata.cwd || '',
+      repo: session.repo || metadata.repo,
+      branch: session.branch || metadata.branch,
+      gitSha: session.gitSha || metadata.gitSha,
+      model: session.model || sessionNotes.model,
+    };
+    const timeline: SessionEvent[] = [];
+    let sequence = 0;
 
     // Convert Amp messages to unified ConversationMessage format.
     // Slice to recent window (×2 to account for user+assistant pairs, matching gemini pattern).
@@ -233,8 +275,16 @@ export async function extractAmpContext(session: UnifiedSession, config?: Verbos
         recentMessages.push({
           role: msg.role,
           content: text,
-          // Amp threads don't carry per-message timestamps; use thread creation as fallback
-          timestamp: new Date(thread.created),
+          timestamp: new Date(msg.meta?.sentAt ?? thread.created),
+          sourceId: String(msg.messageId),
+        });
+        timeline.push({
+          kind: 'message',
+          sequence: sequence++,
+          role: msg.role,
+          content: text,
+          timestamp: new Date(msg.meta?.sentAt ?? thread.created),
+          sourceId: String(msg.messageId),
         });
       }
     }
@@ -268,6 +318,30 @@ export async function extractAmpContext(session: UnifiedSession, config?: Verbos
         }
       }
     }
+    const trimmed = recentMessages.slice(-cfg.recentMessages);
+
+    const markdown = generateHandoffMarkdown(
+      enrichedSession,
+      trimmed,
+      filesModified,
+      pendingTasks,
+      toolSummaries,
+      sessionNotes,
+      cfg,
+      'inline',
+      timeline,
+    );
+
+    return {
+      session: enrichedSession,
+      recentMessages: trimmed,
+      filesModified,
+      pendingTasks,
+      toolSummaries,
+      sessionNotes,
+      timeline,
+      markdown,
+    };
   }
 
   const trimmed = recentMessages.slice(-cfg.recentMessages);
@@ -283,7 +357,7 @@ export async function extractAmpContext(session: UnifiedSession, config?: Verbos
   );
 
   return {
-    session: sessionNotes?.model ? { ...session, model: sessionNotes.model } : session,
+    session,
     recentMessages: trimmed,
     filesModified,
     pendingTasks,

--- a/src/parsers/amp.ts
+++ b/src/parsers/amp.ts
@@ -72,6 +72,14 @@ const AMP_BASE_DIR = process.env.XDG_DATA_HOME
   ? path.join(process.env.XDG_DATA_HOME, 'amp', 'threads')
   : path.join(homeDir(), '.local', 'share', 'amp', 'threads');
 
+function safeFileURLToPath(uri: string): string {
+  try {
+    return fileURLToPath(uri);
+  } catch {
+    return '';
+  }
+}
+
 /**
  * Find all Amp thread JSON files
  */
@@ -139,7 +147,7 @@ function extractModel(thread: AmpThread): string | undefined {
 
 function extractAmpMetadata(thread: AmpThread): Pick<UnifiedSession, 'cwd' | 'repo' | 'branch' | 'gitSha'> {
   const firstTree = thread.env?.initial?.trees?.[0];
-  const cwd = firstTree?.uri?.startsWith('file://') ? fileURLToPath(firstTree.uri) : '';
+  const cwd = firstTree?.uri?.startsWith('file://') ? safeFileURLToPath(firstTree.uri) : '';
   const repo = extractRepo({ gitUrl: firstTree?.repository?.url, cwd });
   const ref = firstTree?.repository?.ref;
   const branch = ref?.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;

--- a/src/parsers/amp.ts
+++ b/src/parsers/amp.ts
@@ -163,12 +163,14 @@ function extractAmpMetadata(thread: AmpThread): Pick<UnifiedSession, 'cwd' | 're
 /**
  * Extract session notes: model info and token usage from usageLedger
  */
-function extractSessionNotes(thread: AmpThread): SessionNotes {
+function extractSessionNotes(
+  thread: AmpThread,
+  metadata: Pick<UnifiedSession, 'cwd' | 'repo' | 'branch' | 'gitSha'> = extractAmpMetadata(thread),
+): SessionNotes {
   const notes: SessionNotes = {};
 
   const model = extractModel(thread);
   if (model) notes.model = model;
-  const metadata = extractAmpMetadata(thread);
   notes.sourceMetadata = {
     ...(metadata.cwd ? { cwd: metadata.cwd } : {}),
     ...(metadata.repo ? { repo: metadata.repo } : {}),
@@ -260,8 +262,9 @@ export async function extractAmpContext(session: UnifiedSession, config?: Verbos
   let sessionNotes: SessionNotes | undefined;
 
   if (thread) {
-    sessionNotes = extractSessionNotes(thread);
+    // Compute metadata once and reuse for both sessionNotes and the enrichedSession.
     const metadata = extractAmpMetadata(thread);
+    sessionNotes = extractSessionNotes(thread, metadata);
     const enrichedSession: UnifiedSession = {
       ...session,
       cwd: session.cwd || metadata.cwd || '',


### PR DESCRIPTION
## Summary

Hardens the Amp thread JSON parser so it stops dropping the metadata that makes a handoff useful. Before this change, every Amp session surfaced with `cwd: ''`, no `repo`, no `branch`, no `gitSha`, and every message timestamp pinned to the thread's `created` timestamp — fine for "list my threads", useless for cross-tool handoff. After this change, `parseAmpSessions` and `extractAmpContext` derive cwd / repo / branch / gitSha from `env.initial.trees[0]`, attach per-message timestamps from `msg.meta.sentAt`, emit a `SessionEvent` timeline, populate `sessionNotes.sourceMetadata` + token usage, and read the thread file once per parse instead of twice. A regression test pins the wire format end-to-end against an XDG-rooted fixture.

The branch ships two commits: the main feature (`9776f7f`) and a follow-up safety guard (`86872fb`) that wraps `fileURLToPath` so a malformed `file://` URI in `env.initial.trees[0].uri` degrades to an empty `cwd` instead of throwing and silently dropping the entire thread (or, worse, crashing `extractAmpContext` on resume).

## Context / Why now

Amp is the seventh CLI in the registry and the only one whose thread JSON ships repository metadata in a structured `env.initial.trees[]` block. The previous parser walked past it. The handoff foundation work on `feat/handoff-foundation` introduced `gitSha`, `sourceMetadata`, and the `SessionEvent` timeline as first-class fields — none of which the Amp parser was wiring up. This branch closes that gap so Amp threads land in the unified index with the same fidelity as Claude / Codex / Copilot threads.

This is one of seven sibling parser-hardening branches stacked on `feat/handoff-foundation`. The base branch is `feat/handoff-foundation`, not `main` — please review the diff against that base, not against `main`.

## Round history (review convergence)

This branch went through the project's two-round codex review loop:

- **Round 1**: 1 major item flagged, 1 accepted and applied. The item was the `fileURLToPath` malformed-URI hazard — `fileURLToPath` throws on UNC paths and malformed percent-escapes, which would have either dropped the thread silently in `parseAmpSessions` or thrown on resume in `extractAmpContext`. The fix wraps it in `safeFileURLToPath` with a `'' fallback` matching the downstream cwd-empty handling. Commit: `86872fb`.
- **Round 2**: 0 major items flagged. Loop terminated cleanly with `terminal_reason: "no major in round 2"`.
- **Status**: `DONE` (not `DONE-PRAGMATIC`). Convergence was clean; no caveats were carried forward from review.

Codex's role across both rounds was the major-item flagging pass. Round 2 emitting zero majors is the convergence signal that ended the loop.

## The changes

### 1. Metadata extraction from `env.initial.trees[0]` — `src/parsers/amp.ts`

New `extractAmpMetadata(thread)` reads the first tree entry from Amp's environment block and derives:

- `cwd` from `firstTree.uri` (only when it's a `file://` URL, via the new `safeFileURLToPath` guard).
- `repo` via the shared `extractRepo({ gitUrl, cwd })` helper from `parser-helpers.ts` — same path Claude / Codex use.
- `branch` from `firstTree.repository.ref`, stripping the `refs/heads/` prefix when present.
- `gitSha` from `firstTree.repository.sha`, passed through unchanged.

The function returns a `Pick<UnifiedSession, 'cwd' | 'repo' | 'branch' | 'gitSha'>` and is called from both `parseAmpSessions` (so the index lists Amp threads with their repo) and `extractAmpContext` (so the handoff markdown shows them).

In `extractAmpContext`, the metadata is merged onto the session via `enrichedSession`: existing values on `session` win, and Amp-derived values fill the gaps. This matters because the in-memory session may have been hydrated from the JSONL index (which carries the parsed values) before resume, so we don't want the parser to clobber them — but if the index was built before this branch landed, the cached values will be empty and the Amp data fills in.

### 2. Per-message timestamps from `msg.meta.sentAt` — `src/parsers/amp.ts`

`AmpMessage` gained an optional `meta?: { sentAt?: number }` typing. Both the recent-messages list and the new timeline events read `new Date(msg.meta?.sentAt ?? thread.created)`. When `sentAt` is absent the previous behavior (thread `created` timestamp) is preserved — no regression for older threads.

### 3. Single-pass `readThreadFile` — `src/parsers/amp.ts`

Previously `parseAmpSessions` called `parseThreadFile(filePath)` (which `readFileSync`'d + `JSON.parse`'d) and then immediately did a second `fs.readFileSync(filePath, 'utf8')` to count lines. Now `readThreadFile` returns `{ thread, raw }` in a single pass; `lines` is computed from `raw.split('\n').length`. The legacy `parseThreadFile` is kept as a thin wrapper so `extractAmpContext` and any other caller stays source-compatible.

### 4. Shared `extractTextFromBlocks` — `src/parsers/amp.ts`

`extractMessageText` now delegates to `extractTextFromBlocks` from `utils/content.ts` instead of inlining its own filter/map/join. Same output, one fewer place that has to learn about new block types if Amp's content schema grows.

### 5. `sessionNotes.sourceMetadata` + token usage — `src/parsers/amp.ts`

`extractSessionNotes` now populates `sessionNotes.sourceMetadata` with whichever of `cwd / repo / branch / gitSha` Amp gave us, alongside the existing `model` and `tokenUsage` accumulation. This is what feeds the "Source metadata" block in the handoff markdown.

### 6. `SessionEvent` timeline + handoff render — `src/parsers/amp.ts`

`extractAmpContext` now builds a `timeline: SessionEvent[]` of message kinds (sequence-numbered, role + content + timestamp + sourceId) and passes it through to `generateHandoffMarkdown` with `'inline'` rendering. The early-return fallback path (when the thread JSON itself can't be re-read on resume — e.g. file deleted between `parseAmpSessions` and `extractAmpContext`) preserves the previous behavior of returning an empty timeline.

### 7. `safeFileURLToPath` guard — `src/parsers/amp.ts` (round-1 fix)

Wraps `node:url`'s `fileURLToPath` in a try/catch returning `''` on failure. This is the round-1 codex-flagged hazard. `fileURLToPath` will throw on `file://server/share/...` UNC paths and on malformed percent-escapes (`file:///%ZZ`). Without the guard, a single malformed thread would either disappear from the index (`parseAmpSessions`'s outer try/catch swallows it) or crash on resume.

### 8. Regression test — `src/__tests__/amp-parser.test.ts` (new)

Builds an XDG-rooted fixture (`XDG_DATA_HOME=<tmp>/xdg-data`, threads at `<xdg>/amp/threads/`), writes a realistic thread JSON with `env.initial.trees[0].uri = pathToFileURL(homeDir + '/amp-project').href`, repository url/ref/sha, two messages with `meta.sentAt`, and a `usageLedger.events[0]` token block. Asserts:

- `parseAmpSessions()` returns `cwd`, `repo: 'user/amp-project'`, `branch: 'parser-fixes'`, `gitSha`, and `model` extracted from tags.
- `extractAmpContext().recentMessages` carry the `sentAt` timestamps, not the thread `created`.
- `sessionNotes.tokenUsage` accumulates `{ input: 12, output: 8 }`.
- The rendered markdown shows `~/amp-project` (HOME-relative) and contains neither `installationID` nor `deviceFingerprint` (Amp threads carry these in `env.initial`, but they should never leak into the handoff body).

Test loads the parser via `vi.resetModules()` + `vi.stubEnv` so the AMP_BASE_DIR module-load-time constant respects the per-test XDG override.

## Files touched

| File | Δ | What changed |
|---|---|---|
| `src/parsers/amp.ts` | +113 / −31 | Metadata extraction from `env.initial.trees[0]`, per-message timestamps, single-pass `readThreadFile`, shared `extractTextFromBlocks`, `sourceMetadata` + token usage, `SessionEvent` timeline, `safeFileURLToPath` guard. |
| `src/__tests__/amp-parser.test.ts` | +105 / 0 | New regression test: XDG-rooted fixture, asserts cwd/repo/branch/gitSha/model + per-message timestamps + token usage + handoff markdown content. |

Aggregate: 2 files, +218 / −31.

## Verification

- `pnpm test src/__tests__/amp-parser.test.ts` — passes locally on the worktree.
- `pnpm run build` — clean tsc compile against the new `extractTextFromBlocks` import and the `node:` protocol switch (`fs`, `path`, `url`).
- Round-2 codex review pass on the branch — 0 major items flagged.

What I did **not** run:

- Real Amp CLI end-to-end (`amp` binary spawning a thread, this parser reading it, then resuming into Claude / Codex). The fixture exercises the JSON shape but not the resume binary contract.
- Cross-platform tests on Linux/Windows. Branch was developed on macOS; `safeFileURLToPath` is the only Windows-sensitive path (UNC handling) and is exercised by the guard's try/catch but not by a Windows-shaped fixture.

## Risks / Known limitations

1. **Schema assumption: `env.initial.trees[0]` is the working tree.** Amp's thread JSON allows `trees: []` to be an array. We only read the first entry. If a thread genuinely has multiple working trees (e.g. monorepo workspace switches mid-thread), only the first one is surfaced. The unified `UnifiedSession` shape only holds one cwd / repo / branch anyway, so this is the correct truncation, but it's worth a reviewer pass to confirm we're not silently dropping the "active" tree when it isn't `[0]`.
2. **`firstTree.uri` "starts with `file://`" gate.** We only call `safeFileURLToPath` when the URI starts with `file://`. If Amp ever emits a non-`file://` scheme for local paths (e.g. `vscode-remote://`, `ssh://`, or a plain absolute path without a scheme), `cwd` falls back to `''`. The downstream code already handles empty cwd gracefully, but the handoff markdown loses the `~/amp-project` hint.
3. **`branch` slicing.** We strip `refs/heads/` but not `refs/remotes/origin/` or `refs/tags/`. An Amp thread checked out on a tag or detached at a remote ref would surface the full ref name. I judged this fine (rare, and the full ref is informative when it happens), but a reviewer may prefer a stricter normalization.
4. **Round-2 review was zero-major, not zero-minor.** The codex pass only flags major items; minor style/idiom issues are not gated. This is project policy, not a regression in this branch — but it means "DONE" here is "no blocking review items," not "formally validated."
5. **The XDG fixture mocks the storage path, not the Amp wire format.** The fixture is hand-written from the parser's typings, not snapshotted from a real Amp thread file. If Amp ships a schema change (new block type, renamed `meta.sentAt` field), this test won't catch it — only the next codex round on a future branch would. A reviewer with access to a real Amp installation (`~/.local/share/amp/threads/*.json`) could spot-check the typings against a live thread.
6. **Order-of-operations in `extractAmpContext` early-return path.** When the thread JSON re-read fails (file deleted between index and resume), we fall through to the legacy empty-context path — which now passes `session` as-is, not `enrichedSession`. The session at that point will have whatever cwd/repo/branch the JSONL index carried, which is correct; but if the index was built pre-this-branch, those fields are empty. The fallback path is rare (file deleted mid-resume) and the behavior matches pre-this-branch, so I judged it not worth special-casing — flagging for reviewer judgment.

## Reviewer guidance — research-powerpack tools

Downstream review tooling (codex, evaluator) should use the research-powerpack MCP tools where verification is load-bearing:

- `mcp__research-powerpack__web-search` — quick lookups for `node:url` `fileURLToPath` semantics on UNC paths, vitest `vi.stubEnv` + `vi.resetModules` interaction, and Amp CLI's documented thread-storage layout.
- `mcp__research-powerpack__start-research` — deeper passes when verifying:
  - Whether `env.initial.trees[]` is documented anywhere in Amp's public docs / changelog as the canonical working-tree block, or whether we're relying on observed behavior.
  - Whether `msg.meta.sentAt` is millisecond-epoch (assumed here, matching `Date.parse`) or some other unit on Amp's wire.
  - Cross-platform behavior of `pathToFileURL` + `fileURLToPath` round-trips on Windows (the test uses `pathToFileURL(homeDir + '/amp-project')`, which on Windows produces `file:///C:/...` — the parser should round-trip cleanly, but reviewer should verify).
- `mcp__research-powerpack__scrape-links` — for spot-checking primary sources (Amp release notes, `node:url` docs, vitest env-stub docs) when web-search excerpts are not enough.

Cite primary sources inline. Required for any major-flagged finding on this PR.

## Request to the reviewer

Four explicit calls for judgment, each ending with the question I want answered:

1. The unified `UnifiedSession` shape holds one cwd, but Amp's `env.initial.trees[]` is an array. I picked index `[0]`. Should `extractAmpMetadata` keep the "first wins" rule, or should it scan all trees and pick the one whose `uri` matches the user's current working directory at resume time?

2. The parser only calls `safeFileURLToPath` when `firstTree.uri` starts with `file://`. If you have seen Amp emit non-`file://` URIs for local working trees in real installations (Codespaces, remote SSH, devcontainers, plain absolute paths), what schemes have you observed in `env.initial.trees[].uri`?

3. Round-2 codex flagged zero major items, which is the project's convergence signal — but codex cannot see schema drift, real-Windows behavior, or Amp version skew. Is there a class of issue you would want a manual pass on before merging this, rather than treating "no majors" as implicit green-light?

4. The `extractAmpContext` early-return fallback path (when the thread JSON re-read fails on resume) currently passes `session` as-is, not `enrichedSession`. Should the fallback be hardened to use `enrichedSession` so a deleted-mid-resume thread still surfaces whatever Amp metadata was already on the in-memory session, or is the rarity of that path enough to leave it alone?

## Follow-ups (not in scope)

- Snapshot a real Amp thread file under `src/__tests__/fixtures/` so future schema drift gets caught at test time.
- Cross-platform CI matrix (macOS / Linux / Windows) for the parser tests — the XDG fixture is portable, but `pathToFileURL` round-trips and UNC-path edge cases benefit from a real Windows runner.
- Once all seven parser-hardening branches land on `feat/handoff-foundation`, fold `extractAmpMetadata` and its siblings into a single `extractParserMetadata(source, thread)` dispatcher in `parser-helpers.ts` to reduce per-parser duplication.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Amp thread parser to preserve repo context and accurate per-message timing. Adds a `SessionEvent` timeline, single-pass reads, and a regression test with real telemetry redaction.

- **New Features**
  - Extract `cwd`/`repo`/`branch`/`gitSha` from `env.initial.trees[0]`; surface in `sessionNotes.sourceMetadata`.
  - Use `msg.meta.sentAt` for per-message timestamps; emit a `SessionEvent` timeline and render it inline.
  - Single-pass `readThreadFile` returns parsed thread + raw text for line counts; `extractMessageText` uses shared `extractTextFromBlocks`.
  - Test: XDG fixture includes `installationID`/`deviceFingerprint` and asserts they don’t appear in markdown; also checks model, token usage, and HOME-relative `cwd`.

- **Refactors**
  - Wrap `fileURLToPath` with `safeFileURLToPath` so malformed URIs fall back to empty `cwd` instead of throwing.
  - Compute Amp metadata once in `extractAmpContext` and pass it to `extractSessionNotes` and session enrichment to avoid duplicate work.

<sup>Written for commit b63be382722131181c5ad65f6973de41593e02b5. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/48?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

