### PR TITLE
✨ feat(parsers/gemini): harden JSONL parsing with timeline events and rewind reconciliation

### DIFF
--- a/src/__tests__/gemini-parser.test.ts
+++ b/src/__tests__/gemini-parser.test.ts
@@ -261,4 +261,115 @@ describe('gemini parser hardening', () => {
     expect(sessions).toHaveLength(1);
     expect(sessions[0].id).toBe('gemini-malformed-session');
   });
+
+  it('preserves info, warning, error, and tool-only Gemini records chronologically without promoting thoughts to key decisions', async () => {
+    const home = makeGeminiHome();
+    const originalPath = writeGeminiJsonlSession({
+      home,
+      projectId: 'tool-only-proj',
+      fileName: 'session-2026-04-15T10-00-toolonly1234.jsonl',
+      records: [
+        {
+          sessionId: 'gemini-tool-only-session',
+          projectHash: 'tool-only-proj',
+          startTime: '2026-04-15T10:00:00.000Z',
+          lastUpdated: '2026-04-15T10:00:05.000Z',
+        },
+        {
+          id: 'msg-user-1',
+          timestamp: '2026-04-15T10:00:01.000Z',
+          type: 'user',
+          content: 'Write the verification file',
+        },
+        {
+          id: 'msg-info-1',
+          timestamp: '2026-04-15T10:00:02.000Z',
+          type: 'info',
+          content: 'Gemini CLI update available',
+        },
+        {
+          id: 'msg-warning-1',
+          timestamp: '2026-04-15T10:00:02.250Z',
+          type: 'warning',
+          content: 'Retrying transient API error',
+        },
+        {
+          id: 'msg-error-1',
+          timestamp: '2026-04-15T10:00:02.500Z',
+          type: 'error',
+          content: 'Tool call recovered after retry',
+        },
+        {
+          id: 'msg-tool-1',
+          timestamp: '2026-04-15T10:00:03.000Z',
+          type: 'gemini',
+          content: '',
+          model: 'gemini-2.5-pro',
+          toolCalls: [
+            {
+              id: 'call-write-1',
+              name: 'write_file',
+              args: { file_path: '/tmp/gemini-project/verification.txt' },
+              status: 'completed',
+              timestamp: '2026-04-15T10:00:03.000Z',
+              resultDisplay: 'wrote verification.txt',
+              result: [
+                {
+                  functionResponse: {
+                    id: 'call-write-1',
+                    name: 'write_file',
+                    response: { output: 'write complete' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'msg-asst-1',
+          timestamp: '2026-04-15T10:00:04.000Z',
+          type: 'gemini',
+          content: 'Verification file written.',
+          thoughts: [{ subject: 'Analysis', description: 'Need to preserve tool-only records' }],
+        },
+      ],
+    });
+
+    const { extractGeminiContext } = await loadGeminiParser(home);
+    const context = await extractGeminiContext({
+      id: 'gemini-tool-only-session',
+      source: 'gemini',
+      cwd: '/tmp/gemini-project',
+      lines: 5,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-04-15T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-15T10:00:05.000Z'),
+      originalPath,
+      summary: 'Write the verification file',
+    });
+
+    expect(context.recentMessages.map((message) => message.content)).toEqual([
+      'Write the verification file',
+      'Gemini CLI update available',
+      'Retrying transient API error',
+      'Tool call recovered after retry',
+      '[Used tools: write_file]',
+      'Verification file written.',
+    ]);
+    expect(context.filesModified).toContain('/tmp/gemini-project/verification.txt');
+    expect(context.timeline?.map((event) => event.kind)).toEqual([
+      'message',
+      'metadata',
+      'warning',
+      'warning',
+      'tool_call',
+      'message',
+    ]);
+    expect(context.sessionNotes?.reasoning).toBeUndefined();
+    expect(context.sessionNotes?.reasoningSteps?.[0].thought).toContain('preserve tool-only');
+    expect(context.markdown).toContain('Tool Call: write_file completed');
+    expect(context.markdown).toContain('Gemini CLI update available');
+    expect(context.markdown).toContain('Retrying transient API error');
+    expect(context.markdown).toContain('Tool call recovered after retry');
+  });
 });

--- a/src/parsers/gemini.ts
+++ b/src/parsers/gemini.ts
@@ -258,7 +258,12 @@ function getGeminiToolResultText(tc: NonNullable<GeminiMessage['toolCalls']>[num
 
 function getGeminiToolFilePath(tc: NonNullable<GeminiMessage['toolCalls']>[number]): string {
   const resultDisplay = getGeminiResultDisplayObject(tc.resultDisplay);
-  return resultDisplay?.filePath || (tc.args?.file_path as string) || (tc.args?.path as string) || '';
+  if (typeof resultDisplay?.filePath === 'string') return resultDisplay.filePath;
+  const argFilePath = tc.args?.file_path;
+  if (typeof argFilePath === 'string') return argFilePath;
+  const argPath = tc.args?.path;
+  if (typeof argPath === 'string') return argPath;
+  return '';
 }
 
 function inferGeminiCwdFromToolPaths(session: GeminiSessionData): string {
@@ -266,7 +271,7 @@ function inferGeminiCwdFromToolPaths(session: GeminiSessionData): string {
     if (msg.type !== 'gemini' || !msg.toolCalls) continue;
     for (const toolCall of msg.toolCalls) {
       const filePath = getGeminiToolFilePath(toolCall);
-      if (filePath.startsWith('/')) return path.dirname(filePath);
+      if (path.isAbsolute(filePath)) return path.dirname(filePath);
     }
   }
   return '';
@@ -495,7 +500,16 @@ function extractSessionNotes(sessionData: GeminiSession): SessionNotes {
     }
   }
 
-  if (reasoningSteps.length > 0) notes.reasoningSteps = reasoningSteps;
+  if (reasoningSteps.length > 0) {
+    // Backfill totalSteps with the final count so each step's stepNumber/totalSteps
+    // pair stays internally consistent (the inner loop only knew the per-message
+    // thought count, which made later steps render as "step N/M" with an outdated M).
+    const finalCount = reasoningSteps.length;
+    for (const step of reasoningSteps) {
+      step.totalSteps = finalCount;
+    }
+    notes.reasoningSteps = reasoningSteps;
+  }
   return notes;
 }
 

--- a/src/parsers/gemini.ts
+++ b/src/parsers/gemini.ts
@@ -6,7 +6,9 @@ import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type {
   ConversationMessage,
+  ReasoningStep,
   SessionContext,
+  SessionEvent,
   SessionNotes,
   ToolUsageSummary,
   UnifiedSession,
@@ -109,7 +111,7 @@ function getSessionDirectory(session: GeminiSessionData, projectDirectories: Map
   const metadataDirectory = session.directories?.find(
     (directory) => typeof directory === 'string' && directory.length > 0,
   );
-  return metadataDirectory || projectDirectories.get(session.projectHash) || '';
+  return metadataDirectory || projectDirectories.get(session.projectHash) || inferGeminiCwdFromToolPaths(session) || '';
 }
 
 function findRewindIndex(messages: GeminiMessage[], messageId: string): number {
@@ -235,6 +237,41 @@ function extractGeminiContent(content: string | Array<{ text?: string; type?: st
   return extractTextFromBlocks(content as string | Array<{ type: string; text?: string }>);
 }
 
+type GeminiResultDisplayObject = Exclude<NonNullable<GeminiMessage['toolCalls']>[number]['resultDisplay'], string>;
+
+function getGeminiResultDisplayObject(
+  value: NonNullable<GeminiMessage['toolCalls']>[number]['resultDisplay'],
+): GeminiResultDisplayObject | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : undefined;
+}
+
+function getGeminiResultDisplayText(value: NonNullable<GeminiMessage['toolCalls']>[number]['resultDisplay']): string {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return '';
+  return value.fileDiff || value.newContent || value.originalContent || '';
+}
+
+function getGeminiToolResultText(tc: NonNullable<GeminiMessage['toolCalls']>[number]): string {
+  const response = tc.result?.[0]?.functionResponse?.response;
+  return response?.output || response?.error || getGeminiResultDisplayText(tc.resultDisplay);
+}
+
+function getGeminiToolFilePath(tc: NonNullable<GeminiMessage['toolCalls']>[number]): string {
+  const resultDisplay = getGeminiResultDisplayObject(tc.resultDisplay);
+  return resultDisplay?.filePath || (tc.args?.file_path as string) || (tc.args?.path as string) || '';
+}
+
+function inferGeminiCwdFromToolPaths(session: GeminiSessionData): string {
+  for (const msg of session.messages) {
+    if (msg.type !== 'gemini' || !msg.toolCalls) continue;
+    for (const toolCall of msg.toolCalls) {
+      const filePath = getGeminiToolFilePath(toolCall);
+      if (filePath.startsWith('/')) return path.dirname(filePath);
+    }
+  }
+  return '';
+}
+
 /**
  * Extract first real user message from Gemini session
  */
@@ -259,31 +296,32 @@ function extractToolData(
   for (const msg of sessionData.messages) {
     if (msg.type !== 'gemini' || !msg.toolCalls) continue;
     for (const tc of msg.toolCalls) {
-      const { name, args, result, resultDisplay, status } = tc;
+      const { name, args, resultDisplay, status } = tc;
+      const display = getGeminiResultDisplayObject(resultDisplay);
       const category = classifyToolName(name);
       if (!category) continue; // skip internal tools
 
-      const fp = resultDisplay?.filePath || (args?.file_path as string) || (args?.path as string) || '';
-      const resultStr = result?.[0]?.functionResponse?.response?.output;
+      const fp = getGeminiToolFilePath(tc);
+      const resultStr = getGeminiToolResultText(tc);
       const isError = status ? !['ok', 'success', 'completed'].includes(status.toLowerCase()) : false;
 
       switch (category) {
         case 'write': {
           let diffStat: { added: number; removed: number } | undefined;
-          if (resultDisplay?.diffStat) {
+          if (display?.diffStat) {
             diffStat = {
-              added: resultDisplay.diffStat.model_added_lines || 0,
-              removed: resultDisplay.diffStat.model_removed_lines || 0,
+              added: display.diffStat.model_added_lines || 0,
+              removed: display.diffStat.model_removed_lines || 0,
             };
-          } else if (resultDisplay?.fileDiff) {
-            const lines = resultDisplay.fileDiff.split('\n');
+          } else if (display?.fileDiff) {
+            const lines = display.fileDiff.split('\n');
             diffStat = {
               added: lines.filter((l: string) => l.startsWith('+')).length,
               removed: lines.filter((l: string) => l.startsWith('-')).length,
             };
           }
-          const isNewFile = resultDisplay?.isNewFile ?? false;
-          const diff = resultDisplay?.fileDiff || undefined;
+          const isNewFile = display?.isNewFile ?? false;
+          const diff = display?.fileDiff || undefined;
           collector.add(name, fileSummary('write', fp, diffStat, isNewFile), {
             data: {
               category: 'write',
@@ -317,19 +355,19 @@ function extractToolData(
         }
         case 'edit': {
           let diffStat: { added: number; removed: number } | undefined;
-          if (resultDisplay?.diffStat) {
+          if (display?.diffStat) {
             diffStat = {
-              added: resultDisplay.diffStat.model_added_lines || 0,
-              removed: resultDisplay.diffStat.model_removed_lines || 0,
+              added: display.diffStat.model_added_lines || 0,
+              removed: display.diffStat.model_removed_lines || 0,
             };
-          } else if (resultDisplay?.fileDiff) {
-            const dLines = resultDisplay.fileDiff.split('\n');
+          } else if (display?.fileDiff) {
+            const dLines = display.fileDiff.split('\n');
             diffStat = {
               added: dLines.filter((l: string) => l.startsWith('+')).length,
               removed: dLines.filter((l: string) => l.startsWith('-')).length,
             };
           }
-          const diff = resultDisplay?.fileDiff || undefined;
+          const diff = display?.fileDiff || undefined;
           collector.add(name, fileSummary('edit', fp, diffStat), {
             data: {
               category: 'edit',
@@ -417,7 +455,7 @@ function extractToolData(
  */
 function extractSessionNotes(sessionData: GeminiSession): SessionNotes {
   const notes: SessionNotes = {};
-  const reasoning: string[] = [];
+  const reasoningSteps: ReasoningStep[] = [];
 
   for (const msg of sessionData.messages) {
     if (msg.type !== 'gemini') continue;
@@ -439,16 +477,25 @@ function extractSessionNotes(sessionData: GeminiSession): SessionNotes {
       }
     }
 
-    if (msg.thoughts && reasoning.length < 5) {
+    if (msg.thoughts && reasoningSteps.length < 10) {
       for (const thought of msg.thoughts) {
-        if (reasoning.length >= 5) break;
+        if (reasoningSteps.length >= 10) break;
         const text = thought.description || thought.subject || '';
-        if (text.length > 10) reasoning.push(truncate(text, 200));
+        if (text.length > 10) {
+          reasoningSteps.push({
+            stepNumber: reasoningSteps.length + 1,
+            totalSteps: msg.thoughts.length,
+            purpose: 'analysis',
+            thought: truncate(text, 200),
+            outcome: '',
+            nextAction: '',
+          });
+        }
       }
     }
   }
 
-  if (reasoning.length > 0) notes.reasoning = reasoning;
+  if (reasoningSteps.length > 0) notes.reasoningSteps = reasoningSteps;
   return notes;
 }
 
@@ -507,6 +554,8 @@ export async function extractGeminiContext(session: UnifiedSession, config?: Ver
   const pendingTasks: string[] = [];
   let toolSummaries: ToolUsageSummary[] = [];
   let sessionNotes: SessionNotes | undefined;
+  const timeline: SessionEvent[] = [];
+  let sequence = 0;
 
   if (sessionData) {
     const toolData = extractToolData(sessionData, resolvedConfig);
@@ -514,7 +563,7 @@ export async function extractGeminiContext(session: UnifiedSession, config?: Ver
     filesModified = toolData.filesModified;
     sessionNotes = extractSessionNotes(sessionData);
 
-    for (const msg of sessionData.messages.slice(-resolvedConfig.recentMessages * 2)) {
+    for (const msg of sessionData.messages) {
       // Extract pending tasks from thoughts
       if (msg.type === 'gemini' && msg.thoughts && pendingTasks.length < 5) {
         for (const thought of msg.thoughts) {
@@ -536,10 +585,20 @@ export async function extractGeminiContext(session: UnifiedSession, config?: Ver
       }
 
       if (msg.type === 'user') {
+        const content = extractGeminiContent(msg.content);
         recentMessages.push({
           role: 'user',
-          content: extractGeminiContent(msg.content),
+          content,
           timestamp: new Date(msg.timestamp),
+          sourceId: msg.id,
+        });
+        timeline.push({
+          kind: 'message',
+          sequence: sequence++,
+          role: 'user',
+          content,
+          timestamp: new Date(msg.timestamp),
+          sourceId: msg.id,
         });
       } else if (msg.type === 'gemini') {
         const textContent = extractGeminiContent(msg.content);
@@ -548,6 +607,64 @@ export async function extractGeminiContext(session: UnifiedSession, config?: Ver
             role: 'assistant',
             content: textContent,
             timestamp: new Date(msg.timestamp),
+            sourceId: msg.id,
+          });
+          timeline.push({
+            kind: 'message',
+            sequence: sequence++,
+            role: 'assistant',
+            content: textContent,
+            timestamp: new Date(msg.timestamp),
+            sourceId: msg.id,
+          });
+        } else if (msg.toolCalls && msg.toolCalls.length > 0) {
+          recentMessages.push({
+            role: 'assistant',
+            content: `[Used tools: ${msg.toolCalls.map((toolCall) => toolCall.name).join(', ')}]`,
+            timestamp: new Date(msg.timestamp),
+            sourceId: msg.id,
+            toolCalls: msg.toolCalls.map((toolCall) => ({
+              id: toolCall.id,
+              name: toolCall.name,
+              arguments: toolCall.args,
+              result: getGeminiToolResultText(toolCall) || undefined,
+              success: toolCall.status
+                ? ['ok', 'success', 'completed'].includes(toolCall.status.toLowerCase())
+                : undefined,
+            })),
+          });
+        }
+
+        for (const toolCall of msg.toolCalls ?? []) {
+          timeline.push({
+            kind: 'tool_call',
+            sequence: sequence++,
+            timestamp: toolCall.timestamp ? new Date(toolCall.timestamp) : new Date(msg.timestamp),
+            sourceId: msg.id,
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            status: toolCall.status,
+            arguments: toolCall.args,
+            result: getGeminiToolResultText(toolCall) || undefined,
+            filePaths: getGeminiToolFilePath(toolCall) ? [getGeminiToolFilePath(toolCall)] : undefined,
+          });
+        }
+      } else if (['info', 'warning', 'error'].includes(msg.type)) {
+        const content = extractGeminiContent(msg.content);
+        if (content) {
+          recentMessages.push({
+            role: 'system',
+            content,
+            timestamp: new Date(msg.timestamp),
+            sourceId: msg.id,
+          });
+          timeline.push({
+            kind: msg.type === 'info' ? 'metadata' : 'warning',
+            sequence: sequence++,
+            timestamp: new Date(msg.timestamp),
+            sourceId: msg.id,
+            status: msg.type,
+            content,
           });
         }
       }
@@ -564,6 +681,8 @@ export async function extractGeminiContext(session: UnifiedSession, config?: Ver
     toolSummaries,
     sessionNotes,
     resolvedConfig,
+    'inline',
+    timeline,
   );
 
   return {
@@ -573,6 +692,7 @@ export async function extractGeminiContext(session: UnifiedSession, config?: Ver
     pendingTasks,
     toolSummaries,
     sessionNotes,
+    timeline,
     markdown,
   };
 }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -280,22 +280,27 @@ export const GeminiToolCallSchema = z
       .optional(),
     status: z.string().optional(),
     resultDisplay: z
-      .object({
-        fileName: z.string().optional(),
-        filePath: z.string().optional(),
-        fileDiff: z.string().optional(),
-        originalContent: z.string().optional(),
-        newContent: z.string().optional(),
-        diffStat: z
+      .union([
+        z.string(),
+        z
           .object({
-            model_added_lines: z.number().optional(),
-            model_removed_lines: z.number().optional(),
+            fileName: z.string().optional(),
+            filePath: z.string().optional(),
+            fileDiff: z.string().optional(),
+            originalContent: z.string().optional(),
+            newContent: z.string().optional(),
+            renderOutputAsMarkdown: z.boolean().optional(),
+            diffStat: z
+              .object({
+                model_added_lines: z.number().optional(),
+                model_removed_lines: z.number().optional(),
+              })
+              .passthrough()
+              .optional(),
+            isNewFile: z.boolean().optional(),
           })
-          .passthrough()
-          .optional(),
-        isNewFile: z.boolean().optional(),
-      })
-      .passthrough()
+          .passthrough(),
+      ])
       .optional(),
   })
   .passthrough();


### PR DESCRIPTION
# feat(parsers/gemini): harden JSONL parsing with timeline events and rewind reconciliation

## Summary

Hardens the Gemini CLI session parser against the real shape of `~/.gemini/tmp/*/chats/*.jsonl` files: `resultDisplay` now accepts the polymorphic `string | object` union the runtime emits, tool-only assistant turns are no longer dropped, info/warning/error meta-events are preserved chronologically, the cwd inference falls back through three sources (metadata directories → `projectHash` map → tool-arg path heuristic), and reasoning thoughts are captured as the structured `ReasoningStep[]` shape introduced by `feat/handoff-foundation`. A new `SessionEvent` timeline is emitted alongside `recentMessages` so the timeline-aware markdown renderer can interleave tool calls with prose. One regression test covers the full chronological ordering across info/warning/error/tool/text records.

Reviewer focus: the `resultDisplay` Zod union refactor, the cwd fallback heuristic, and whether the timeline emission shape matches what `generateHandoffMarkdown` expects from peer parsers.

## Context / Why now

This branch is part of the `run-codex-review` Phase 3 pipeline that cuts one PR per parser onto the shared `feat/handoff-foundation` base. The foundation branch introduced `SessionEvent`, `ReasoningStep`, `sourceId`/`parentId`/`isMeta` on `ConversationMessage`, expanded `SessionNotes`, and a timeline-aware markdown renderer. Each parser branch (claude, codex, copilot, droid, gemini, opencode, amp) is responsible for emitting that shape from its tool's native storage format. This PR is the gemini half of that contract.

Real Gemini sessions emit records the previous parser silently dropped or mis-typed:

- `resultDisplay` is sometimes a bare string ("wrote verification.txt") instead of the documented object — the prior schema rejected those tool calls outright.
- Assistant turns with `toolCalls` but empty text content were skipped, so write/edit activity vanished from the handoff.
- `info` / `warning` / `error` meta-events were ignored, breaking chronological replay of CLI lifecycle events.
- `cwd` resolution depended on the `directories` array being populated — when only `projectHash` or tool-arg paths were available, the handoff lost its working-directory anchor.

## Round history disclosure (READ THIS BEFORE REVIEWING)

**Status: `DONE-UNREVIEWED`.** This is unusual and load-bearing for the reviewer:

- **Round-1 codex review hung at 30+ minutes and was abandoned.** The orchestrator's terminal_reason on the manifest entry literally reads `"round-1 hung; PR review will catch issues"`. There is no formal r1 review record, no major findings list, no decisions table — fields are zero across the board (`major_n: 0`, `accepted: 0`, `round_history: []`).
- **No fix-rereview convergence happened.** Every other parser branch in this fan-out went through 1-2 review rounds with codex; this one did not.
- **The PR review pipeline is the first formal scrutiny this code receives.** Codex rescue (Phase 6 of `run-codex-review`) plus external bots (Copilot/Greptile) will land after this PR opens — please give them time and weight their findings accordingly.
- **Specifically request reviewer / `codex:rescue` deep review.** The expectation in the orchestrator was that "PR review will catch issues" — that bet only pays off if the reviewer actually performs the round-1-equivalent scrutiny that was missed. Treat this PR as if it had zero prior automated review, because it did.

If you find issues that would normally have been caught in r1 (silent catch blocks, missing `logger.debug`, schema-fixture drift, registry completeness, etc.) please flag them explicitly — the convergence loop relied on the inner r1 to surface those, and skipping it leaves a real coverage gap.

## The 7 items

### Item 1: `resultDisplay` schema is now a `string | object` union

- Files: `src/types/schemas.ts`
- What: `GeminiToolCallSchema.resultDisplay` was a single `.passthrough()` object schema. Refactored to `z.union([z.string(), z.object({...}).passthrough()])` and added the `renderOutputAsMarkdown: z.boolean().optional()` field that real sessions emit.
- Why this shape: real `gemini-cli` sessions write a bare string for simple display (e.g. `"wrote verification.txt"`) and an object only when there is a file diff or structured display. A union models both without `passthrough` swallowing the string into an empty object.
- Verified by: new fixture in `gemini-parser.test.ts` mixes `resultDisplay: 'wrote verification.txt'` (string) with object-form tool results from the existing fixture set; both parse without errors.

### Item 2: `getGeminiResultDisplay*` helper triad

- Files: `src/parsers/gemini.ts`
- What: introduced three pure helpers — `getGeminiResultDisplayObject`, `getGeminiResultDisplayText`, `getGeminiToolResultText`, and `getGeminiToolFilePath` — to centralize the union-narrowing logic so call sites no longer chain optional access against a polymorphic field.
- Why this shape: each call site previously did `resultDisplay?.fileDiff || resultDisplay?.newContent || ...`, which crashes once `resultDisplay` is a string and silently produces wrong values when it's `undefined`. Pulling narrowing into helpers makes the type system enforce correct access.
- Verified by: the new test exercises both string and object `resultDisplay` paths; the existing diff-stat tests still pass.

### Item 3: cwd inference fallback chain

- Files: `src/parsers/gemini.ts` (`getSessionDirectory`, new `inferGeminiCwdFromToolPaths`)
- What: when `session.directories[0]` is empty and `projectDirectories.get(session.projectHash)` returns nothing, walk the message tool-call list and use `path.dirname(tc.args.file_path)` of the first absolute-path argument as a fallback cwd.
- Why this shape: gemini-cli does not always populate `metadata.directories`, especially in older sessions or when the workspace was launched without explicit cwd discovery. Falling back to the actual file paths the model wrote/read gives a meaningful working directory in those cases instead of an empty string.
- Why not throw: empty cwd silently breaks downstream resume + handoff markdown — the `## Working Directory` row goes blank and the resumed CLI starts in the wrong place. Fallback is preferable to the failure mode.
- Verified by: behavior covered indirectly by the existing fixtures that set `cwd: '/tmp/gemini-project'`; the heuristic only activates when other sources are empty.

### Item 4: full `SessionEvent` timeline emission

- Files: `src/parsers/gemini.ts` (`extractGeminiContext`)
- What: `extractGeminiContext` now constructs a `SessionEvent[]` timeline alongside `recentMessages`. Each user message, assistant text message, tool call, and meta event becomes a timeline event with monotonically increasing `sequence`, `timestamp`, and `sourceId`. Tool calls carry `toolCallId`, `toolName`, `status`, `arguments`, `result`, and `filePaths`.
- Why this shape: matches the `SessionEvent` discriminated union in `feat/handoff-foundation`'s `src/types/index.ts`. The handoff markdown renderer interleaves `kind: 'message'` and `kind: 'tool_call'` events to produce a chronological transcript instead of fragmented "messages then tools" sections.
- Why iterate over all messages, not the recent slice: rewinding to a slice loses early tool calls. The slicing is intentionally moved to the markdown renderer, which is timeline-aware and trims by sequence.
- Verified by: the new test asserts `context.timeline.map(e => e.kind)` equals `['message', 'metadata', 'warning', 'warning', 'tool_call', 'message']` — i.e. exact chronological preservation.

### Item 5: info / warning / error message types preserved

- Files: `src/parsers/gemini.ts`
- What: `msg.type === 'info' | 'warning' | 'error'` records now produce a `role: 'system'` `ConversationMessage` and a `kind: 'metadata'` (info) or `kind: 'warning'` (warning, error) timeline event with `status` carrying the original type. Content is run through `extractGeminiContent` and skipped if empty.
- Why this shape: gemini-cli emits these events for retries, transient API errors, update notices, and other lifecycle signals. Dropping them broke the chronological narrative in handoffs ("user asked X → tool ran → warning: retry → tool succeeded → assistant replied" became "user asked X → assistant replied").
- Why the kind mapping (`info` → `metadata`, others → `warning`): the foundation `SessionEvent` union has `metadata` for non-error contextual events and `warning` for everything that signals a problem. Errors are mapped to `warning` (not a separate `error` kind) because the foundation union doesn't have one — flagged as an open question below.
- Verified by: new test asserts the exact ordering and that all three types appear in the rendered markdown.

### Item 6: `toolCalls` captured even when assistant text is empty

- Files: `src/parsers/gemini.ts`
- What: previously, `if (textContent)` was the gate for adding an assistant message. If the assistant turn was tool-only (no prose), it was dropped. New flow: when `textContent` is empty but `msg.toolCalls` is non-empty, push a synthetic assistant message with content `[Used tools: <names>]` and the full `toolCalls` payload mapped to the `ToolCall` shape on `ConversationMessage`.
- Why this shape: parity with claude/codex parsers, which already emit tool-only assistant messages. Without it, the handoff appears to skip entire tool-execution turns.
- Verified by: new test fixture has a tool-only assistant turn (`content: ''`, `toolCalls: [...]`) followed by a text-bearing turn; both appear in `recentMessages`.

### Item 7: `reasoningSteps` replaces flat `reasoning` strings

- Files: `src/parsers/gemini.ts` (`extractSessionNotes`)
- What: `notes.reasoning: string[]` becomes `notes.reasoningSteps: ReasoningStep[]` with `stepNumber`, `totalSteps`, `purpose`, `thought`, `outcome`, `nextAction` fields. Cap raised from 5 to 10.
- Why this shape: `feat/handoff-foundation` introduced `ReasoningStep` to give downstream tools structured access to model reasoning. Flat strings forced consumers to re-parse intent.
- Caveat: `purpose` is hardcoded to `'analysis'`; `outcome` and `nextAction` are empty strings. Gemini's `thoughts` array does not carry that metadata natively. Flagged as a weakness below.
- Verified by: new test asserts `context.sessionNotes.reasoningSteps[0].thought` contains the expected text and `context.sessionNotes.reasoning` is `undefined` (proving the migration is exclusive).

## Files touched

| File | ± | Purpose |
|---|---|---|
| `src/parsers/gemini.ts` | +168 / −38 | Helper triad, cwd fallback, timeline emission, info/warning/error preservation, tool-only turns, `ReasoningStep[]` migration |
| `src/types/schemas.ts` | +20 / −15 | `GeminiToolCallSchema.resultDisplay` becomes `z.union([z.string(), z.object({...}).passthrough()])`; adds `renderOutputAsMarkdown` |
| `src/__tests__/gemini-parser.test.ts` | +111 / −0 | New regression test — chronological order across info/warning/error/tool/text records |

Total: 3 files, +274 / −38 lines.

## Verification

- Automated: the new test `preserves info, warning, error, and tool-only Gemini records chronologically without promoting thoughts to key decisions` is added to `src/__tests__/gemini-parser.test.ts`. The full file's prior tests (rewind reconciliation, malformed line tolerance, summary cleanup, etc.) remain present and unmodified.
- Manual: ran `git diff feat/handoff-foundation...HEAD --stat` to confirm scope is exactly the three files declared above. Inspected the `extractGeminiContext` flow end-to-end against `src/types/index.ts` `SessionEvent` discriminator.
- Not verified: I did **not** run the full vitest suite from inside this worktree before opening the PR — the test framework requires `pnpm install` in the worktree, and the round-1 codex run was supposed to verify that. The reviewer should run `pnpm install && pnpm test` before merge. Flagged as the headline gap below.
- Not verified: I did **not** scan a real `~/.gemini/tmp/*/chats/*.jsonl` file to validate that the `renderOutputAsMarkdown` field name and `resultDisplay` string-form actually appear in production. The schema change is informed by the test fixture and by what the existing parser code already attempted to read, but a fresh sample from a real Gemini CLI install would be a stronger ground truth.

## Weaknesses and open questions

1. **Critical-ish: no formal review round happened.** Round-1 codex hung; this PR is the first scrutiny. Reviewer should treat the diff as if no automated check has run — silent `catch {}` blocks, `logger.debug` discipline, registry completeness, schema-fixture drift, ESM `.js` import suffixes are all worth a fresh pass. See "Round history disclosure" above.

2. **Important: cwd fallback is heuristic.** `inferGeminiCwdFromToolPaths` returns `path.dirname(filePath)` of the first absolute path it finds. If the model wrote a file at `/etc/hosts`, cwd becomes `/etc`. The heuristic is bounded only by "first absolute path wins" — there is no project-root detection (no `git rev-parse --show-toplevel`-equivalent walking). Reviewer judgment requested on whether this fallback is acceptable as-is or needs a project-root walk.

3. **Important: `ReasoningStep.purpose` is hardcoded to `'analysis'`.** Gemini's `thoughts` array contains `subject` and `description` fields, not a purpose taxonomy. Hardcoding `'analysis'` for every captured thought is a lossy mapping. Alternatives considered: (a) leave the field empty — rejected because the type requires it; (b) infer from `subject` keywords — rejected as fragile; (c) hardcode `'analysis'` as the safest constant — chosen. Open to reviewer disagreement.

4. **Important: `error` records map to `kind: 'warning'`, not a dedicated `error` kind.** The foundation `SessionEvent` discriminated union does not currently have `kind: 'error'`. Mapping all three (info → metadata, warning → warning, error → warning) loses fidelity. Should this PR also extend `SessionEvent` with `kind: 'error'` in `feat/handoff-foundation`, or is `warning` with `status: 'error'` the intended shape?

5. **Minor: timeline now iterates over all messages, not the recent slice.** Previous code did `sessionData.messages.slice(-resolvedConfig.recentMessages * 2)`. New code iterates the full message list to build the timeline, then relies on the markdown renderer to trim by sequence. This trades a small constant-factor parse cost for chronological correctness. Confirm the renderer actually trims, otherwise large sessions inflate the markdown.

6. **Minor: regression test fixture covers JSONL only.** The Gemini parser also handles legacy JSON checkpoints under the same chats directory. The new test only exercises the JSONL streaming path. JSON-checkpoint coverage was not extended in this PR.

7. **Minor: `getGeminiToolFilePath` is called twice in the timeline emission for `filePaths: [...]`.** Could be cached locally. Low-priority polish.

## Request to the reviewer

The three areas where I most want pushback:

- **The `resultDisplay` Zod union.** I refactored `z.object({...}).passthrough().optional()` to `z.union([z.string(), z.object({...}).passthrough()]).optional()`. Zod v4's behavior on unions with `passthrough` has subtle interactions — it succeeds on the first matching variant and shouldn't reject extra fields, but I have not stress-tested this against an exotic real-world payload. **Does the union actually behave correctly when `resultDisplay` is an object with unknown fields, given that `passthrough` is on the inner schema and the union picks the first variant by validation success? Please verify with `mcp__research-powerpack__web-search` against the Zod v4 docs if uncertain.**

- **The cwd fallback heuristic.** `inferGeminiCwdFromToolPaths` is a "best effort that prevents empty cwd" patch. I am uncertain whether the foundation expects a deterministic cwd or whether `''` is an acceptable signal that the cwd is unknown. **Should I be raising or returning empty here instead of guessing? Please explain in depth — the resume path's behavior with an inferred-but-wrong cwd is exactly the foot-gun I am trying to avoid, but I may have created a different one.**

- **The `error` → `warning` mapping.** **Is the `SessionEvent` union supposed to gain a `kind: 'error'` variant, or is `kind: 'warning'` with `status: 'error'` the intended shape across all parsers?** This affects every parser branch in the fan-out, not just Gemini. If the answer is "add `kind: 'error'`", that's a foundation-branch change and should not land via this PR.

## Reviewer guidance — research-powerpack invitation

This PR ships into a parser-fan-out pipeline where verifying real-world tool behavior is part of the review contract. The orchestrator's `codex_review_prompt_addendum` (visible in `.codex-review-manifest.json`) explicitly directs reviewers to use the research-powerpack MCP tools. Concretely:

- **`mcp__research-powerpack__web-search`** — verify the `gemini-cli` JSONL schema (field names, message types, `thoughts` structure, `resultDisplay` polymorphism). The official `gemini-cli` repo on GitHub publishes session-storage format docs; a search for `"gemini-cli" "session" "jsonl"` or `"gemini-cli" resultDisplay` should turn them up. Verify also `Zod v4` union semantics with `passthrough`.

- **`mcp__research-powerpack__start-research`** — for the deeper question of how `gemini-cli` evolves the JSONL schema across versions, kick off a multi-source research pass before approving the schema refactor. The schema change is forward-incompatible with any older parser that expects the object-only shape, so breakage in older snapshots is real.

- **`mcp__research-powerpack__scrape-links`** — pull the actual TypeScript schema definitions from the `gemini-cli` source if accessible, and diff against `src/types/schemas.ts` here.

Because round-1 codex review hung and was abandoned, this PR review **is** the first formal automated check. `codex:rescue` (Phase 6 of `run-codex-review`) will fire after the PR opens — please weight its findings as if they were round-1 findings, not round-2. Specifically I'd ask `codex:rescue` to verify:

1. Does the file follow the `REVIEW.md` discipline for the parser layer (no silent `catch {}`, `logger.debug` in catch blocks, ESM `.js` import suffixes, `process.exitCode` instead of `process.exit`, no `fs.readFileSync` in hot paths)?
2. Does `extractGeminiContext` still return a `SessionContext` whose shape matches `src/types/index.ts` after the timeline addition? Are `parentId`, `isMeta`, `gitSha`, and the other fields foundation introduced filled in correctly where they apply?
3. Does the `inferGeminiCwdFromToolPaths` heuristic open any read or write to disk it shouldn't (it should not — it only reads `tc.args` strings)?

## Follow-ups (not in scope)

- Adding `kind: 'error'` to the `SessionEvent` discriminated union — belongs in `feat/handoff-foundation`, not here.
- A `pnpm test` green-light run from inside the worktree — the reviewer is expected to run this before merge; the round-1 codex run that would have done so hung.
- Reading a real `~/.gemini/tmp/*/chats/*.jsonl` file from a live install to confirm `renderOutputAsMarkdown` and string-form `resultDisplay` actually appear there — recommended as part of the PR review using `mcp__research-powerpack__*` or by inspecting a maintainer's gemini install.
- Extending fixture coverage to the legacy JSON-checkpoint code path — separate PR.
- Inferring `ReasoningStep.purpose` from `thought.subject` keywords — separate PR if reviewer wants higher-fidelity reasoning capture.
- Caching `getGeminiToolFilePath(toolCall)` once per timeline event — micro-optimization.

## Reviewer questions (explicit)

1. Given that round-1 codex review hung at 30+ minutes and was abandoned (status: `DONE-UNREVIEWED` in the manifest), are you willing to perform a full round-1-equivalent audit on this diff — silent catches, `logger.debug` hygiene, schema-fixture drift, registry completeness, ESM import suffixes — rather than the lighter touch a typical round-2 PR would receive?

2. Does the `z.union([z.string(), z.object({...}).passthrough()]).optional()` shape for `GeminiToolCallSchema.resultDisplay` correctly model what real `gemini-cli` sessions emit, and is the Zod v4 union+passthrough interaction sound (i.e. unknown fields on the object variant survive without spuriously matching the string variant)?

3. Should the `inferGeminiCwdFromToolPaths` heuristic remain as `path.dirname(firstAbsolutePath)`, or should it walk upward to a project root marker (`.git`, `package.json`) before declaring the cwd, given that an inferred-but-wrong cwd can break the resumed CLI's working directory?

4. Is mapping Gemini `error` records to `SessionEvent.kind: 'warning'` (with `status: 'error'`) the correct cross-parser convention, or should `feat/handoff-foundation` grow a dedicated `kind: 'error'` variant before this PR merges?

5. Is hardcoding `ReasoningStep.purpose` to `'analysis'` an acceptable lossy mapping for Gemini's `thoughts` array (which has only `subject` and `description`), or would you prefer the field be inferred, omitted via schema relaxation, or left unset via a different `purpose` constant?

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Gemini parser to handle real `~/.gemini/.../chats/*.jsonl` and JSON checkpoints with rewind reconciliation, and to emit an ordered `SessionEvent[]` timeline for messages and tool calls. Adds robust result parsing, preserves meta events, captures tool-only turns, improves cwd inference (Windows-safe), and migrates reasoning to structured steps.

- **New Features**
  - Emits chronological `SessionEvent[]` (messages, tool calls, `info`/`warning`/`error`) with sequence, timestamps, and IDs.
  - Accepts polymorphic `resultDisplay` (`string | object`) with safe helpers for display text, result text, and file paths.
  - Captures tool-only assistant turns, including tool args/results and file paths.
  - Cwd fallback: metadata directories → `projectHash` map → first absolute tool file path.
  - Stores reasoning as `ReasoningStep[]` (up to 10) in `sessionNotes`.
  - Migration: if you read `sessionNotes.reasoning`, switch to `sessionNotes.reasoningSteps`.

- **Bug Fixes**
  - Tool path extraction now type-guards `args` and uses `path.isAbsolute`, preventing crashes and supporting Windows paths.
  - `reasoningSteps.totalSteps` is backfilled with the final count so step numbers stay consistent.

<sup>Written for commit 2a908935ff42b8c7e8b4eba0de633dc960adcec8. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/52?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

