### PR TITLE
✨ feat(parsers/opencode): harden SQLite/JSON parsing with timeline events and metadata-derived success

### DIFF
--- a/src/__tests__/opencode.test.ts
+++ b/src/__tests__/opencode.test.ts
@@ -776,4 +776,73 @@ describe('OpenCode parser', () => {
       fixture.cleanup();
     }
   });
+
+  it('marks completed bash tools with non-zero exit metadata as failed and preserves full untruncated output', async () => {
+    const longOutput = `${'line\n'.repeat(80)}SENTINEL_FULL_OUTPUT`;
+    const fixture = createOpenCodeSqliteFixture('opencode.db', {
+      sessionId: 'ses_exit_metadata',
+      messages: [
+        {
+          id: 'msg_user_1',
+          role: 'user',
+          timeCreatedOffsetMs: -3_000,
+          parts: [{ type: 'text', text: 'Run the failing command' }],
+        },
+        {
+          id: 'msg_assistant_1',
+          role: 'assistant',
+          timeCreatedOffsetMs: -2_000,
+          parts: [
+            {
+              type: 'tool',
+              callID: 'call_bash_exit',
+              tool: 'bash',
+              state: {
+                status: 'completed',
+                input: { command: 'pnpm test failing' },
+                output: longOutput,
+                metadata: { exit: 1, truncated: false },
+              },
+            },
+            {
+              type: 'text',
+              text: 'The command failed because the assertion is wrong.',
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      process.env.OPENCODE_DB = fixture.dbPath;
+
+      const { parseOpenCodeSessions, extractOpenCodeContext } = await importOpenCodeParser();
+      const [session] = await parseOpenCodeSessions();
+      const context = await extractOpenCodeContext(session);
+      const assistant = context.recentMessages.find((message) => message.role === 'assistant');
+      const bashSummary = context.toolSummaries.find((summary) => summary.name === 'bash');
+
+      expect(assistant?.toolCalls?.[0]).toMatchObject({
+        id: 'call_bash_exit',
+        name: 'bash',
+        success: false,
+        metadata: { exit: 1, truncated: false },
+      });
+      expect(assistant?.toolCalls?.[0].result).toContain('SENTINEL_FULL_OUTPUT');
+      expect(context.sessionNotes?.sourceMetadata).toMatchObject({
+        slug: 'test-session',
+        version: '1.2.0',
+        projectId: 'proj_test',
+      });
+      expect(bashSummary?.errorCount).toBe(1);
+      expect(bashSummary?.samples[0].data).toMatchObject({
+        category: 'shell',
+        command: 'pnpm test failing',
+        exitCode: 1,
+        errored: true,
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
 });

--- a/src/parsers/opencode.ts
+++ b/src/parsers/opencode.ts
@@ -1301,7 +1301,7 @@ export async function extractOpenCodeContext(
   const sessionNotes = extractOpenCodeSessionNotes(session.id);
 
   const trimmed = trimMessages(recentMessages, resolvedConfig.recentMessages);
-  const timeline = buildOpenCodeTimeline(recentMessages);
+  const timeline = buildOpenCodeTimeline(trimmed);
 
   const markdown = generateHandoffMarkdown(
     session,

--- a/src/parsers/opencode.ts
+++ b/src/parsers/opencode.ts
@@ -1303,7 +1303,7 @@ export async function extractOpenCodeContext(
   const sessionNotes = extractOpenCodeSessionNotes(session.id);
 
   const trimmed = trimMessages(recentMessages, resolvedConfig.recentMessages);
-  const timeline = buildOpenCodeTimeline(trimmed);
+  const timeline = buildOpenCodeTimeline(trimmed, resolvedConfig.handoff.timelineWindow);
 
   const markdown = generateHandoffMarkdown(
     session,
@@ -1329,20 +1329,25 @@ export async function extractOpenCodeContext(
   };
 }
 
-function buildOpenCodeTimeline(messages: ConversationMessage[]): SessionEvent[] {
-  const events: SessionEvent[] = [];
+function buildOpenCodeTimeline(messages: ConversationMessage[], timelineWindow?: number): SessionEvent[] {
+  // Build per-message clusters of (one message event + N tool_call events) so we can
+  // budget the tool events without dropping any preserved user/assistant message.
+  type Cluster = { message: SessionEvent; tools: SessionEvent[] };
+  const clusters: Cluster[] = [];
   let sequence = 0;
+
   for (const message of messages) {
-    events.push({
+    const messageEvent: SessionEvent = {
       kind: 'message',
       sequence: sequence++,
       role: message.role,
       content: message.content,
       timestamp: message.timestamp,
       sourceId: message.sourceId,
-    });
+    };
+    const toolEvents: SessionEvent[] = [];
     for (const toolCall of message.toolCalls ?? []) {
-      events.push({
+      toolEvents.push({
         kind: 'tool_call',
         sequence: sequence++,
         timestamp: message.timestamp,
@@ -1354,6 +1359,37 @@ function buildOpenCodeTimeline(messages: ConversationMessage[]): SessionEvent[] 
         metadata: toolCall.metadata,
       });
     }
+    clusters.push({ message: messageEvent, tools: toolEvents });
+  }
+
+  const totalEvents = clusters.reduce((sum, cluster) => sum + 1 + cluster.tools.length, 0);
+
+  // When the consumer's tail-slice (timelineWindow) cannot fit every event we built,
+  // budget tool events around the messages so the slice still contains the preserved
+  // user prompts. Each cluster keeps its message event; remaining budget is distributed
+  // round-robin over tool events from the latest cluster backwards.
+  if (timelineWindow !== undefined && timelineWindow > 0 && totalEvents > timelineWindow) {
+    const messageCount = clusters.length;
+    let toolBudget = Math.max(0, timelineWindow - messageCount);
+    // Walk clusters from newest to oldest, allocating tool slots so trailing tool
+    // activity is preserved alongside the user prompts that introduced it.
+    const allowed: number[] = clusters.map(() => 0);
+    for (let i = clusters.length - 1; i >= 0 && toolBudget > 0; i--) {
+      const take = Math.min(toolBudget, clusters[i].tools.length);
+      allowed[i] = take;
+      toolBudget -= take;
+    }
+    for (let i = 0; i < clusters.length; i++) {
+      // Keep the most recent tool calls within each cluster (the trailing ones the
+      // assistant emitted just before the next message).
+      clusters[i].tools = clusters[i].tools.slice(-allowed[i]);
+    }
+  }
+
+  const events: SessionEvent[] = [];
+  for (const cluster of clusters) {
+    events.push(cluster.message);
+    for (const tool of cluster.tools) events.push(tool);
   }
   return events;
 }

--- a/src/parsers/opencode.ts
+++ b/src/parsers/opencode.ts
@@ -8,6 +8,7 @@ import { logger } from '../logger.js';
 import type {
   ConversationMessage,
   SessionContext,
+  SessionEvent,
   SessionNotes,
   ToolCall,
   ToolUsageSummary,
@@ -193,9 +194,13 @@ function renderToolPart(partData: Record<string, unknown>): {
 } | null {
   const toolName = typeof partData.tool === 'string' ? partData.tool : 'tool';
   const state = isRecord(partData.state) ? partData.state : {};
+  const metadata = getRecordValue(state, 'metadata');
   const status = typeof state.status === 'string' ? state.status : undefined;
-  const resultPreview = previewUnknown(state.output) || previewUnknown(state.error);
+  const fullResult = stringifyToolValue(state.output) ?? stringifyToolValue(state.error);
+  const resultPreview = fullResult ? previewUnknown(fullResult) : '';
   const argPreview = previewUnknown(state.input, 120);
+  const exitCode = firstNumber(metadata, ['exit', 'exitCode']);
+  const metadataIndicatesError = exitCode !== undefined && exitCode !== 0;
 
   const detailBits = [argPreview, resultPreview].filter(Boolean);
   const statusLabel = status ? ` ${status}` : '';
@@ -205,7 +210,9 @@ function renderToolPart(partData: Record<string, unknown>): {
     Boolean,
   );
   const summary = summaryBits.length > 0 ? summaryBits.join(' | ') : 'invoked';
-  const success = status === 'completed' ? true : status === 'error' ? false : undefined;
+  let success: boolean | undefined;
+  if (status === 'error' || metadataIndicatesError) success = false;
+  else if (status === 'completed') success = true;
 
   return {
     content,
@@ -216,8 +223,9 @@ function renderToolPart(partData: Record<string, unknown>): {
       name: toolName,
       ...(typeof partData.callID === 'string' ? { id: partData.callID } : {}),
       ...(normalizeToolArguments(state.input) ? { arguments: normalizeToolArguments(state.input) } : {}),
-      ...(resultPreview ? { result: resultPreview } : {}),
+      ...(fullResult ? { result: fullResult } : {}),
       ...(success !== undefined ? { success } : {}),
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
     },
   };
 }
@@ -1159,6 +1167,16 @@ function extractSessionNotesFromSqlite(sessionId: string): SessionNotes | undefi
       }
 
       if (reasoning.length > 0) notes.reasoning = reasoning;
+      const sessionRow = db.prepare('SELECT project_id, slug, version FROM session WHERE id = ?').get(sessionId) as
+        | { project_id?: string; slug?: string; version?: string }
+        | undefined;
+      if (sessionRow) {
+        notes.sourceMetadata = {
+          ...(sessionRow.slug ? { slug: sessionRow.slug } : {}),
+          ...(sessionRow.version ? { version: sessionRow.version } : {}),
+          ...(sessionRow.project_id ? { projectId: sessionRow.project_id } : {}),
+        };
+      }
       return Object.keys(notes).length > 0 ? notes : undefined;
     } catch (err) {
       logger.debug('opencode: failed to extract SQLite session notes', dbPath, sessionId, err);
@@ -1220,6 +1238,21 @@ function extractSessionNotesFromJson(sessionId: string): SessionNotes | undefine
     if (firstCreated !== undefined && lastCreated !== undefined && lastCreated >= firstCreated) {
       notes.activeTimeMs = lastCreated - firstCreated;
     }
+
+    for (const projectDir of listSubdirectories(path.join(getOpenCodeStorageDir(), 'session'))) {
+      const sessionFile = path.join(projectDir, `${sessionId}.json`);
+      if (!fs.existsSync(sessionFile)) continue;
+      const content = fs.readFileSync(sessionFile, 'utf8');
+      const result = OpenCodeSessionSchema.safeParse(JSON.parse(content));
+      if (result.success) {
+        notes.sourceMetadata = {
+          ...(result.data.slug ? { slug: result.data.slug } : {}),
+          ...(result.data.version ? { version: result.data.version } : {}),
+          projectId: result.data.projectID,
+        };
+      }
+      break;
+    }
   } catch (err) {
     logger.debug('opencode: failed to extract JSON session notes', sessionId, err);
   }
@@ -1268,6 +1301,7 @@ export async function extractOpenCodeContext(
   const sessionNotes = extractOpenCodeSessionNotes(session.id);
 
   const trimmed = trimMessages(recentMessages, resolvedConfig.recentMessages);
+  const timeline = buildOpenCodeTimeline(recentMessages);
 
   const markdown = generateHandoffMarkdown(
     session,
@@ -1277,6 +1311,8 @@ export async function extractOpenCodeContext(
     toolData.summaries,
     sessionNotes,
     resolvedConfig,
+    'inline',
+    timeline,
   );
 
   return {
@@ -1286,6 +1322,36 @@ export async function extractOpenCodeContext(
     pendingTasks,
     toolSummaries: toolData.summaries,
     ...(sessionNotes ? { sessionNotes } : {}),
+    timeline,
     markdown,
   };
+}
+
+function buildOpenCodeTimeline(messages: ConversationMessage[]): SessionEvent[] {
+  const events: SessionEvent[] = [];
+  let sequence = 0;
+  for (const message of messages) {
+    events.push({
+      kind: 'message',
+      sequence: sequence++,
+      role: message.role,
+      content: message.content,
+      timestamp: message.timestamp,
+      sourceId: message.sourceId,
+    });
+    for (const toolCall of message.toolCalls ?? []) {
+      events.push({
+        kind: 'tool_call',
+        sequence: sequence++,
+        timestamp: message.timestamp,
+        toolName: toolCall.name,
+        toolCallId: toolCall.id,
+        status: toolCall.success === undefined ? undefined : toolCall.success ? 'success' : 'error',
+        arguments: toolCall.arguments,
+        result: toolCall.result,
+        metadata: toolCall.metadata,
+      });
+    }
+  }
+  return events;
 }

--- a/src/parsers/opencode.ts
+++ b/src/parsers/opencode.ts
@@ -216,6 +216,8 @@ function renderToolPart(partData: Record<string, unknown>): {
   if (status === 'error' || metadataIndicatesError) success = false;
   else if (status === 'completed') success = true;
 
+  const normalizedArguments = normalizeToolArguments(state.input);
+
   return {
     content,
     toolName,
@@ -224,7 +226,7 @@ function renderToolPart(partData: Record<string, unknown>): {
     toolCall: {
       name: toolName,
       ...(typeof partData.callID === 'string' ? { id: partData.callID } : {}),
-      ...(normalizeToolArguments(state.input) ? { arguments: normalizeToolArguments(state.input) } : {}),
+      ...(normalizedArguments ? { arguments: normalizedArguments } : {}),
       ...(fullResult ? { result: fullResult } : {}),
       ...(success !== undefined ? { success } : {}),
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
@@ -1245,12 +1247,21 @@ function extractSessionNotesFromJson(sessionId: string): SessionNotes | undefine
       const sessionFile = path.join(projectDir, `${sessionId}.json`);
       if (!fs.existsSync(sessionFile)) continue;
       const content = fs.readFileSync(sessionFile, 'utf8');
-      const result = OpenCodeSessionSchema.safeParse(JSON.parse(content));
+      let parsedJson: unknown;
+      try {
+        parsedJson = JSON.parse(content);
+      } catch (err) {
+        // One malformed session file shouldn't lose the reasoning/token/activeTime
+        // already extracted from the message dir for this session.
+        logger.debug('opencode: skipping malformed session file', sessionFile, err);
+        continue;
+      }
+      const result = OpenCodeSessionSchema.safeParse(parsedJson);
       if (result.success) {
         notes.sourceMetadata = {
           ...(result.data.slug ? { slug: result.data.slug } : {}),
           ...(result.data.version ? { version: result.data.version } : {}),
-          projectId: result.data.projectID,
+          ...(result.data.projectID ? { projectId: result.data.projectID } : {}),
         };
       }
       break;
@@ -1370,6 +1381,20 @@ function buildOpenCodeTimeline(messages: ConversationMessage[], timelineWindow?:
   // round-robin over tool events from the latest cluster backwards.
   if (timelineWindow !== undefined && timelineWindow > 0 && totalEvents > timelineWindow) {
     const messageCount = clusters.length;
+    if (messageCount > timelineWindow) {
+      // Even the message events alone exceed the window; keep the most recent
+      // clusters (already preserves the latest user prompt) and drop all tool
+      // events so the consumer's tail-slice cannot evict messages.
+      const tail = clusters.slice(-timelineWindow);
+      tail.forEach((cluster) => {
+        cluster.tools = [];
+      });
+      clusters.length = 0;
+      clusters.push(...tail);
+      const trimmedEvents: SessionEvent[] = [];
+      for (const cluster of clusters) trimmedEvents.push(cluster.message);
+      return trimmedEvents;
+    }
     let toolBudget = Math.max(0, timelineWindow - messageCount);
     // Walk clusters from newest to oldest, allocating tool slots so trailing tool
     // activity is preserved alongside the user prompts that introduced it.
@@ -1381,8 +1406,9 @@ function buildOpenCodeTimeline(messages: ConversationMessage[], timelineWindow?:
     }
     for (let i = 0; i < clusters.length; i++) {
       // Keep the most recent tool calls within each cluster (the trailing ones the
-      // assistant emitted just before the next message).
-      clusters[i].tools = clusters[i].tools.slice(-allowed[i]);
+      // assistant emitted just before the next message). slice(-0) === slice(0)
+      // returns the full array, so guard the zero-budget case explicitly.
+      clusters[i].tools = allowed[i] > 0 ? clusters[i].tools.slice(-allowed[i]) : [];
     }
   }
 

--- a/src/parsers/opencode.ts
+++ b/src/parsers/opencode.ts
@@ -196,7 +196,9 @@ function renderToolPart(partData: Record<string, unknown>): {
   const state = isRecord(partData.state) ? partData.state : {};
   const metadata = getRecordValue(state, 'metadata');
   const status = typeof state.status === 'string' ? state.status : undefined;
-  const fullResult = stringifyToolValue(state.output) ?? stringifyToolValue(state.error);
+  const outputString = stringifyToolValue(state.output);
+  const errorString = stringifyToolValue(state.error);
+  const fullResult = outputString && outputString.length > 0 ? outputString : errorString;
   const resultPreview = fullResult ? previewUnknown(fullResult) : '';
   const argPreview = previewUnknown(state.input, 120);
   const exitCode = firstNumber(metadata, ['exit', 'exitCode']);


### PR DESCRIPTION
## Summary

Hardens the OpenCode parser so it produces accurate tool-call records, surfaces session provenance, and preserves user prompts in the trimmed timeline. `renderToolPart` now returns a structured `toolCall` (id, args, full result, success, metadata) instead of a string preview; success is inferred from `status` *and* exit-code metadata so completed-but-non-zero bash invocations are flagged as failures. SQLite + JSON code paths both extract `sourceMetadata` (slug, version, projectId) into `SessionNotes`. A new cluster-budgeted timeline builder guarantees user messages survive `slice(-timelineWindow)` even when a single assistant turn floods the window with tool events. 69 lines of regression tests cover the new behaviour.

## Context / Why now

OpenCode is the only parser backed by SQLite (with a JSON-file fallback for older installs), so it lags the rest of the parser fleet on the `feat/handoff-foundation` upgrades: timeline events on `SessionContext`, `sourceMetadata` on `SessionNotes`, and structured `ToolCall` shapes. This branch closes those gaps so handoffs *out of* OpenCode (e.g. `continues resume <opencode-session> --as claude`) carry the same fidelity as Claude Code or Codex sources. It also resolves a class of bugs where OpenCode's `bash` tool would record `success: true` for commands that exited non-zero — purely because the tool's `state.status` is `completed` regardless of exit code; the truth lives in `state.metadata.exit`.

## What changed

Commits, oldest first, grouped logically:

### 1. `191261c` ✨ feat(parsers/opencode): hardened SQLite/JSON parsing with timeline events + tests

The base feature commit. Five concerns:

- **Structured `ToolCall` from `renderToolPart`.** Previously the tool block emitted only a markdown summary and a short result preview. Now it returns `{ content, summary, isError, toolCall }` with the full untruncated result, normalised arguments, the `callID`, and a `metadata` passthrough. The summary string is preserved for the markdown renderer; the `toolCall` flows into `ConversationMessage.toolCalls` for downstream consumers.
- **Metadata-derived success inference.** `success` is no longer just `status === 'completed'`. The new logic reads `state.metadata.exit` / `state.metadata.exitCode`; if it is defined and non-zero, `success = false`. This fixes the `bash` exit-code blind spot. `status === 'error'` still wins over metadata.
- **`sourceMetadata` extraction.** Both code paths (`extractSessionNotesFromSqlite`, `extractSessionNotesFromJson`) now populate `notes.sourceMetadata` with `{ slug, version, projectId }`. SQLite reads from the `session` table; JSON reads from the per-project session JSON file under `<storage>/session/<projectId>/<sessionId>.json`.
- **Channel-specific DB discovery.** Adds `opencode-*.db` glob alongside the canonical `opencode.db` so users on `dev`/`stable` channels are not invisible to the parser.
- **Timeline event emission.** `extractOpenCodeContext` builds a `SessionEvent[]` timeline from the trimmed message list and passes it (plus `'inline'` mode) to `generateHandoffMarkdown`.

### 2. `7f70850` 🐛 fix(parsers/opencode): build timeline from trimmed messages

`cdx-1` from round-1 codex review. The initial commit fed `recentMessages` (untrimmed) into `buildOpenCodeTimeline`, then relied on the renderer's `slice(-timelineWindow)` to clip. Result: tool_call events from earlier history flooded the slice and evicted the most recent user prompt. The fix passes `trimmed` instead, so the timeline composes with the user-retention guarantee already enforced by `trimMessages`.

### 3. `53626b1` 🐛 fix(parsers/opencode): preserve error fallback in renderToolPart

`cdx-1` from round-2 codex review. The previous expression `previewUnknown(state.output) || previewUnknown(state.error)` short-circuited on truthy-but-empty output strings and dropped error text. Reworked into an explicit `fullResult = outputString && outputString.length > 0 ? outputString : errorString` so the error path is reached when output is missing-or-empty.

### 4. `e9fd77c` 🐛 fix(parsers/opencode): preserve user prompt when timeline clips tool events

`cdx-2` from round-2 codex review. Even with trimmed input, a single assistant turn with N tool calls can still exceed `timelineWindow` and push the preceding user prompt out of the tail slice. The fix clusters each message with its tool events, allocates message slots first, then distributes the remaining budget to tool events from newest cluster backwards. Within each cluster the *most recent* tool calls win (the trailing ones the assistant emitted just before the next message). Rationale comments in the code call out the invariant the heuristic preserves.

## Files touched

| Path | +Adds | -Dels | Purpose |
|---|---:|---:|---|
| `src/parsers/opencode.ts` | 107 | 3 | Structured `toolCall`, metadata-derived `success`, error fallback, `sourceMetadata` (SQLite + JSON), channel-specific DB glob, `buildOpenCodeTimeline` with cluster-budgeted slot allocation. |
| `src/__tests__/opencode.test.ts` | 69 | 0 | Regression test: completed bash with `metadata.exit: 1` is flagged failed; full untruncated output preserved; `sourceMetadata` populated; `errorCount` and tool-summary `samples[].errored` propagate. |

## How it was reviewed

Two rounds of `/codex:review` on the worktree, status `DONE-PRAGMATIC`:

| Round | Major items raised | Accepted | Items |
|---|---:|---:|---|
| r1 | 1 | 1 | cdx-1: timeline built from untrimmed messages → fix `7f70850`. |
| r2 | 2 | 2 | cdx-1: error fallback short-circuited on empty output → fix `53626b1`. cdx-2: tool-event flood within a single turn evicts the user prompt → fix `e9fd77c`. |

`DONE-PRAGMATIC` (not `DONE`) because convergence was reached *via reasoned heuristics tested against fixtures*, not against an external corpus of real OpenCode session databases across channels and minor versions. The cluster-budgeted timeline preserves user prompts under the test scenarios we constructed; it has not been validated against, e.g., a session with 50 tool calls in a single assistant turn followed by no further user message.

This PR will be evaluated post-open by **Codex rescue** (triggered automatically) and the GitHub PR review bots (Copilot, Greptile, Devin) plus any human reviewers. The body is written with that audience in mind.

## Risks / Known limitations

- **Timeline budgeting is a heuristic, not a proof.** Cluster-budgeted slot allocation guarantees every preserved *message* event survives the tail slice, but the heuristic for *which* tool events to keep ("most recent within each cluster, distributing remaining budget from newest cluster backwards") is reasoned, not derived from observed user-utility data. Edge cases with very wide assistant turns may still produce a slice that is less informative than a flat `slice(-N)` if the trailing tool calls are noise.
- **`sourceMetadata` schema brittleness.** The SQLite path hardcodes a `SELECT project_id, slug, version FROM session WHERE id = ?`. OpenCode's session table is not a public contract — column names and presence vary across minor versions and channels. The query is wrapped in the existing `try/catch` so a schema drift will degrade gracefully (no `sourceMetadata`) rather than crash, but it will silently lose fidelity. The JSON fallback uses Zod's `OpenCodeSessionSchema.safeParse`, which is more resilient.
- **Channel-specific DB discovery may surprise multi-channel users.** Globbing `opencode-*.db` alongside `opencode.db` means a user with `dev` and `stable` channels installed will see sessions from both surfaced in `continues list`. We treat this as a feature (more sessions are good) but a single-channel user with a stale `opencode-old.db` left over from a manual move will get phantom entries.
- **Exit-code coverage.** Metadata-derived error inference covers `metadata.exit` and `metadata.exitCode`. If OpenCode introduces a new metadata key for failures (e.g. `metadata.signal`, `metadata.terminatedBy`), those will read as success until the key list is extended.
- **Test fixture realism.** `createOpenCodeSqliteFixture` writes a synthetic schema. It mirrors the columns we read but does not exercise the variation across actual installs.

## Reviewer questions

1. The cluster-budget heuristic in `buildOpenCodeTimeline` allocates slots by walking clusters newest-to-oldest, which means an early-conversation cluster with many tool calls will get zero tool slots before a late-conversation cluster with one tool call gets its slot. Is that the right priority for handoff utility, or should we weight by cluster recency *and* tool count, or invert and prefer earlier clusters when later clusters contain mostly noise?
2. Reading `slug, version, project_id` directly from the OpenCode `session` SQLite table couples us to an unversioned schema. Should we instead probe the `sqlite_master` table for column presence and skip absent fields, or is the current `try/catch` graceful-degradation sufficient for a read-only parser?
3. For the channel-specific DB glob, do we want explicit channel labelling on the surfaced sessions (e.g. `[dev]`, `[stable]` in the session label) so users can disambiguate when the same session id appears in multiple DBs, or is "first match wins" acceptable since OpenCode session ids are unique per install?
4. The error fallback in `renderToolPart` now prefers `output` when present-and-non-empty, otherwise `error`. Is this the correct ordering for the case where both are populated (output succeeded, error is a warning), or should non-empty `error` always take precedence?
5. The metadata-derived `success` check inspects `metadata.exit` and `metadata.exitCode`. Does OpenCode emit any other failure-signal keys (signals, timeouts, killed-by-user) that we should fold into the same check?

## Reviewer guidance

This PR's correctness depends on assumptions about three external surfaces. For any major-flagged finding, please verify with primary sources before recommending a change. The research-powerpack MCP tools are explicitly available for this:

- **`mcp__research-powerpack__web-search`** — quick checks on Node `node:sqlite` API surface (it is still flagged experimental in Node 22+; confirm flags or behaviour have not changed in newer minors), Zod `safeParse` semantics around unknown keys, vitest fixture conventions.
- **`mcp__research-powerpack__start-research`** — multi-source synthesis on cross-platform behaviour: macOS `~/Library/Application Support/opencode/` versus Linux `$XDG_DATA_HOME/opencode/` versus the fallback path the parser uses (`~/.local/share/opencode/`), and whether the channel-specific DB layout we glob for exists on Windows installs at all.
- **`mcp__research-powerpack__scrape-links`** — fetch the OpenCode session-storage docs/source directly to confirm: (a) the `session` table columns referenced by `extractSessionNotesFromSqlite`, (b) the per-project JSON layout under `<storage>/session/<projectId>/<sessionId>.json`, (c) the channel naming convention for `opencode-*.db`.

Cite evidence inline for any major finding. Prefer primary sources (OpenCode repo, Node docs, Zod docs) over secondary commentary. For the AI-CLI session-storage assumptions specifically, the OpenCode source tree is the only authoritative reference — please link the exact file/line if disagreeing with a behaviour assertion in this PR.

## Test plan

- [x] `pnpm test src/__tests__/opencode.test.ts` — new "marks completed bash tools with non-zero exit metadata as failed and preserves full untruncated output" test passes.
- [x] `pnpm test src/__tests__/unit-conversions.test.ts` — all 42 cross-tool conversion paths still pass; OpenCode-as-source and OpenCode-as-target conversions exercise the new `toolCall` shape end to end.
- [x] `pnpm run build` — TypeScript compiles cleanly under strict mode; `SessionEvent` import wired through.
- [ ] Manual smoke test against a real `~/.local/share/opencode/opencode.db` from a recent OpenCode session. *(Recommended before merge; not run by author.)*
- [ ] Manual smoke test with a stale JSON-only OpenCode install (no SQLite DB present) to confirm the JSON fallback still extracts `sourceMetadata`. *(Recommended before merge; not run by author.)*
- [ ] Spot-check `continues resume <opencode-session> --as codex` produces a markdown handoff whose `Recent Conversation` section retains the original user prompt even when the assistant turn was tool-heavy.

## Follow-ups (not in scope)

- Validate the cluster-budget timeline heuristic against a corpus of real OpenCode sessions and tune slot allocation if the "newest-cluster-first" walk produces unhelpful slices in practice.
- Probe `sqlite_master` for `session` table columns instead of hard-selecting `slug, version, project_id`, so schema drift across OpenCode versions degrades column-by-column rather than via the outer `try/catch`.
- Extend the failure-signal key list (`metadata.exit`, `metadata.exitCode`) once we observe additional keys in real OpenCode session data.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the OpenCode parser to emit structured tool calls, infer success from exit metadata, extract provenance, and build a clipped timeline that keeps user prompts. Adds resilient SQLite/JSON parsing, channel-aware DB discovery, and timeline handoff in `inline` mode.

- **New Features**
  - `renderToolPart` returns a structured tool call (id, args, full result, success, metadata).
  - Success inferred from `status` plus `metadata.exit`/`metadata.exitCode`; non‑zero `bash` exits are failures.
  - Extracted `sourceMetadata` (slug, version, projectId) from SQLite and JSON; collects reasoning highlights.
  - Channel-aware DB discovery (`opencode-*.db`).
  - Timeline events built from trimmed messages with a cluster-budgeted builder; returned on context and passed to handoff in `inline` mode.
  - Added 69 lines of regression tests.

- **Bug Fixes**
  - Preserve error fallback in tool rendering when output is present-but-empty.
  - Timeline budgeting: keep messages when tool events overflow; handle zero-budget slices and when messages alone exceed `timelineWindow`.
  - JSON path: per-file `JSON.parse` guard; avoid storing `projectId: undefined`.
  - Deduped argument normalization in `renderToolPart`.

<sup>Written for commit aaaa009d9ade9e0d712c2b26a3583c99295d7f40. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/49?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

