### PR TITLE
:sparkles: feat(handoff): structured timeline + per-message metadata + verbosity controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .continues-handoff.md
 .agent-workspace/
 stress-test-output.log
+.battle-test/
 # Generated / local tooling
 .agents/
 .claude/skills/

--- a/src/__tests__/shared-utils.test.ts
+++ b/src/__tests__/shared-utils.test.ts
@@ -21,6 +21,7 @@ import {
 import { countDiffStats, extractStdoutTail, formatEditDiff, formatNewFileDiff } from '../utils/diff.js';
 import { findFiles, listSubdirectories, mapConcurrent } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
+import { generateHandoffMarkdown, safePath } from '../utils/markdown.js';
 import { extractRepo, trimMessages } from '../utils/parser-helpers.js';
 import {
   type AnthropicMessage,
@@ -88,7 +89,7 @@ describe('scanJsonlHead', () => {
     const dir = makeTmpDir();
     const file = path.join(dir, 'test.jsonl');
     const lines = Array.from({ length: 100 }, (_, i) => JSON.stringify({ i }));
-    fs.writeFileSync(file, lines.join('\n') + '\n');
+    fs.writeFileSync(file, `${lines.join('\n')}\n`);
 
     const visited: number[] = [];
     await scanJsonlHead(file, 5, (parsed) => {
@@ -1101,5 +1102,82 @@ describe('detectCategory fallback via classifyToolName', () => {
   });
   it('classifies request_user_input as ask', () => {
     expect(classifyToolName('request_user_input')).toBe('ask');
+  });
+});
+
+describe('generateHandoffMarkdown battle-test rendering', () => {
+  it('tildifies only the actual home directory boundary', () => {
+    const home = os.homedir();
+    const childPath = path.join(home, 'project/file.ts');
+    const siblingPath = `${home}-sibling/project/file.ts`;
+
+    expect(safePath(home)).toBe('~');
+    expect(safePath(childPath)).toBe('~/project/file.ts');
+    expect(safePath(siblingPath)).toBe(siblingPath);
+  });
+
+  it('renders home-relative paths, UTC timestamps, sub-minute active time, and a larger final assistant answer', () => {
+    const home = os.homedir();
+    const cwd = path.join(home, 'project');
+    const longFinal = `${'final '.repeat(150)}SENTINEL_FINAL_STATE`;
+    const markdown = generateHandoffMarkdown(
+      {
+        id: 'renderer-session',
+        source: 'codex',
+        cwd,
+        repo: 'user/project',
+        lines: 2,
+        bytes: 100,
+        createdAt: new Date('2026-04-15T10:00:00.000Z'),
+        updatedAt: new Date('2026-04-15T10:00:24.000Z'),
+        originalPath: path.join(home, '.codex', 'sessions', 'rollout.jsonl'),
+      },
+      [
+        { role: 'user', content: 'Fix the renderer', timestamp: new Date('2026-04-15T10:00:01.000Z') },
+        { role: 'assistant', content: longFinal, timestamp: new Date('2026-04-15T10:00:24.000Z') },
+      ],
+      [path.join(cwd, 'src/render.ts'), path.join(home, '.codex', 'config.toml')],
+      [],
+      [],
+      { activeTimeMs: 24_587 },
+      getPreset('standard'),
+    );
+
+    expect(markdown).toContain('~/.codex/sessions/rollout.jsonl');
+    expect(markdown).toContain('`./src/render.ts`');
+    expect(markdown).toContain('`~/.codex/config.toml`');
+    expect(markdown).toContain('2026-04-15 10:00:24 UTC');
+    expect(markdown).toContain('| **Active Time** | 25 sec |');
+    expect(markdown).toContain('SENTINEL_FINAL_STATE');
+  });
+
+  it('renders timeline activity before grouped tool activity', () => {
+    const markdown = generateHandoffMarkdown(
+      {
+        id: 'timeline-session',
+        source: 'gemini',
+        cwd: '/tmp/project',
+        lines: 3,
+        bytes: 100,
+        createdAt: new Date('2026-04-15T10:00:00.000Z'),
+        updatedAt: new Date('2026-04-15T10:00:03.000Z'),
+        originalPath: '/tmp/project/session.jsonl',
+      },
+      [],
+      [],
+      [],
+      [{ name: 'write_file', count: 1, samples: [{ summary: 'write login.ts' }] }],
+      undefined,
+      getPreset('standard'),
+      'inline',
+      [
+        { kind: 'message', sequence: 0, role: 'user', content: 'Create login.ts' },
+        { kind: 'tool_call', sequence: 1, toolName: 'write_file', arguments: { file_path: 'login.ts' } },
+        { kind: 'message', sequence: 2, role: 'assistant', content: 'Done.' },
+      ],
+    );
+
+    expect(markdown.indexOf('## Recent Conversation')).toBeLessThan(markdown.indexOf('## Tool Activity'));
+    expect(markdown.indexOf('Tool Call: write_file')).toBeLessThan(markdown.indexOf('### Write'));
   });
 });

--- a/src/config/verbosity.ts
+++ b/src/config/verbosity.ts
@@ -14,9 +14,9 @@
  * Users can override any subset of fields — unspecified fields
  * inherit from the chosen preset (or `standard` if none specified).
  */
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import YAML from 'yaml';
 import { z } from 'zod';
 import { logger } from '../logger.js';
@@ -92,6 +92,13 @@ const PendingTasksConfigSchema = z.object({
   maxTasks: z.number().int().min(0).default(10),
 });
 
+const HandoffConfigSchema = z.object({
+  finalAnswerChars: z.number().int().min(0).default(4000),
+  timelineWindow: z.number().int().min(0).default(20),
+  includeToolAppendix: z.boolean().default(true),
+  pathPolicy: z.enum(['home-relative', 'raw']).default('home-relative'),
+});
+
 const ClaudeAgentConfigSchema = z.object({
   filterProgressEvents: z.boolean().default(true),
   parseSubagents: z.boolean().default(true),
@@ -126,6 +133,7 @@ export const VerbosityConfigSchema = z.object({
   thinking: ThinkingConfigSchema,
   compactSummary: CompactSummaryConfigSchema,
   pendingTasks: PendingTasksConfigSchema,
+  handoff: HandoffConfigSchema,
   agents: AgentsConfigSchema,
 });
 
@@ -197,6 +205,12 @@ const MINIMAL_PRESET: VerbosityConfig = {
     extractFromThinking: false,
     extractFromSubagents: false,
     maxTasks: 5,
+  },
+  handoff: {
+    finalAnswerChars: 2000,
+    timelineWindow: 8,
+    includeToolAppendix: true,
+    pathPolicy: 'home-relative',
   },
   agents: {
     claude: {
@@ -273,6 +287,12 @@ const STANDARD_PRESET: VerbosityConfig = {
     extractFromSubagents: true,
     maxTasks: 10,
   },
+  handoff: {
+    finalAnswerChars: 4000,
+    timelineWindow: 20,
+    includeToolAppendix: true,
+    pathPolicy: 'home-relative',
+  },
   agents: {
     claude: {
       filterProgressEvents: true,
@@ -348,6 +368,12 @@ const VERBOSE_PRESET: VerbosityConfig = {
     extractFromSubagents: true,
     maxTasks: 20,
   },
+  handoff: {
+    finalAnswerChars: 8000,
+    timelineWindow: 40,
+    includeToolAppendix: true,
+    pathPolicy: 'home-relative',
+  },
   agents: {
     claude: {
       filterProgressEvents: true,
@@ -422,6 +448,12 @@ const FULL_PRESET: VerbosityConfig = {
     extractFromThinking: true,
     extractFromSubagents: true,
     maxTasks: 100,
+  },
+  handoff: {
+    finalAnswerChars: 20000,
+    timelineWindow: 200,
+    includeToolAppendix: true,
+    pathPolicy: 'home-relative',
   },
   agents: {
     claude: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,8 @@ export interface UnifiedSession {
   repo?: string;
   /** Git branch */
   branch?: string;
+  /** Git commit SHA when the source tool records it */
+  gitSha?: string;
   /** Session summary/description */
   summary?: string;
   /** Number of conversation turns */
@@ -53,6 +55,12 @@ export interface ConversationMessage {
   content: string;
   timestamp?: Date;
   toolCalls?: ToolCall[];
+  /** Source-tool message identifier, when available */
+  sourceId?: string;
+  /** Source-tool parent message identifier, when available */
+  sourceParentId?: string;
+  /** True when the message is useful metadata rather than user-visible conversation */
+  isMeta?: boolean;
 }
 
 /** Tool call information */
@@ -64,6 +72,37 @@ export interface ToolCall {
   result?: string;
   /** Whether the tool call succeeded. Absent when status is unknown. */
   success?: boolean;
+  /** Source-tool metadata such as exit code, truncation state, timing, or output path. */
+  metadata?: Record<string, unknown>;
+}
+
+export type SessionEventKind =
+  | 'message'
+  | 'tool_call'
+  | 'tool_result'
+  | 'lifecycle'
+  | 'reasoning'
+  | 'metadata'
+  | 'warning';
+
+export interface SessionEvent {
+  kind: SessionEventKind;
+  sequence: number;
+  timestamp?: Date;
+  role?: ConversationMessage['role'];
+  content?: string;
+  id?: string;
+  sourceId?: string;
+  sourceParentId?: string;
+  toolName?: string;
+  toolCallId?: string;
+  status?: string;
+  arguments?: Record<string, unknown>;
+  result?: string;
+  filePaths?: string[];
+  metadata?: Record<string, unknown>;
+  isFinalAnswer?: boolean;
+  isMeta?: boolean;
 }
 
 // ── Structured Tool Sample Data ─────────────────────────────────────────────
@@ -200,6 +239,8 @@ export interface ToolSample {
   summary: string;
   /** Structured data for rich rendering. Absent for legacy/not-yet-updated parsers. */
   data?: StructuredToolSample;
+  /** Source event id this sample came from, when available. */
+  sourceEventId?: string;
 }
 
 /** Aggregated tool usage: unique tool name + count + representative samples */
@@ -212,6 +253,8 @@ export interface ToolUsageSummary {
   errorCount?: number;
   /** Up to N representative samples (N varies by category) */
   samples: ToolSample[];
+  /** Source event ids represented by this grouped summary, when available. */
+  sourceEventIds?: string[];
 }
 
 /** Result from a subagent/task invocation */
@@ -258,6 +301,18 @@ export interface SessionNotes {
   reasoningSteps?: ReasoningStep[];
   /** External tool results (MCP, plugins) with size and preview */
   externalToolResults?: Array<{ name: string; sizeBytes: number; preview: string }>;
+  /** Tool-specific lifecycle events such as turn start/abort/complete. */
+  lifecycle?: Array<{ type: string; timestamp?: string; message?: string; metadata?: Record<string, unknown> }>;
+  /** Bootstrap/environment details that should not be mixed into conversation text. */
+  bootstrap?: Array<{ type: string; content: string; timestamp?: string; metadata?: Record<string, unknown> }>;
+  /** Raw source metadata retained for parser fidelity but not rendered verbosely by default. */
+  sourceMetadata?: Record<string, unknown>;
+  /** Snapshot metadata such as Claude file-history-snapshot records. */
+  fileHistorySnapshots?: Array<{ timestamp?: string; cwd?: string; metadata?: Record<string, unknown> }>;
+  /** Pointer to raw source data, redacted when rendered. */
+  rawAccess?: { kind: 'file' | 'directory' | 'sqlite'; path: string; redacted?: boolean };
+  /** Known parser fidelity limits or downgraded source records. */
+  fidelityWarnings?: string[];
 }
 
 /** Extracted context for cross-tool continuation */
@@ -273,6 +328,8 @@ export interface SessionContext {
   toolSummaries: ToolUsageSummary[];
   /** Contextual notes from AI reasoning, model info, etc. */
   sessionNotes?: SessionNotes;
+  /** Chronological high-fidelity activity stream, when the parser can provide it. */
+  timeline?: SessionEvent[];
   /** Generated markdown for injection */
   markdown: string;
 }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -55,13 +55,17 @@ export const CodexSessionMetaSchema = z
     payload: z
       .object({
         id: z.string().optional(),
+        timestamp: z.string().optional(),
         cwd: z.string().optional(),
         git: z
           .object({
             branch: z.string().optional(),
             repository_url: z.string().optional(),
+            commit_hash: z.string().optional(),
+            sha: z.string().optional(),
           })
           .optional(),
+        source: z.string().optional(),
       })
       .passthrough()
       .optional(),
@@ -206,6 +210,7 @@ export const CopilotEventSchema = z
       .object({
         sessionId: z.string().optional(),
         selectedModel: z.string().optional(),
+        currentModel: z.string().optional(),
         content: z.string().optional(),
         transformedContent: z.string().optional(),
         messageId: z.string().optional(),
@@ -215,6 +220,7 @@ export const CopilotEventSchema = z
               .object({
                 name: z.string(),
                 arguments: z.record(z.string(), z.unknown()).optional(),
+                args: z.record(z.string(), z.unknown()).optional(),
               })
               .passthrough(),
           )
@@ -241,7 +247,11 @@ export type CopilotEvent = z.infer<typeof CopilotEventSchema>;
 
 export const GeminiToolCallSchema = z
   .object({
+    id: z.string().optional(),
     name: z.string(),
+    displayName: z.string().optional(),
+    description: z.string().optional(),
+    timestamp: z.string().optional(),
     args: z.record(z.string(), z.unknown()).optional(),
     result: z
       .array(
@@ -249,9 +259,12 @@ export const GeminiToolCallSchema = z
           .object({
             functionResponse: z
               .object({
+                id: z.string().optional(),
+                name: z.string().optional(),
                 response: z
                   .object({
                     output: z.string().optional(),
+                    error: z.string().optional(),
                   })
                   .passthrough()
                   .optional(),
@@ -693,6 +706,7 @@ export const SerializedSessionSchema = z.object({
   cwd: z.string(),
   repo: z.string().optional(),
   branch: z.string().optional(),
+  gitSha: z.string().optional(),
   summary: z.string().optional(),
   lines: z.number(),
   bytes: z.number(),

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -315,12 +315,13 @@ function renderRecentActivity(
   config: VerbosityConfig,
 ): string[] {
   const window = config.handoff.timelineWindow;
+  const messageWindow = Math.min(window, config.recentMessages);
   const events =
     window <= 0
       ? []
       : timeline.length > 0
         ? [...timeline].sort((left, right) => left.sequence - right.sequence).slice(-window)
-        : messagesToTimeline(messages.slice(-config.recentMessages));
+        : messagesToTimeline(messages.slice(-messageWindow));
 
   if (events.length === 0) return [];
 
@@ -348,7 +349,10 @@ function renderRecentActivity(
         lines.push(`### ${label}${name}${status}${timestamp}`);
         lines.push('');
         if (event.arguments && Object.keys(event.arguments).length > 0) {
-          lines.push(`Arguments: \`${truncateWithMarker(JSON.stringify(event.arguments), 500)}\``);
+          lines.push('Arguments:');
+          lines.push('```json');
+          lines.push(truncateWithMarker(JSON.stringify(event.arguments), 500));
+          lines.push('```');
           lines.push('');
         }
         if (event.result) {
@@ -369,8 +373,11 @@ function renderRecentActivity(
         lines.push(`### ${title}${status}${timestamp}`);
         lines.push('');
         if (event.content) lines.push(truncateWithMarker(event.content, config.maxMessageChars));
-        if (!event.content && event.metadata)
-          lines.push(`\`${truncateWithMarker(JSON.stringify(event.metadata), 500)}\``);
+        if (!event.content && event.metadata) {
+          lines.push('```json');
+          lines.push(truncateWithMarker(JSON.stringify(event.metadata), 500));
+          lines.push('```');
+        }
         lines.push('');
         break;
       }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,10 +1,11 @@
-import * as os from 'os';
+import * as os from 'node:os';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { adapters } from '../parsers/registry.js';
 import type {
   ConversationMessage,
   ReasoningStep,
+  SessionEvent,
   SessionNotes,
   SubagentResult,
   ToolSample,
@@ -29,8 +30,43 @@ import {
 /** Replace home directory prefix with ~ and escape backticks for safe markdown inline code */
 const _home = os.homedir();
 export function safePath(p: string): string {
-  const tildified = p.startsWith(_home) ? '~' + p.slice(_home.length) : p;
+  const tildified = p === _home || p.startsWith(`${_home}/`) ? `~${p.slice(_home.length)}` : p;
   return tildified.replace(/`/g, '\\`');
+}
+
+function displayPath(p: string, cwd: string | undefined, config: VerbosityConfig): string {
+  if (config.handoff.pathPolicy === 'raw') return p.replace(/`/g, '\\`');
+  if (cwd && pathIsInside(p, cwd)) {
+    const rel = p === cwd ? '.' : `./${p.slice(cwd.length).replace(/^\/+/, '')}`;
+    return rel.replace(/`/g, '\\`');
+  }
+  return safePath(p);
+}
+
+function pathIsInside(candidate: string, root: string): boolean {
+  if (!candidate || !root || !candidate.startsWith('/')) return false;
+  const normalizedCandidate = candidate.replace(/\/+$/u, '');
+  const normalizedRoot = root.replace(/\/+$/u, '');
+  return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}/`);
+}
+
+function formatTimestamp(date: Date): string {
+  return date
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.\d{3}Z$/u, ' UTC');
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) {
+    return `${Math.max(1, Math.round(ms / 1000))} sec`;
+  }
+  return `${Math.round(ms / 60_000)} min`;
+}
+
+function truncateWithMarker(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n\n[...${(text.length - maxChars).toLocaleString()} chars omitted]`;
 }
 
 /** Human-readable labels for each session source — derived lazily from the adapter registry */
@@ -109,7 +145,8 @@ export function generateHandoffMarkdown(
   toolSummaries: ToolUsageSummary[] = [],
   sessionNotes?: SessionNotes,
   config: VerbosityConfig = getPreset('standard'),
-  mode: 'inline' | 'reference' = 'inline',
+  _mode: 'inline' | 'reference' = 'inline',
+  timeline: SessionEvent[] = [],
 ): string {
   const labels = getSourceLabels();
   const sourceLabel = labels[session.source] || session.source;
@@ -125,11 +162,11 @@ export function generateHandoffMarkdown(
     '|-------|-------|',
     `| **Source** | ${sourceLabel} |`,
     `| **Session ID** | \`${session.id}\` |`,
-    `| **Working Directory** | \`${session.cwd}\` |`,
+    `| **Working Directory** | \`${displayPath(session.cwd, undefined, config)}\` |`,
   ];
 
   if (session.originalPath) {
-    lines.push(`| **Session File** | \`${safePath(session.originalPath)}\` |`);
+    lines.push(`| **Session File** | \`${displayPath(session.originalPath, session.cwd, config)}\` |`);
   }
 
   if (session.repo) {
@@ -138,10 +175,13 @@ export function generateHandoffMarkdown(
   if (session.model) {
     lines.push(`| **Model** | ${session.model} |`);
   }
+  if (session.gitSha) {
+    lines.push(`| **Git SHA** | \`${session.gitSha.slice(0, 12)}\` |`);
+  }
   if (sessionNotes?.model && sessionNotes.model !== session.model) {
     lines.push(`| **Model** | ${sessionNotes.model} |`);
   }
-  lines.push(`| **Last Active** | ${session.updatedAt.toISOString().slice(0, 16).replace('T', ' ')} |`);
+  lines.push(`| **Last Active** | ${formatTimestamp(session.updatedAt)} |`);
   if (sessionNotes?.tokenUsage && (sessionNotes.tokenUsage.input > 0 || sessionNotes.tokenUsage.output > 0)) {
     lines.push(
       `| **Tokens Used** | ${sessionNotes.tokenUsage.input.toLocaleString()} in / ${sessionNotes.tokenUsage.output.toLocaleString()} out |`,
@@ -156,8 +196,7 @@ export function generateHandoffMarkdown(
     lines.push(`| **Thinking Tokens** | ${sessionNotes.thinkingTokens.toLocaleString()} |`);
   }
   if (sessionNotes?.activeTimeMs) {
-    const mins = Math.round(sessionNotes.activeTimeMs / 60000);
-    lines.push(`| **Active Time** | ${mins} min |`);
+    lines.push(`| **Active Time** | ${formatDuration(sessionNotes.activeTimeMs)} |`);
   }
   lines.push(`| **Files Modified** | ${filesModified.length} |`);
   lines.push(`| **Messages** | ${messages.length} |`);
@@ -180,11 +219,12 @@ export function generateHandoffMarkdown(
     lines.push('');
   }
 
-  // ── Category-aware Tool Activity section ──
-  if (toolSummaries.length > 0) {
-    lines.push('## Tool Activity');
+  const finalAssistant = [...messages].reverse().find((message) => message.role === 'assistant' && message.content);
+  if (finalAssistant) {
+    lines.push('## Current State');
     lines.push('');
-    lines.push(...renderToolActivity(toolSummaries, caps));
+    lines.push(truncateWithMarker(finalAssistant.content, config.handoff.finalAnswerChars));
+    lines.push('');
     lines.push('');
   }
 
@@ -208,19 +248,13 @@ export function generateHandoffMarkdown(
     lines.push(...renderReasoningChain(sessionNotes.reasoningSteps));
   }
 
-  // Show recent messages for richer context
-  const recentMessages = messages.slice(-config.recentMessages);
-  if (recentMessages.length > 0) {
-    lines.push('## Recent Conversation');
+  lines.push(...renderRecentActivity(timeline, messages, config));
+
+  // ── Category-aware Tool Activity appendix ──
+  if (config.handoff.includeToolAppendix && toolSummaries.length > 0) {
+    lines.push('## Tool Activity');
     lines.push('');
-    for (const msg of recentMessages) {
-      const role = msg.role === 'user' ? 'User' : 'Assistant';
-      lines.push(`### ${role}`);
-      lines.push('');
-      const maxChars = config.maxMessageChars;
-      lines.push(msg.content.slice(0, maxChars) + (msg.content.length > maxChars ? '\u2026' : ''));
-      lines.push('');
-    }
+    lines.push(...renderToolActivity(toolSummaries, caps));
     lines.push('');
   }
 
@@ -228,7 +262,7 @@ export function generateHandoffMarkdown(
     lines.push('## Files Modified');
     lines.push('');
     for (const file of filesModified) {
-      lines.push(`- \`${file}\``);
+      lines.push(`- \`${displayPath(file, session.cwd, config)}\``);
     }
     lines.push('');
     lines.push('');
@@ -248,10 +282,10 @@ export function generateHandoffMarkdown(
     lines.push('## Session Origin');
     lines.push('');
     lines.push(`This session was extracted from **${labels[session.source] || session.source}** session data.`);
-    lines.push(`- **Session file**: \`${safePath(session.originalPath)}\``);
+    lines.push(`- **Session file**: \`${displayPath(session.originalPath, session.cwd, config)}\``);
     lines.push(`- **Session ID**: \`${session.id}\``);
     if (session.cwd) {
-      lines.push(`- **Project directory**: \`${session.cwd}\``);
+      lines.push(`- **Project directory**: \`${displayPath(session.cwd, undefined, config)}\``);
     }
     lines.push('');
     lines.push('> To access the raw session data, inspect the file path above.');
@@ -265,6 +299,94 @@ export function generateHandoffMarkdown(
   );
 
   return lines.join('\n');
+}
+
+const NON_MESSAGE_TITLES: Record<'lifecycle' | 'metadata' | 'warning' | 'reasoning', string> = {
+  lifecycle: 'Lifecycle',
+  metadata: 'Metadata',
+  warning: 'Note',
+  reasoning: 'Note',
+};
+
+function renderRecentActivity(
+  timeline: SessionEvent[],
+  messages: ConversationMessage[],
+  config: VerbosityConfig,
+): string[] {
+  const events =
+    timeline.length > 0
+      ? [...timeline].sort((left, right) => left.sequence - right.sequence).slice(-config.handoff.timelineWindow)
+      : messagesToTimeline(messages.slice(-config.recentMessages));
+
+  if (events.length === 0) return [];
+
+  const lines: string[] = ['## Recent Conversation', ''];
+  for (const event of events) {
+    const timestamp = event.timestamp ? ` (${formatTimestamp(event.timestamp)})` : '';
+    switch (event.kind) {
+      case 'message': {
+        const role = event.role === 'user' ? 'User' : event.role === 'system' ? 'System' : 'Assistant';
+        lines.push(`### ${role}${timestamp}`);
+        lines.push('');
+        if (event.content) {
+          lines.push(
+            event.content.slice(0, config.maxMessageChars) + (event.content.length > config.maxMessageChars ? '…' : ''),
+          );
+        }
+        lines.push('');
+        break;
+      }
+      case 'tool_call':
+      case 'tool_result': {
+        const label = event.kind === 'tool_call' ? 'Tool Call' : 'Tool Result';
+        const status = event.status ? ` ${event.status}` : '';
+        const name = event.toolName ? `: ${event.toolName}` : '';
+        lines.push(`### ${label}${name}${status}${timestamp}`);
+        lines.push('');
+        if (event.arguments && Object.keys(event.arguments).length > 0) {
+          lines.push(`Arguments: \`${truncateWithMarker(JSON.stringify(event.arguments), 500)}\``);
+          lines.push('');
+        }
+        if (event.result) {
+          lines.push(truncateWithMarker(event.result, config.maxMessageChars));
+          lines.push('');
+        } else if (event.content) {
+          lines.push(truncateWithMarker(event.content, config.maxMessageChars));
+          lines.push('');
+        }
+        break;
+      }
+      case 'lifecycle':
+      case 'metadata':
+      case 'warning':
+      case 'reasoning': {
+        const title = NON_MESSAGE_TITLES[event.kind];
+        const status = event.status ? ` ${event.status}` : '';
+        lines.push(`### ${title}${status}${timestamp}`);
+        lines.push('');
+        if (event.content) lines.push(truncateWithMarker(event.content, config.maxMessageChars));
+        if (!event.content && event.metadata)
+          lines.push(`\`${truncateWithMarker(JSON.stringify(event.metadata), 500)}\``);
+        lines.push('');
+        break;
+      }
+    }
+  }
+  lines.push('');
+  return lines;
+}
+
+function messagesToTimeline(messages: ConversationMessage[]): SessionEvent[] {
+  return messages.map((message, index) => ({
+    kind: 'message',
+    sequence: index,
+    role: message.role,
+    content: message.content,
+    timestamp: message.timestamp,
+    sourceId: message.sourceId,
+    sourceParentId: message.sourceParentId,
+    isMeta: message.isMeta,
+  }));
 }
 
 // ── MCP Namespace Grouping ───────────────────────────────────────────────────
@@ -672,7 +794,7 @@ const COMPACT_LABELS: Record<string, string> = {
   mcp: 'MCP',
 };
 
-function formatCompactSample(sample: ToolSample, category: string): string {
+function formatCompactSample(sample: ToolSample, _category: string): string {
   const d = sample.data;
   if (!d) return `\`${sample.summary}\``;
 
@@ -712,7 +834,7 @@ function renderSubagentResults(results: SubagentResult[], config: VerbosityConfi
     lines.push(`### ${r.description} (${r.taskId})`);
     if (r.status === 'completed' && r.result) {
       const maxChars = config.task.subagentResultChars;
-      const text = r.result.length > maxChars ? r.result.slice(0, maxChars) + '\u2026' : r.result;
+      const text = r.result.length > maxChars ? `${r.result.slice(0, maxChars)}\u2026` : r.result;
       // Render each line as a blockquote
       for (const line of text.split('\n')) {
         lines.push(`> ${line}`);
@@ -744,7 +866,7 @@ function renderReasoningChain(steps: ReasoningStep[]): string[] {
 
   for (const step of steps) {
     const label = `**${capitalize(step.purpose)}** (step ${step.stepNumber}/${step.totalSteps})`;
-    const thought = step.thought.length > 200 ? step.thought.slice(0, 200) + '\u2026' : step.thought;
+    const thought = step.thought.length > 200 ? `${step.thought.slice(0, 200)}\u2026` : step.thought;
     let line = `${step.stepNumber}. ${label}: ${thought}`;
     if (step.nextAction) {
       line += `\n   \u2192 Next: ${step.nextAction}`;

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -314,9 +314,12 @@ function renderRecentActivity(
   messages: ConversationMessage[],
   config: VerbosityConfig,
 ): string[] {
+  const window = config.handoff.timelineWindow;
   const events =
     timeline.length > 0
-      ? [...timeline].sort((left, right) => left.sequence - right.sequence).slice(-config.handoff.timelineWindow)
+      ? window <= 0
+        ? []
+        : [...timeline].sort((left, right) => left.sequence - right.sequence).slice(-window)
       : messagesToTimeline(messages.slice(-config.recentMessages));
 
   if (events.length === 0) return [];

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,4 +1,5 @@
 import * as os from 'node:os';
+import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { adapters } from '../parsers/registry.js';
@@ -30,7 +31,7 @@ import {
 /** Replace home directory prefix with ~ and escape backticks for safe markdown inline code */
 const _home = os.homedir();
 export function safePath(p: string): string {
-  const tildified = p === _home || p.startsWith(`${_home}/`) ? `~${p.slice(_home.length)}` : p;
+  const tildified = p === _home || p.startsWith(`${_home}${path.sep}`) ? `~${p.slice(_home.length)}` : p;
   return tildified.replace(/`/g, '\\`');
 }
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -316,11 +316,11 @@ function renderRecentActivity(
 ): string[] {
   const window = config.handoff.timelineWindow;
   const events =
-    timeline.length > 0
-      ? window <= 0
-        ? []
-        : [...timeline].sort((left, right) => left.sequence - right.sequence).slice(-window)
-      : messagesToTimeline(messages.slice(-config.recentMessages));
+    window <= 0
+      ? []
+      : timeline.length > 0
+        ? [...timeline].sort((left, right) => left.sequence - right.sequence).slice(-window)
+        : messagesToTimeline(messages.slice(-config.recentMessages));
 
   if (events.length === 0) return [];
 


### PR DESCRIPTION
# :sparkles: feat(handoff): structured timeline + per-message metadata + verbosity controls

## Summary

This PR lands the **foundation layer** that the seven per-tool parser branches (`feat/parser-claude`, `feat/parser-codex`, `feat/parser-copilot`, `feat/parser-droid`, `feat/parser-gemini`, `feat/parser-opencode`, `feat/parser-amp`) will all consume. It introduces a chronological `SessionEvent` timeline alongside the existing `ConversationMessage[]`, adds source-tool provenance fields (`gitSha`, `sourceId`, `sourceParentId`, `isMeta`) so downstream renderers can reconcile messages back to their origin records, expands `SessionNotes` with lifecycle / bootstrap / fidelity-warning slots, and rewrites `generateHandoffMarkdown()` to be timeline-aware while remaining backward compatible with parsers that still pass only messages. A `handoff` block is added to `VerbosityConfig` so the four presets (`minimal` / `standard` / `verbose` / `full`) drive timeline window size, final-answer truncation, tool-appendix inclusion, and path-rendering policy.

The branch reached `DONE-PRAGMATIC` after two rounds of `/codex:review` (r1: 2 majors, both accepted; r2: 1 major, accepted). No type-check or test run was performed in the worktree by the orchestrator before this hand-off; the convergence is **review-driven**, not CI-validated. The reviewer should treat this as "code that two `/codex:review` passes signed off on" rather than "code we have proof works under `pnpm build && pnpm test`".

## Context / Why now

`continues` already extracts conversation history, file changes, and a grouped Tool-Activity summary from each supported AI CLI. The grouped summary loses **chronology** — a reviewer reading a handoff cannot tell whether `write_file` happened before or after the user clarified the requirement, and the recent-message section never showed tool calls inline with messages. The seven per-tool parser branches stacked on top of this foundation each emit a `SessionEvent[]` so the renderer can interleave messages, tool calls, tool results, lifecycle events, and reasoning steps in their original order. Doing the type/config/renderer work first lets every parser branch be reviewed in isolation against a stable contract instead of co-evolving the foundation with seven parsers in flight.

The home-directory tildify bug (`~`-prefix on a sibling directory like `~-sibling`) and the timeline-window=0 escape hatch are both small but were caught by `/codex:review` and are worth surfacing because they shape how downstream verbosity flags compose.

## The four commits, in order

### 1. `c69e14d` :sparkles: feat(handoff): structured timeline + per-message metadata + verbosity controls

Foundation commit. Adds the abstractions every parser branch consumes:

- **`src/types/index.ts`** — new `SessionEvent` interface and `SessionEventKind` union (`'message' | 'tool_call' | 'tool_result' | 'lifecycle' | 'reasoning' | 'metadata' | 'warning'`); `gitSha` on `UnifiedSession`; `sourceId`, `sourceParentId`, `isMeta` on `ConversationMessage`; `metadata`, `sourceEventId`, `sourceEventIds` on tool sample/summary types; new `SessionNotes` fields (`lifecycle`, `bootstrap`, `sourceMetadata`, `fileHistorySnapshots`, `rawAccess`, `fidelityWarnings`); optional `timeline?: SessionEvent[]` on `SessionContext`.
- **`src/types/schemas.ts`** — Zod augments so the schema parser does not strip new source-tool fields: `SerializedSessionSchema.gitSha`; Codex `meta.payload.timestamp`, `git.commit_hash`, `git.sha`, `source`; Copilot `currentModel` and `tool.args` (alongside existing `arguments`); Gemini tool-call `id`, `displayName`, `description`, `timestamp`, plus `functionResponse.id`, `functionResponse.name`, and `functionResponse.response.error`.
- **`src/config/verbosity.ts`** — new `HandoffConfigSchema` with `finalAnswerChars`, `timelineWindow`, `includeToolAppendix`, `pathPolicy: 'home-relative' | 'raw'`. All four presets get a `handoff` block: `minimal` 2k chars / 8 events, `standard` 4k / 20, `verbose` 8k / 40, `full` 20k / 200. Imports converted to `node:` prefix as part of the touch.
- **`src/utils/markdown.ts`** — adds `displayPath()` (cwd-relative when inside cwd, else home-relative tilde, else raw under `pathPolicy='raw'`), `pathIsInside()`, `formatTimestamp()` (full UTC string, not the previous minute-truncated `T`-replaced slice), `formatDuration()` (sub-minute renders as seconds, not `0 min`), `truncateWithMarker()` with a chars-omitted footer, and `renderRecentActivity()` which consumes `SessionEvent[]` when provided and falls back to a `messagesToTimeline()` adapter for parsers that still pass only `messages`. The renderer now emits a `## Current State` block (last assistant answer, truncated to `handoff.finalAnswerChars`) and demotes the grouped `## Tool Activity` to an appendix gated by `handoff.includeToolAppendix`.
- **`src/__tests__/shared-utils.test.ts`** — three new tests: `safePath` boundary behavior (`~`-sibling must NOT tildify), home-relative + UTC-timestamp + sub-minute `Active Time` + final-answer rendering, and timeline-aware ordering (`Recent Conversation` precedes `Tool Activity` and tool calls appear inline within the recent-conversation section).

### 2. `71ac7d1` :bug: fix(handoff): handle Windows path separator in safePath

Round-1 codex `cdx-1` finding. The original `p.startsWith(_home + '/')` boundary check would never match on Windows where `os.homedir()` returns `C:\Users\<name>` and stored paths use backslashes. Switched the boundary to `path.sep` so tildify works on both POSIX and Windows. Without this, every Windows session would have rendered absolute home paths verbatim — a real privacy regression for the cross-tool handoff doc.

### 3. `aac5d4a` :bug: fix(handoff): suppress timeline when window <= 0

Round-2 codex `cdx-1` finding. `Array.prototype.slice(-0)` returns the entire array (because `-0 === 0`), and `slice(-positive)` on a small array also returns the whole thing. So a user setting `handoff.timelineWindow: 0` (intending to disable the recent-activity section entirely) would have silently received the full timeline. Added an explicit `window <= 0 ? [] : …` guard before the slice.

### 4. `72d4c58` :bug: fix(handoff): honor timelineWindow=0 in message fallback path

Round-2 follow-up. The previous fix only guarded the structured-timeline branch of the conditional; the `messagesToTimeline()` fallback (which is what every existing parser call site uses today, since the per-tool branches that emit `timeline` are not yet merged) still ran `messages.slice(-config.recentMessages)` and rendered the section. Pulled the `window <= 0` guard outermost so both code paths suppress the section.

## Files touched

| File | LOC delta | What |
|---|---|---|
| `.gitignore` | +1 | Ignore `.battle-test/` (used by handoff acceptance tests) |
| `src/types/index.ts` | +57 / -0 | `SessionEvent`, `SessionEventKind`, message/tool/notes additions, `timeline?` on `SessionContext` |
| `src/types/schemas.ts` | +14 / -0 | Zod schema augments for Codex, Copilot, Gemini source data + `gitSha` on serialized form |
| `src/config/verbosity.ts` | +37 / -3 | `HandoffConfigSchema`; `handoff` block on all four presets; `node:` import prefixes |
| `src/utils/markdown.ts` | +163 / -23 | `displayPath` / `formatTimestamp` / `formatDuration` / `truncateWithMarker` / `renderRecentActivity` / `messagesToTimeline`; `## Current State` section; tool-activity demoted to appendix; `safePath` boundary fix |
| `src/__tests__/shared-utils.test.ts` | +79 / -1 | Three battle-test renderer cases |

Net: **+342 / -34 across 6 files**, of which `src/utils/markdown.ts` is the load-bearing one.

## Verification — what was run, what was not

Run by the author in the worktree:

- `git status --short` — clean
- `git log main..HEAD --oneline` — four expected commits
- `git diff main...HEAD --stat` — six files, deltas above

**Not run before this PR opens** (the orchestrator handed straight from `/codex:review` convergence to PR creation):

- `pnpm build`
- `pnpm test`
- `pnpm exec tsc --noEmit`
- Any actual handoff against a real `~/.codex/sessions/` or `~/.claude/projects/` session

The three new vitest cases in `shared-utils.test.ts` are written against the live exports (`safePath`, `generateHandoffMarkdown`, `getPreset('standard')`) and should pass — but until the reviewer or CI runs `pnpm test`, that is an assertion, not a verified fact. The same caveat applies to type-checking. Treat the **DONE-PRAGMATIC** status as "two codex passes signed off on the diff" rather than "the build is green".

## Round history (DONE-PRAGMATIC convergence)

| Round | Reviewer | Items | Accepted | Outcome |
|---|---|---|---|---|
| r1 | `/codex:review` | 2 major | 2 | `safePath` Windows separator fix (commit `71ac7d1`); rendering test additions captured the codex feedback so future regressions are caught |
| r2 | `/codex:review` | 1 major | 1 | `timelineWindow <= 0` escape hatch — first attempt (`aac5d4a`) only fixed the structured-timeline branch; follow-up (`72d4c58`) extended the guard to the message-fallback path |

The status is **DONE-PRAGMATIC**: every codex finding was accepted and addressed, but no formal validation gate (CI green, manual handoff dry-run) was run between r2 and this PR. The next branch in the merge order (`feat/parser-claude`) consumes `SessionEvent` and `displayPath` and will exercise the foundation against a real-tool extraction path; treat that branch's CI as the first proper integration check.

## Risks / Known limitations

1. **Timeline ordering is parser-trust-based.** `renderRecentActivity()` sorts by `event.sequence` (ascending). Sequence is a parser-assigned integer; if a parser branch emits non-monotonic or duplicate sequences (or starts at the wrong base for late-merged tool results), the recent-activity section will render in subtly wrong order. There is no defensive validation here — the foundation trusts the parsers to produce a coherent stream.
2. **`displayPath()` cwd-relative branch is POSIX-shaped.** It checks `candidate.startsWith('/')` and uses literal `/` separators. On Windows, paths that share a drive prefix with `cwd` will fall through to the home-tildify branch (where `path.sep` is correctly handled by the r1 fix), but the `./` cwd-relative form is not produced. Acceptable for now because the index file and most session storage paths live under `~`, but worth flagging.
3. **`gitSha` is added to the type and the serialized schema, but not yet populated by any parser** in this PR. The Codex/Claude/etc. parser branches each populate it from their own session metadata. Until those land, the `## Git SHA` row never appears in rendered handoffs and the schema field is always `undefined` on the wire.
4. **No migration/back-compat for `~/.continues/sessions.jsonl`** users with caches written by the previous schema version. `SerializedSessionSchema.gitSha` is optional, so old cache files parse fine; but any operator who manually serialized sessions with an old build and now reads them through this build will see `gitSha: undefined` until the cache is rebuilt by `continues rebuild`. This is the expected path and the cache TTL is 5 minutes anyway, but explicitly: there is no hard cutover, no version bump, no warning.
5. **The renderer's `## Current State` block always picks the *last* assistant message with non-empty content.** If the source tool emitted a refusal, an error, or an "I'll continue in a moment…" stall as the final assistant turn, that becomes the current state in the handoff. There is no "skip if final answer is shorter than N chars" filter. Acceptable for `standard` preset (4k char budget hides this), more visible at `minimal` (2k).
6. **Timeline window 0 is the only "off" switch.** There is no `handoff.includeRecentActivity: false` config — to suppress the section the user has to set `timelineWindow: 0`. The fact that round 2 had to fix two code paths to honor this single setting is itself a smell that the off-switch deserves a dedicated boolean. Not done here to keep the PR scoped.
7. **`SessionEvent.role` reuses `ConversationMessage['role']`** which today is `'user' | 'assistant' | 'system'`. The renderer's `event.kind === 'message'` branch maps anything that is not `'user'` or `'system'` to `'Assistant'` — including future `'tool'` or `'function'` roles if the type is widened. This is an implicit coupling worth a reviewer eye.

## Reviewer guidance

This is the foundation of a 9-branch stacked merge. Please prioritize:

1. **The `SessionEvent` shape.** Seven downstream parser branches will be writing emitters against this interface within the next few merges. Are the fields (`kind`, `sequence`, `role`, `content`, `id`, `sourceId`, `sourceParentId`, `toolName`, `toolCallId`, `status`, `arguments`, `result`, `filePaths`, `metadata`, `isFinalAnswer`, `isMeta`) the right cross-tool denominator, or are we baking in a Codex/Claude-shaped lens that Gemini, Copilot, OpenCode, Droid, Cursor, and Amp will fight against?
2. **The verbosity preset numbers.** `standard` = 20 timeline events, 4k final-answer chars. Is 20 events enough to recover the chronological end of a 200-message session, or does it just create a visible truncation with no signal?
3. **The fallback-to-messages path.** When `timeline` is empty, `messagesToTimeline()` synthesizes events with `sequence = index`. This means a parser that emits *both* messages and a partial tool-only timeline will see them concatenated incorrectly. Is the "timeline OR messages, not both" contract clear enough, and should we encode it in the type (e.g. mutually exclusive discriminated union) instead of letting parsers learn it by reading the renderer source?
4. **`displayPath` policy choice.** The `home-relative` policy renders `./file.ts` when `cwd === ~/proj` and `~/proj/file.ts` otherwise. Should we add a `cwd-relative-only` policy that never tildifies, for users who pipe handoffs into terminals where `~` will not be expanded?
5. **Round-2 codex finding fragility.** The `timelineWindow <= 0` bug needed two commits because the first guard was placed at the wrong scope. Is the current guard placement (outermost in `renderRecentActivity`) durable against future refactors, or should it be a config-time invariant (clamp to 1 in the schema, document "use a different flag to disable") so the renderer never has to think about it?

Downstream reviewers (`/codex:review` rescue, `/do-review` evaluator, MCP-based research bots) — please use the `mcp__research-powerpack__web-search`, `mcp__research-powerpack__start-research`, and `mcp__research-powerpack__scrape-links` tools when verifying:

- **Library API correctness.** `node:path` separator semantics on Windows, `Date.prototype.toISOString()` UTC guarantees, Zod `passthrough()` vs `strict()` behavior on optional augments, `Array.prototype.slice(-0)` edge cases.
- **Cross-platform behavior assumptions.** `os.homedir()` on Windows (does it ever return a trailing slash?), `path.sep` vs hard-coded separators, what `cwd` looks like under WSL, whether `process.cwd()` and `~` overlap on macOS sandboxed processes.
- **AI CLI session-storage formats.** When validating that the new Zod augments (Codex `meta.payload.timestamp` / `git.commit_hash` / `git.sha` / `source`; Copilot `currentModel` and `tool.args`; Gemini `id` / `displayName` / `description` / `timestamp` / `functionResponse.error`) match what the **current** versions of Codex CLI, GitHub Copilot CLI, and Gemini CLI actually write to disk. Cite primary sources (the tool's source, its release notes, or the actual fixture in `~/.codex/sessions/` etc.) — not blog summaries. Required for any major-flagged item.

## Follow-ups (not in scope)

- Rendering tests for the `lifecycle` / `metadata` / `warning` / `reasoning` event kinds. Right now only the `message` and `tool_call` paths have explicit assertions.
- A dedicated `handoff.includeRecentActivity: boolean` flag (see Risk #6).
- A snapshot-style golden test for the entire markdown body at each preset, so future renderer changes get a visual diff.
- Documenting `pathPolicy: 'raw'` somewhere user-facing — right now it is only discoverable by reading `verbosity.ts`.
- Expanding `pathIsInside` to handle Windows drive-letter paths properly.

## Request to the reviewer

Please weigh in specifically on questions 1, 2, and 5 above — those decisions get baked into the seven parser branches that depend on this foundation, and reversing them post-merge means touching every parser. Questions 3 and 4 can ride along as follow-ups if needed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a structured `SessionEvent` timeline with per-message metadata and handoff verbosity controls, and updates the markdown renderer to interleave events with a clear “Current State.” Also renders JSON arguments/metadata in fenced code blocks and applies timeline windowing consistently.

- **New Features**
  - Foundation types: `SessionEvent` timeline; message provenance (`sourceId`, `sourceParentId`, `isMeta`); `gitSha`; expanded `SessionNotes`.
  - Renderer: timeline‑aware `generateHandoffMarkdown()`; new “Current State”; cwd/home‑relative paths via `pathPolicy`; UTC timestamps; better duration + truncation; Tool Activity moved to an appendix; message fallback kept for back‑compat.
  - Config: new `handoff` block (`finalAnswerChars`, `timelineWindow`, `includeToolAppendix`, `pathPolicy`) across all presets.
  - Schemas: Zod augments for Codex, Copilot, Gemini; `SerializedSession.gitSha`.
  - Tests: coverage for tildify boundary, UTC/duration rendering, and timeline ordering.

- **Bug Fixes**
  - Correct `safePath` home-boundary on Windows using `path.sep`.
  - Honor `handoff.timelineWindow = 0` to suppress Recent Conversation in both timeline and message-fallback paths.
  - Apply `handoff.timelineWindow` in the message-fallback path (cap to `min(window, recentMessages)`).
  - Render tool-call arguments and lifecycle metadata in fenced `json` code blocks to avoid inline backtick issues.

<sup>Written for commit 6a951b65584f878de9f6c6b83b19e190e972cb3d. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/53?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

