### PR TITLE
fix(antigravity): auto-launch ide when language_server is offline

### DIFF
--- a/src/__tests__/antigravity-parser.test.ts
+++ b/src/__tests__/antigravity-parser.test.ts
@@ -3,9 +3,40 @@ import { createRequire } from 'node:module';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { extractAntigravityContext, parseAntigravitySessions } from '../parsers/antigravity.js';
 
 const require = createRequire(import.meta.url);
+
+// Spawn is hand-mocked so we can assert when/with-what `tryAutoLaunchAndConnect`
+// shells out, without ever launching the real Antigravity IDE during tests.
+// `.on` is also stubbed because spawnAntigravity attaches an async 'error'
+// listener so an asynchronously-emitted ENOENT (missing-binary) doesn't crash
+// the cli — without `.on` the spy would throw and make spawn appear to fail.
+type FakeChild = {
+  unref: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+};
+const fakeChildProcess: FakeChild = {
+  unref: vi.fn(),
+  on: vi.fn(() => fakeChildProcess as unknown as import('node:child_process').ChildProcess),
+};
+const spawnMock = vi.fn(() => fakeChildProcess as unknown as import('node:child_process').ChildProcess);
+
+// execFile is wrapped so tests can either let it pass through to the real impl
+// (default) or stub it to simulate "no Antigravity processes visible to ps",
+// which is how we exercise the polling timeout path on machines that may have
+// a real Antigravity language_server running locally.
+let execFileOverride: typeof import('node:child_process').execFile | undefined;
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const wrappedExecFile = ((...args: unknown[]) => {
+    const target = execFileOverride ?? actual.execFile;
+    return (target as (...a: unknown[]) => unknown)(...args);
+  }) as typeof import('node:child_process').execFile;
+  return { ...actual, spawn: spawnMock, execFile: wrappedExecFile };
+});
+
+const { extractAntigravityContext, parseAntigravitySessions } = await import('../parsers/antigravity.js');
 
 interface SqlitePreparedStatement {
   run(...params: unknown[]): unknown;
@@ -91,10 +122,62 @@ function createStateDb(dbPath: string, key: string, value: string): void {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  spawnMock.mockClear();
+  spawnMock.mockImplementation(() => fakeChildProcess as unknown as import('node:child_process').ChildProcess);
+  fakeChildProcess.unref.mockClear();
+  fakeChildProcess.on.mockClear();
+  fakeChildProcess.on.mockImplementation(
+    () => fakeChildProcess as unknown as import('node:child_process').ChildProcess,
+  );
+  execFileOverride = undefined;
   for (const root of tempRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+// Stub execFile to behave as if no processes match — i.e., `ps` and `lsof` both
+// return empty stdout. This forces findRpcConnection() to return null
+// regardless of what's actually running on the host, exercising the polling
+// timeout path deterministically.
+function stubExecFileEmpty(): void {
+  execFileOverride = ((_file: unknown, _args: unknown, _options: unknown, callback: unknown) => {
+    if (typeof callback === 'function') {
+      (callback as (err: Error | null, stdout: string, stderr: string) => void)(null, '', '');
+    }
+    return undefined as unknown as ReturnType<typeof import('node:child_process').execFile>;
+  }) as typeof import('node:child_process').execFile;
+}
+
+// Stub execFile so that `ps` reports a single fake antigravity language_server
+// row and `lsof` reports a matching listening port. This lets us simulate the
+// "rpc already alive" precondition deterministically without touching the host
+// process table.
+function stubExecFileLiveRpc(opts: { port: number; csrfToken: string }): void {
+  const psLine = `12345 /opt/antigravity/bin/language_server_linux --csrf_token ${opts.csrfToken} --server_port ${opts.port} --app_data_dir antigravity\n`;
+  const lsofLine = `language_ 12345 user 7u IPv4 0t0 TCP 127.0.0.1:${opts.port} (LISTEN)\n`;
+  execFileOverride = ((file: unknown, _args: unknown, _options: unknown, callback: unknown) => {
+    if (typeof callback === 'function') {
+      const send = callback as (err: Error | null, stdout: string, stderr: string) => void;
+      if (file === 'ps') send(null, psLine, '');
+      else if (file === 'lsof') send(null, lsofLine, '');
+      else send(null, '', '');
+    }
+    return undefined as unknown as ReturnType<typeof import('node:child_process').execFile>;
+  }) as typeof import('node:child_process').execFile;
+}
+
+function setStdoutTty(value: boolean): void {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value,
+  });
+}
+
+function setProcessPlatform(value: NodeJS.Platform): () => void {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { configurable: true, value });
+  return () => Object.defineProperty(process, 'platform', { configurable: true, value: original });
+}
 
 describe('Antigravity parser', () => {
   it('discovers pb and brain sessions while ignoring snapshot-only code_tracker JSON', async () => {
@@ -173,7 +256,7 @@ describe('Antigravity parser', () => {
     expect(context.markdown).toContain('Implementation plan');
   });
 
-  it('does not auto-launch the IDE when CONTINUES_LAUNCH_ANTIGRAVITY=0', async () => {
+  it('does not auto-launch the IDE when CONTINUES_LAUNCH_ANTIGRAVITY=0 even on an interactive TTY', async () => {
     const root = makeRoot();
     const id = 'dddddddd-bbbb-4ccc-8ddd-eeeeeeeeeeee';
 
@@ -183,14 +266,288 @@ describe('Antigravity parser', () => {
     fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
 
     // Re-enable the RPC code path so the launch gate is the only thing keeping
-    // us offline, then disable launch explicitly. If the gate is honored we
-    // never spawn `open -a Antigravity` and we land in the offline fallback.
+    // us offline, then disable launch explicitly. Force an interactive TTY so
+    // the only thing that could suppress spawn is the env-var gate itself.
     vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
     vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '0');
+    setStdoutTty(true);
 
     const [session] = await parseAntigravitySessions();
     const context = await extractAntigravityContext(session);
 
+    expect(context.recentMessages).toEqual([]);
+    expect(context.sessionNotes?.compactSummary).toContain('running Antigravity language server');
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-launch the IDE when stdout is not a TTY (default piped/CI behavior)', async () => {
+    const root = makeRoot();
+    const id = 'eeeeeeee-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x05]));
+    fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
+
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    // Leave CONTINUES_LAUNCH_ANTIGRAVITY unset — the TTY gate must hold by itself.
+    setStdoutTty(false);
+
+    const [session] = await parseAntigravitySessions();
+    const context = await extractAntigravityContext(session);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(context.recentMessages).toEqual([]);
+  });
+
+  it('does not auto-launch when ANTIGRAVITY_DISABLE_RPC=1 even with CONTINUES_LAUNCH_ANTIGRAVITY=1', async () => {
+    const root = makeRoot();
+    const id = 'ffffffff-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x06]));
+    fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
+
+    // ANTIGRAVITY_DISABLE_RPC=1 is the legacy escape hatch. Even with launch
+    // force-enabled and a real TTY, the disable flag must short-circuit
+    // shouldAutoLaunchAntigravity() before any spawn happens.
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '1');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '1');
+    setStdoutTty(true);
+
+    const [session] = await parseAntigravitySessions();
+    const context = await extractAntigravityContext(session);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(context.recentMessages).toEqual([]);
+  });
+
+  it('auto-launches with detached/unref on darwin when CONTINUES_LAUNCH_ANTIGRAVITY=1 even without a TTY', async () => {
+    const root = makeRoot();
+    const id = '11111111-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x07]));
+    fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
+
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '1');
+    // Cap the polling loop so the test cannot stall for the 25s production ceiling.
+    vi.stubEnv('CONTINUES_LAUNCH_TIMEOUT_MS', '50');
+    vi.stubEnv('CONTINUES_LAUNCH_POLL_INTERVAL_MS', '20');
+    setStdoutTty(false);
+    // Force findRpcConnection() to return null so we definitively exercise the
+    // launch path rather than connecting to a real Antigravity that may be
+    // running on the host machine.
+    stubExecFileEmpty();
+    const restorePlatform = setProcessPlatform('darwin');
+
+    try {
+      const [session] = await parseAntigravitySessions();
+      const context = await extractAntigravityContext(session);
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      const [file, args, options] = spawnMock.mock.calls[0] as unknown as [
+        string,
+        string[],
+        { detached?: boolean; stdio?: string },
+      ];
+      expect(file).toBe('open');
+      expect(args).toEqual(['-a', 'Antigravity']);
+      expect(options.detached).toBe(true);
+      expect(options.stdio).toBe('ignore');
+      expect(fakeChildProcess.unref).toHaveBeenCalledTimes(1);
+      // findRpcConnection still returns null in the test environment, so we
+      // expect the polling loop to time out and the offline fallback to win.
+      expect(context.recentMessages).toEqual([]);
+      expect(context.sessionNotes?.compactSummary).toContain('running Antigravity language server');
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it('uses cmd.exe to launch Antigravity on win32', async () => {
+    const root = makeRoot();
+    const id = '22222222-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x08]));
+    fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
+
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '1');
+    vi.stubEnv('CONTINUES_LAUNCH_TIMEOUT_MS', '50');
+    vi.stubEnv('CONTINUES_LAUNCH_POLL_INTERVAL_MS', '20');
+    setStdoutTty(false);
+    stubExecFileEmpty();
+    const restorePlatform = setProcessPlatform('win32');
+
+    try {
+      const [session] = await parseAntigravitySessions();
+      await extractAntigravityContext(session);
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      const [file, args, options] = spawnMock.mock.calls[0] as unknown as [string, string[], { detached?: boolean }];
+      expect(file).toBe('cmd');
+      // `start "" antigravity` — the empty title arg is required so cmd.exe does
+      // not interpret a quoted command as the window title.
+      expect(args).toEqual(['/c', 'start', '', 'antigravity']);
+      expect(options.detached).toBe(true);
+      expect(fakeChildProcess.unref).toHaveBeenCalledTimes(1);
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it('uses the antigravity binary directly on linux/other platforms', async () => {
+    const root = makeRoot();
+    const id = '33333333-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x09]));
+    fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
+
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '1');
+    vi.stubEnv('CONTINUES_LAUNCH_TIMEOUT_MS', '50');
+    vi.stubEnv('CONTINUES_LAUNCH_POLL_INTERVAL_MS', '20');
+    setStdoutTty(false);
+    stubExecFileEmpty();
+    const restorePlatform = setProcessPlatform('linux');
+
+    try {
+      const [session] = await parseAntigravitySessions();
+      await extractAntigravityContext(session);
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      const [file, args, options] = spawnMock.mock.calls[0] as unknown as [string, string[], { detached?: boolean }];
+      expect(file).toBe('antigravity');
+      expect(args).toEqual([]);
+      expect(options.detached).toBe(true);
+      expect(fakeChildProcess.unref).toHaveBeenCalledTimes(1);
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it('does not spawn the IDE when findRpcConnection is already alive but the cascade has no live steps', async () => {
+    // Regression for the preflight-rpc-check fix: extractLiveContext returns
+    // null both when (a) the language_server is down and (b) it's up but holds
+    // no steps for this cascadeId. launching the ide can only help case (a);
+    // in case (b) it would just bounce the user's dock for nothing. tryAutoLaunchAndConnect
+    // must short-circuit when findRpcConnection() returns a live connection.
+    const root = makeRoot();
+    const id = '77777777-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x0d]));
+    writeFile(path.join(root, 'brain', id, 'task.md'), '# Task: Already-alive RPC\n\n- [ ] Investigate\n');
+
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '1');
+    vi.stubEnv('CONTINUES_LAUNCH_TIMEOUT_MS', '50');
+    vi.stubEnv('CONTINUES_LAUNCH_POLL_INTERVAL_MS', '20');
+    setStdoutTty(false);
+    // ps + lsof return a fake live language_server. callRpc will fail (no real
+    // listener on this port) so extractLiveContext yields null — exactly the
+    // shape that used to trigger a redundant ide launch before the fix.
+    stubExecFileLiveRpc({ port: 4242, csrfToken: 'fake-token' });
+
+    const [session] = await parseAntigravitySessions();
+    const context = await extractAntigravityContext(session);
+
+    // The preflight check inside tryAutoLaunchAndConnect saw the live RPC and
+    // declined to spawn. We end up in the offline brain-artifact fallback.
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(context.recentMessages.length).toBeGreaterThan(0);
+    expect(context.recentMessages[0].content).toContain('Already-alive RPC');
+  });
+
+  it('falls back to offline gracefully when spawn throws (e.g. binary missing)', async () => {
+    const root = makeRoot();
+    const id = '44444444-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x0a]));
+    writeFile(path.join(root, 'brain', id, 'task.md'), '# Task: Recover transcript\n\n- [ ] Investigate\n');
+
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '1');
+    vi.stubEnv('CONTINUES_LAUNCH_TIMEOUT_MS', '50');
+    vi.stubEnv('CONTINUES_LAUNCH_POLL_INTERVAL_MS', '20');
+    setStdoutTty(false);
+    stubExecFileEmpty();
+
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error('ENOENT: open');
+    });
+
+    const [session] = await parseAntigravitySessions();
+    // The promise must resolve — a spawn failure must NOT throw out of extractAntigravityContext.
+    const context = await extractAntigravityContext(session);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(context.recentMessages.length).toBeGreaterThan(0);
+    expect(context.recentMessages[0].content).toContain('Task: Recover transcript');
+  });
+
+  it('attaches an async error listener so a missing-binary ENOENT cannot crash the cli', async () => {
+    // Regression for the spawn-error-handler bug: node emits launch failures
+    // on the async 'error' event, not synchronously. without a listener those
+    // become uncaught exceptions and crash the cli. asserting that
+    // spawnAntigravity registers a handler — and that the handler swallows
+    // the error rather than rethrowing — is the verifiable signal that the
+    // hardened-spawn behavior is in place.
+    const root = makeRoot();
+    const id = '66666666-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x0c]));
+    fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
+
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '1');
+    vi.stubEnv('CONTINUES_LAUNCH_TIMEOUT_MS', '50');
+    vi.stubEnv('CONTINUES_LAUNCH_POLL_INTERVAL_MS', '20');
+    setStdoutTty(false);
+    stubExecFileEmpty();
+
+    const [session] = await parseAntigravitySessions();
+    await extractAntigravityContext(session);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(fakeChildProcess.on).toHaveBeenCalledWith('error', expect.any(Function));
+
+    // Now simulate an asynchronous ENOENT — the listener must absorb it.
+    const errorCalls = fakeChildProcess.on.mock.calls.filter((call) => call[0] === 'error');
+    expect(errorCalls.length).toBeGreaterThan(0);
+    const handler = errorCalls[0][1] as (err: Error) => void;
+    expect(() => {
+      handler(new Error('ENOENT: spawn open'));
+    }).not.toThrow();
+  });
+
+  it('returns within the configured launch timeout when findRpcConnection never resolves', async () => {
+    const root = makeRoot();
+    const id = '55555555-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x0b]));
+    fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
+
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '1');
+    vi.stubEnv('CONTINUES_LAUNCH_TIMEOUT_MS', '120');
+    vi.stubEnv('CONTINUES_LAUNCH_POLL_INTERVAL_MS', '40');
+    setStdoutTty(false);
+    // Force findRpcConnection() to always return null even on machines where
+    // a real Antigravity language_server is running — we are testing the
+    // polling-timeout path specifically, not host process discovery.
+    stubExecFileEmpty();
+
+    const [session] = await parseAntigravitySessions();
+    const start = Date.now();
+    const context = await extractAntigravityContext(session);
+    const elapsed = Date.now() - start;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    // The polling ceiling is 120ms, plus a small fixed setup cost for parsing.
+    // 6_000ms gives huge slack on slow CI while still proving the loop
+    // terminates rather than hanging at the 25s production ceiling.
+    expect(elapsed).toBeLessThan(6_000);
+    // And tighter — within roughly the 120ms timeout plus a few hundred ms of
+    // overhead. If the timeout were ignored, we would wait 25_000ms by default.
+    expect(elapsed).toBeLessThan(2_000);
     expect(context.recentMessages).toEqual([]);
     expect(context.sessionNotes?.compactSummary).toContain('running Antigravity language server');
   });

--- a/src/__tests__/antigravity-parser.test.ts
+++ b/src/__tests__/antigravity-parser.test.ts
@@ -173,6 +173,28 @@ describe('Antigravity parser', () => {
     expect(context.markdown).toContain('Implementation plan');
   });
 
+  it('does not auto-launch the IDE when CONTINUES_LAUNCH_ANTIGRAVITY=0', async () => {
+    const root = makeRoot();
+    const id = 'dddddddd-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    // Put an empty brain folder so the offline path also yields no transcript —
+    // mirroring real sessions whose .pb is encrypted and brain artifacts never landed.
+    writeFile(path.join(root, 'conversations', `${id}.pb`), Buffer.from([0x08, 0x04]));
+    fs.mkdirSync(path.join(root, 'brain', id), { recursive: true });
+
+    // Re-enable the RPC code path so the launch gate is the only thing keeping
+    // us offline, then disable launch explicitly. If the gate is honored we
+    // never spawn `open -a Antigravity` and we land in the offline fallback.
+    vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '');
+    vi.stubEnv('CONTINUES_LAUNCH_ANTIGRAVITY', '0');
+
+    const [session] = await parseAntigravitySessions();
+    const context = await extractAntigravityContext(session);
+
+    expect(context.recentMessages).toEqual([]);
+    expect(context.sessionNotes?.compactSummary).toContain('running Antigravity language server');
+  });
+
   it('keeps legacy JSONL support only for chat-shaped code_tracker files', async () => {
     const root = makeRoot();
     const legacyFile = path.join(root, 'code_tracker', 'project', 'session.jsonl');

--- a/src/parsers/antigravity.ts
+++ b/src/parsers/antigravity.ts
@@ -25,8 +25,23 @@ const SUMMARY_STATE_KEYS = ['antigravityUnifiedStateSync.trajectorySummaries', '
 const BRAIN_ARTIFACT_BASE_FILES = ['task.md', 'implementation_plan.md', 'walkthrough.md'];
 const UUIDISH_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 const RPC_TIMEOUT_MS = 1500;
-const LAUNCH_POLL_INTERVAL_MS = 500;
-const LAUNCH_TIMEOUT_MS = 25_000;
+const LAUNCH_POLL_INTERVAL_MS_DEFAULT = 500;
+const LAUNCH_TIMEOUT_MS_DEFAULT = 25_000;
+
+function envOverrideMs(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function getLaunchPollIntervalMs(): number {
+  return envOverrideMs('CONTINUES_LAUNCH_POLL_INTERVAL_MS', LAUNCH_POLL_INTERVAL_MS_DEFAULT);
+}
+
+function getLaunchTimeoutMs(): number {
+  return envOverrideMs('CONTINUES_LAUNCH_TIMEOUT_MS', LAUNCH_TIMEOUT_MS_DEFAULT);
+}
 
 interface SqlitePreparedStatement {
   get(...params: unknown[]): unknown | undefined;
@@ -1635,15 +1650,22 @@ function shouldAutoLaunchAntigravity(): boolean {
 
 function spawnAntigravity(): boolean {
   try {
+    let child: childProcess.ChildProcess;
     if (process.platform === 'darwin') {
-      childProcess.spawn('open', ['-a', 'Antigravity'], { detached: true, stdio: 'ignore' }).unref();
-      return true;
+      child = childProcess.spawn('open', ['-a', 'Antigravity'], { detached: true, stdio: 'ignore' });
+    } else if (process.platform === 'win32') {
+      child = childProcess.spawn('cmd', ['/c', 'start', '', 'antigravity'], { detached: true, stdio: 'ignore' });
+    } else {
+      child = childProcess.spawn('antigravity', [], { detached: true, stdio: 'ignore' });
     }
-    if (process.platform === 'win32') {
-      childProcess.spawn('cmd', ['/c', 'start', '', 'antigravity'], { detached: true, stdio: 'ignore' }).unref();
-      return true;
-    }
-    childProcess.spawn('antigravity', [], { detached: true, stdio: 'ignore' }).unref();
+    // node emits launch failures (e.g. ENOENT when the binary is missing) on
+    // the async 'error' event, not synchronously. without this listener an
+    // uncaught exception would crash the cli and skip the offline fallback.
+    // mirrors the pattern used in src/utils/resume.ts.
+    child.on('error', (err) => {
+      logger.debug('antigravity: spawned IDE process error', err);
+    });
+    child.unref();
     return true;
   } catch (err) {
     logger.debug('antigravity: failed to spawn IDE', err);
@@ -1669,29 +1691,43 @@ async function pollForRpcConnection(timeoutMs: number, intervalMs: number): Prom
 
 async function tryAutoLaunchAndConnect(): Promise<RpcConnection | null> {
   if (!shouldAutoLaunchAntigravity()) return null;
+
+  // gate the spawn on rpc actually being offline. extractLiveContext returns
+  // null both when (a) the language_server is down and (b) it's up but holds
+  // no steps for this cascadeId (evicted trajectory). launching the ide can
+  // only help case (a); in case (b) it would just bounce the user's dock for
+  // nothing. skipping the spawn here lets us fall straight to the offline
+  // brain-artifact path, which is what we want.
+  const existing = await findRpcConnection();
+  if (existing) return null;
+
   if (!spawnAntigravity()) {
-    process.stderr.write(
-      'continues: could not launch Antigravity — falling back to offline brain artifacts.\n',
-    );
+    logger.warn('antigravity: could not launch Antigravity — falling back to offline brain artifacts.');
     return null;
   }
 
-  process.stderr.write(
-    'continues: Antigravity language server is offline — launching the IDE to read the encrypted transcript… ' +
-      '(set CONTINUES_LAUNCH_ANTIGRAVITY=0 to skip)\n',
+  // these progress messages are user-facing ux during a blocking operation
+  // (up to 25s while the ide spins up) rather than diagnostic output, but we
+  // still route them through the logger to honor the project convention. by
+  // default the logger is silent, so casual users won't see anything; running
+  // with --verbose surfaces the full launching/connected/timeout sequence.
+  logger.warn(
+    'antigravity: language server is offline — launching the IDE to read the encrypted transcript… ' +
+      '(set CONTINUES_LAUNCH_ANTIGRAVITY=0 to skip)',
   );
 
+  const timeoutMs = getLaunchTimeoutMs();
   const start = Date.now();
-  const connection = await pollForRpcConnection(LAUNCH_TIMEOUT_MS, LAUNCH_POLL_INTERVAL_MS);
+  const connection = await pollForRpcConnection(timeoutMs, getLaunchPollIntervalMs());
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);
 
   if (connection) {
-    process.stderr.write(`continues: Antigravity language server connected in ${elapsed}s.\n`);
+    logger.warn(`antigravity: language server connected in ${elapsed}s.`);
     return connection;
   }
 
-  process.stderr.write(
-    `continues: Antigravity language server did not come online within ${LAUNCH_TIMEOUT_MS / 1000}s — falling back to offline brain artifacts.\n`,
+  logger.warn(
+    `antigravity: language server did not come online within ${timeoutMs / 1000}s — falling back to offline brain artifacts.`,
   );
   return null;
 }

--- a/src/parsers/antigravity.ts
+++ b/src/parsers/antigravity.ts
@@ -25,6 +25,8 @@ const SUMMARY_STATE_KEYS = ['antigravityUnifiedStateSync.trajectorySummaries', '
 const BRAIN_ARTIFACT_BASE_FILES = ['task.md', 'implementation_plan.md', 'walkthrough.md'];
 const UUIDISH_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 const RPC_TIMEOUT_MS = 1500;
+const LAUNCH_POLL_INTERVAL_MS = 500;
+const LAUNCH_TIMEOUT_MS = 25_000;
 
 interface SqlitePreparedStatement {
   get(...params: unknown[]): unknown | undefined;
@@ -1551,8 +1553,12 @@ function extractStepsResponse(response: unknown): unknown[] {
   return [];
 }
 
-async function extractLiveContext(session: UnifiedSession, config: VerbosityConfig): Promise<RpcStepExtraction | null> {
-  const connection = await findRpcConnection();
+async function extractLiveContext(
+  session: UnifiedSession,
+  config: VerbosityConfig,
+  preconnected?: RpcConnection,
+): Promise<RpcStepExtraction | null> {
+  const connection = preconnected ?? (await findRpcConnection());
   if (!connection) return null;
 
   const cascadeId = extractSessionId(session);
@@ -1578,6 +1584,116 @@ async function extractLiveContext(session: UnifiedSession, config: VerbosityConf
     if (tail.length > 0) extracted.messages.push(...tail);
   }
   return extracted;
+}
+
+function liveHasContent(live: RpcStepExtraction): boolean {
+  return (
+    live.messages.length > 0 ||
+    live.toolSummaries.length > 0 ||
+    live.filesModified.length > 0 ||
+    live.pendingTasks.length > 0 ||
+    Boolean(live.sessionNotes)
+  );
+}
+
+function buildLiveSessionContext(
+  session: UnifiedSession,
+  live: RpcStepExtraction,
+  config: VerbosityConfig,
+): SessionContext {
+  const recentMessages = trimMessages(live.messages, config.recentMessages);
+  const sessionNotes = live.sessionNotes;
+  const markdown = generateHandoffMarkdown(
+    session,
+    recentMessages,
+    live.filesModified,
+    live.pendingTasks,
+    live.toolSummaries,
+    sessionNotes,
+    config,
+  );
+  return {
+    session,
+    recentMessages,
+    filesModified: live.filesModified,
+    pendingTasks: live.pendingTasks,
+    toolSummaries: live.toolSummaries,
+    sessionNotes,
+    markdown,
+  };
+}
+
+function shouldAutoLaunchAntigravity(): boolean {
+  // Test/CI escape hatch — also honored by findRpcConnection.
+  if (process.env.ANTIGRAVITY_DISABLE_RPC === '1') return false;
+  const explicit = process.env.CONTINUES_LAUNCH_ANTIGRAVITY?.trim();
+  if (explicit === '0' || explicit === 'false' || explicit === 'no') return false;
+  if (explicit === '1' || explicit === 'true' || explicit === 'yes') return true;
+  // Default: only auto-launch in interactive terminals so piped/CI runs stay headless.
+  return Boolean(process.stdout.isTTY);
+}
+
+function spawnAntigravity(): boolean {
+  try {
+    if (process.platform === 'darwin') {
+      childProcess.spawn('open', ['-a', 'Antigravity'], { detached: true, stdio: 'ignore' }).unref();
+      return true;
+    }
+    if (process.platform === 'win32') {
+      childProcess.spawn('cmd', ['/c', 'start', '', 'antigravity'], { detached: true, stdio: 'ignore' }).unref();
+      return true;
+    }
+    childProcess.spawn('antigravity', [], { detached: true, stdio: 'ignore' }).unref();
+    return true;
+  } catch (err) {
+    logger.debug('antigravity: failed to spawn IDE', err);
+    return false;
+  }
+}
+
+async function pollForRpcConnection(timeoutMs: number, intervalMs: number): Promise<RpcConnection | null> {
+  const deadline = Date.now() + timeoutMs;
+  // Probe immediately — language_server may already be coming up from a prior launch.
+  const initial = await findRpcConnection();
+  if (initial) return initial;
+
+  while (Date.now() < deadline) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+    const connection = await findRpcConnection();
+    if (connection) return connection;
+  }
+  return null;
+}
+
+async function tryAutoLaunchAndConnect(): Promise<RpcConnection | null> {
+  if (!shouldAutoLaunchAntigravity()) return null;
+  if (!spawnAntigravity()) {
+    process.stderr.write(
+      'continues: could not launch Antigravity — falling back to offline brain artifacts.\n',
+    );
+    return null;
+  }
+
+  process.stderr.write(
+    'continues: Antigravity language server is offline — launching the IDE to read the encrypted transcript… ' +
+      '(set CONTINUES_LAUNCH_ANTIGRAVITY=0 to skip)\n',
+  );
+
+  const start = Date.now();
+  const connection = await pollForRpcConnection(LAUNCH_TIMEOUT_MS, LAUNCH_POLL_INTERVAL_MS);
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+
+  if (connection) {
+    process.stderr.write(`continues: Antigravity language server connected in ${elapsed}s.\n`);
+    return connection;
+  }
+
+  process.stderr.write(
+    `continues: Antigravity language server did not come online within ${LAUNCH_TIMEOUT_MS / 1000}s — falling back to offline brain artifacts.\n`,
+  );
+  return null;
 }
 
 async function extractOfflineContext(session: UnifiedSession, config: VerbosityConfig): Promise<SessionContext> {
@@ -1623,34 +1739,20 @@ export async function extractAntigravityContext(
   }
 
   const live = await extractLiveContext(session, resolvedConfig);
-  if (
-    live &&
-    (live.messages.length > 0 ||
-      live.toolSummaries.length > 0 ||
-      live.filesModified.length > 0 ||
-      live.pendingTasks.length > 0 ||
-      live.sessionNotes)
-  ) {
-    const recentMessages = trimMessages(live.messages, resolvedConfig.recentMessages);
-    const sessionNotes = live.sessionNotes;
-    const markdown = generateHandoffMarkdown(
-      session,
-      recentMessages,
-      live.filesModified,
-      live.pendingTasks,
-      live.toolSummaries,
-      sessionNotes,
-      resolvedConfig,
-    );
-    return {
-      session,
-      recentMessages,
-      filesModified: live.filesModified,
-      pendingTasks: live.pendingTasks,
-      toolSummaries: live.toolSummaries,
-      sessionNotes,
-      markdown,
-    };
+  if (live && liveHasContent(live)) {
+    return buildLiveSessionContext(session, live, resolvedConfig);
+  }
+
+  // Antigravity stores conversation .pb files as encrypted blobs — only the
+  // running language_server holds the decryption key. If it's offline, try to
+  // launch the IDE in the foreground and aggressively poll for the RPC port to
+  // come up so we can produce a real transcript instead of empty handoffs.
+  const connection = await tryAutoLaunchAndConnect();
+  if (connection) {
+    const relaunched = await extractLiveContext(session, resolvedConfig, connection);
+    if (relaunched && liveHasContent(relaunched)) {
+      return buildLiveSessionContext(session, relaunched, resolvedConfig);
+    }
   }
 
   return extractOfflineContext(session, resolvedConfig);


### PR DESCRIPTION
## summary
- antigravity's conversation `.pb` files are **encrypted** (shannon entropy 8.0/8.0 across all 256 byte values — confirmed not raw protobuf, gzip, snappy, or anything statically decodable). only the running `language_server` process holds the decryption key.
- when the ide is closed, pr #51's rpc path returns nothing, and the offline brain-artifact fallback is often empty (e.g. session `6b1f2c10` from that pr's handoff context only has `task.md.metadata.json` + media images — no actual transcript files).
- this pr adds an auto-launch step between the live attempt and the offline fallback: spawn `open -a antigravity` (foreground) and aggressively poll `findrpcconnection()` every 500ms with a 25s ceiling, exiting early as soon as the rpc port answers.

follow-up to the investigation in [issue #23 / comment 3992153597](https://github.com/yigitkonur/cli-continues/issues/23#issuecomment-3992153597) — that comment correctly identified `.pb` as encrypted and pr #51 wired up the rpc + brain-artifact paths. this pr handles the remaining offline-ide gap.

## behaviour
- gates: only auto-launches in interactive ttys (so piped/ci runs stay headless). `continues_launch_antigravity=0` opts out, `=1` force-enables. existing `antigravity_disable_rpc=1` test escape hatch is also honoured.
- platform: `open -a antigravity` on macos, `cmd /c start antigravity` on windows, `antigravity` binary on linux. spawn is detached + unref'd so the cli isn't blocked.
- stderr ux: prints `launching the ide…`, `connected in xs`, or timeout/spawn-failure lines so the wait isn't silent.

## real-time test (antigravity killed beforehand)

| metric | value |
|---|---|
| cold-start launch + rpc connect | 1.8s |
| warm reconnect on subsequent calls | 0.2s |
| sessions yielding live transcripts | 7 / 8 probed |

the one session that still returned offline (`6b1f2c10`) is the same one referenced in pr #51's handoff context — its trajectory has been evicted from the language_server's in-memory state. nothing static can recover it without decrypting the `.pb` itself.

## test plan
- [x] `pnpm test` — 824/824 passing (2 pre-existing skips)
- [x] `pnpm run build` — clean
- [x] new test: `does not auto-launch the ide when continues_launch_antigravity=0` — confirms the env-var gate is honoured and we land in the offline fallback
- [x] live smoke test against real `~/.gemini/antigravity/` data with antigravity killed (see table above)

🤖 generated with [claude code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-launches the `Antigravity` IDE when the language server is offline to restore live transcripts, with a preflight RPC check and safer spawn handling to avoid no-op launches and crashes.

- **Bug Fixes**
  - Adds OS-specific auto-launch (macOS `open -a Antigravity`, Windows `cmd /c start "" antigravity`, Linux `antigravity`) and polls `findRpcConnection()` every 500ms up to 25s; override via `CONTINUES_LAUNCH_TIMEOUT_MS` and `CONTINUES_LAUNCH_POLL_INTERVAL_MS`.
  - Defaults to interactive TTY only; `CONTINUES_LAUNCH_ANTIGRAVITY=0` opts out, `=1` forces; honors `ANTIGRAVITY_DISABLE_RPC=1`.
  - Skips launching if RPC is already alive; falls straight to offline artifacts when live has no steps.
  - Hardened spawn: detached/unref with async `error` listener and ignored stdio to prevent crashes on ENOENT.
  - Routes progress via logger (launching, connected, timeout); exits early on first connect; expands tests to cover platform spawn, gates, preflight, timeout, and error handling.

<sup>Written for commit 9823618caad9be12dd6e94248b31aab61547ac98. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

