### PR TITLE
fix(parser): harden qwen code jsonl parsing

### DIFF
--- a/src/__tests__/qwen-code-parser.test.ts
+++ b/src/__tests__/qwen-code-parser.test.ts
@@ -1,0 +1,586 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { extractQwenCodeContext, parseQwenCodeSessions } from '../parsers/qwen-code.js';
+import type { UnifiedSession } from '../types/index.js';
+
+const TEST_CWD = '/workspaces/acme/widget';
+const SESSION_ID = '11111111-2222-3333-4444-555555555555';
+
+const originalQwenRuntimeDir = process.env.QWEN_RUNTIME_DIR;
+const originalQwenHome = process.env.QWEN_HOME;
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-code-parser-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function sanitizeCwd(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+function qwenRecord(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    uuid: 'record-id',
+    parentUuid: null,
+    sessionId: SESSION_ID,
+    timestamp: '2026-01-15T10:00:00.000Z',
+    type: 'user',
+    cwd: TEST_CWD,
+    version: '0.14.5',
+    ...overrides,
+  };
+}
+
+function writeJsonl(filePath: string, lines: Array<Record<string, unknown> | string>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `${lines.map((line) => (typeof line === 'string' ? line : JSON.stringify(line))).join('\n')}\n`,
+  );
+}
+
+function writeRuntimeSession(runtimeDir: string, lines: Array<Record<string, unknown> | string>): string {
+  const chatsDir = path.join(runtimeDir, 'projects', sanitizeCwd(TEST_CWD), 'chats');
+  const sessionPath = path.join(chatsDir, `${SESSION_ID}.jsonl`);
+  writeJsonl(sessionPath, lines);
+  return sessionPath;
+}
+
+function sessionFor(originalPath: string): UnifiedSession {
+  return {
+    id: SESSION_ID,
+    source: 'qwen-code',
+    cwd: TEST_CWD,
+    repo: 'acme/widget',
+    branch: 'main',
+    lines: 0,
+    bytes: fs.statSync(originalPath).size,
+    createdAt: new Date('2026-01-15T10:00:00.000Z'),
+    updatedAt: new Date('2026-01-15T10:10:00.000Z'),
+    originalPath,
+    summary: 'Qwen parser test',
+    model: 'qwen3-coder-plus',
+  };
+}
+
+afterEach(() => {
+  if (originalQwenRuntimeDir === undefined) {
+    delete process.env.QWEN_RUNTIME_DIR;
+  } else {
+    process.env.QWEN_RUNTIME_DIR = originalQwenRuntimeDir;
+  }
+
+  if (originalQwenHome === undefined) {
+    delete process.env.QWEN_HOME;
+  } else {
+    process.env.QWEN_HOME = originalQwenHome;
+  }
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('qwen-code parser', () => {
+  it('parses session metadata from Qwen runtime projects/chats JSONL and skips malformed lines', async () => {
+    const runtimeDir = makeTempDir();
+    process.env.QWEN_RUNTIME_DIR = runtimeDir;
+    delete process.env.QWEN_HOME;
+
+    const sessionPath = writeRuntimeSession(runtimeDir, [
+      qwenRecord({
+        uuid: 'u1',
+        timestamp: '2026-01-15T10:00:01.000Z',
+        type: 'user',
+        gitBranch: 'feature/qwen-hardening',
+        message: { role: 'user', parts: [{ text: 'Harden the Qwen Code parser against malformed JSONL.' }] },
+      }),
+      '{"uuid":',
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:00:05.000Z',
+        type: 'assistant',
+        model: 'qwen3-coder-plus',
+        message: { role: 'model', parts: [{ text: 'I will inspect the stored chat records.' }] },
+        usageMetadata: {
+          promptTokenCount: 120,
+          candidatesTokenCount: 80,
+          cachedContentTokenCount: 20,
+          thoughtsTokenCount: 15,
+        },
+      }),
+    ]);
+
+    const sessions = await parseQwenCodeSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: SESSION_ID,
+      source: 'qwen-code',
+      cwd: TEST_CWD,
+      repo: 'acme/widget',
+      branch: 'feature/qwen-hardening',
+      lines: 3,
+      bytes: fs.statSync(sessionPath).size,
+      summary: 'Harden the Qwen Code parser against malformed JSON',
+      model: 'qwen3-coder-plus',
+    });
+    expect(sessions[0]?.createdAt.toISOString()).toBe('2026-01-15T10:00:01.000Z');
+    expect(sessions[0]?.updatedAt.toISOString()).toBe('2026-01-15T10:00:05.000Z');
+  });
+
+  it('prefers QWEN_RUNTIME_DIR over QWEN_HOME and keeps QWEN_HOME as a legacy fallback', async () => {
+    const runtimeDir = makeTempDir();
+    const legacyHome = makeTempDir();
+    process.env.QWEN_RUNTIME_DIR = runtimeDir;
+    process.env.QWEN_HOME = legacyHome;
+
+    writeRuntimeSession(runtimeDir, [
+      qwenRecord({
+        uuid: 'runtime-user',
+        message: { role: 'user', parts: [{ text: 'Runtime dir session should win.' }] },
+      }),
+    ]);
+    writeRuntimeSession(path.join(legacyHome, '.qwen'), [
+      qwenRecord({
+        uuid: 'legacy-user',
+        sessionId: 'legacy-session',
+        message: { role: 'user', parts: [{ text: 'Legacy fallback session.' }] },
+      }),
+    ]);
+
+    const runtimeSessions = await parseQwenCodeSessions();
+
+    expect(runtimeSessions).toHaveLength(1);
+    expect(runtimeSessions[0]?.id).toBe(SESSION_ID);
+    expect(runtimeSessions[0]?.summary).toBe('Runtime dir session should win.');
+
+    delete process.env.QWEN_RUNTIME_DIR;
+
+    const legacySessions = await parseQwenCodeSessions();
+
+    expect(legacySessions).toHaveLength(1);
+    expect(legacySessions[0]?.id).toBe('legacy-session');
+    expect(legacySessions[0]?.summary).toBe('Legacy fallback session.');
+  });
+
+  it('recovers glued JSONL records on one physical line while skipping malformed fragments', async () => {
+    const runtimeDir = makeTempDir();
+    process.env.QWEN_RUNTIME_DIR = runtimeDir;
+    delete process.env.QWEN_HOME;
+
+    const userRecord = qwenRecord({
+      uuid: 'u-glued',
+      timestamp: '2026-01-15T10:00:00.000Z',
+      message: { role: 'user', parts: [{ text: 'Recover glued Qwen JSONL records.' }] },
+    });
+    const assistantRecord = qwenRecord({
+      uuid: 'a-glued',
+      parentUuid: 'u-glued',
+      timestamp: '2026-01-15T10:01:00.000Z',
+      type: 'assistant',
+      model: 'qwen3-coder-plus',
+      message: { role: 'model', parts: [{ text: 'Recovered the glued record.' }] },
+    });
+    const sessionPath = writeRuntimeSession(runtimeDir, [
+      `${JSON.stringify(userRecord)}${JSON.stringify(assistantRecord)}`,
+      '{"uuid":',
+    ]);
+
+    const sessions = await parseQwenCodeSessions();
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      lines: 2,
+      summary: 'Recover glued Qwen JSONL records.',
+      model: 'qwen3-coder-plus',
+    });
+    expect(sessions[0]?.updatedAt.toISOString()).toBe('2026-01-15T10:01:00.000Z');
+    expect(context.recentMessages.map((message) => message.content)).toEqual([
+      'Recover glued Qwen JSONL records.',
+      'Recovered the glued record.',
+    ]);
+  });
+
+  it('uses append-order main path instead of a newer abandoned branch', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        timestamp: '2026-01-15T10:00:00.000Z',
+        message: { role: 'user', parts: [{ text: 'Start the parser hardening.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: { role: 'model', parts: [{ text: 'I found the Qwen storage code.' }] },
+      }),
+      qwenRecord({
+        uuid: 'u-stale',
+        parentUuid: 'a1',
+        timestamp: '2026-01-15T10:20:00.000Z',
+        message: { role: 'user', parts: [{ text: 'This abandoned branch should not win.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a-stale',
+        parentUuid: 'u-stale',
+        timestamp: '2026-01-15T10:21:00.000Z',
+        type: 'assistant',
+        message: { role: 'model', parts: [{ text: 'Stale branch response.' }] },
+      }),
+      qwenRecord({
+        uuid: 'u-active',
+        parentUuid: 'a1',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        message: { role: 'user', parts: [{ text: 'Continue on the active branch.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a-active',
+        parentUuid: 'u-active',
+        timestamp: '2026-01-15T10:03:00.000Z',
+        type: 'assistant',
+        message: { role: 'model', parts: [{ text: 'Active branch response.' }] },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+
+    expect(context.recentMessages.map((message) => message.content)).toEqual([
+      'Start the parser hardening.',
+      'I found the Qwen storage code.',
+      'Continue on the active branch.',
+      'Active branch response.',
+    ]);
+  });
+
+  it('falls back to append order when parent links are broken', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Keep this earlier user turn.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: { role: 'model', parts: [{ text: 'Keep this earlier assistant turn.' }] },
+      }),
+      qwenRecord({
+        uuid: 'u2',
+        parentUuid: 'missing-parent',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        message: { role: 'user', parts: [{ text: 'The latest parent link is broken.' }] },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+
+    expect(context.recentMessages.map((message) => message.content)).toEqual([
+      'Keep this earlier user turn.',
+      'Keep this earlier assistant turn.',
+      'The latest parent link is broken.',
+    ]);
+  });
+
+  it('aggregates duplicate UUID records without losing appended message parts', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Inspect duplicate UUID records.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: { role: 'model', parts: [{ text: 'First assistant fragment.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [
+            { text: 'Need to keep the appended duplicate fragment.', thought: true },
+            { text: 'Second fragment.' },
+          ],
+        },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+
+    expect(context.recentMessages.map((message) => message.content)).toEqual([
+      'Inspect duplicate UUID records.',
+      'First assistant fragment.\nSecond fragment.',
+    ]);
+    expect(context.pendingTasks).toEqual(['Need to keep the appended duplicate fragment.']);
+  });
+
+  it('combines assistant functionCall parts with separate tool_result functionResponse output', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Run the targeted tests.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'Bash', args: { command: 'pnpm vitest qwen-code-parser.test.ts' } } }],
+        },
+      }),
+      qwenRecord({
+        uuid: 't1',
+        parentUuid: 'a1',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        type: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'Bash',
+                response: { output: 'all qwen parser tests passed', status: 'ok' },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+    const bashSummary = context.toolSummaries.find((summary) => summary.name === 'Bash');
+
+    expect(bashSummary?.count).toBe(1);
+    expect(bashSummary?.samples[0]?.summary).toContain('$ pnpm vitest qwen-code-parser.test.ts');
+    expect(bashSummary?.samples[0]?.summary).toContain('all qwen parser tests passed');
+  });
+
+  it('matches duplicate same-tool results by callId instead of tool name', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Run two shell calls with separate outputs.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [
+            { functionCall: { id: 'call-first', name: 'Bash', args: { command: 'echo first' } } },
+            { functionCall: { id: 'call-second', name: 'Bash', args: { command: 'echo second' } } },
+          ],
+        },
+      }),
+      qwenRecord({
+        uuid: 't1',
+        parentUuid: 'a1',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        type: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                callId: 'call-second',
+                name: 'Bash',
+                response: { output: 'second output', status: 'ok' },
+              },
+            },
+            {
+              functionResponse: {
+                callId: 'call-first',
+                name: 'Bash',
+                response: { output: 'first output', status: 'ok' },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+    const bashSummary = context.toolSummaries.find((summary) => summary.name === 'Bash');
+
+    expect(bashSummary?.count).toBe(2);
+    expect(bashSummary?.samples[0]?.summary).toContain('$ echo first');
+    expect(bashSummary?.samples[0]?.summary).toContain('first output');
+    expect(bashSummary?.samples[0]?.summary).not.toContain('second output');
+    expect(bashSummary?.samples[1]?.summary).toContain('$ echo second');
+    expect(bashSummary?.samples[1]?.summary).toContain('second output');
+  });
+
+  it('uses confirmed tool_result file diffs for edits and new files without double-counting inline calls', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Apply the requested file edits.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a-edit',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'Edit', args: { file_path: '/workspaces/acme/widget/src/app.ts' } } }],
+        },
+      }),
+      qwenRecord({
+        uuid: 't-edit',
+        parentUuid: 'a-edit',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        type: 'tool_result',
+        toolCallResult: {
+          displayName: 'Edit',
+          status: 'success',
+          resultDisplay: {
+            fileName: 'app.ts',
+            fileDiff: '--- app.ts\n+++ app.ts\n-old line\n+new line\n+another new line',
+            originalContent: 'old line',
+            newContent: 'new line\nanother new line',
+            diffStat: { model_added_lines: 2, model_removed_lines: 1 },
+          },
+        },
+      }),
+      qwenRecord({
+        uuid: 'a-write',
+        parentUuid: 't-edit',
+        timestamp: '2026-01-15T10:03:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'Write', args: { file_path: '/workspaces/acme/widget/src/new-file.ts' } } }],
+        },
+      }),
+      qwenRecord({
+        uuid: 't-write',
+        parentUuid: 'a-write',
+        timestamp: '2026-01-15T10:04:00.000Z',
+        type: 'tool_result',
+        toolCallResult: {
+          displayName: 'Write',
+          status: 'ok',
+          resultDisplay: {
+            fileName: 'new-file.ts',
+            fileDiff: '--- new-file.ts\n+++ new-file.ts\n+export const created = true;',
+            originalContent: null,
+            newContent: 'export const created = true;',
+            diffStat: { model_added_lines: 1, model_removed_lines: 0 },
+          },
+        },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+    const editSummary = context.toolSummaries.find((summary) => summary.name === 'Edit');
+    const writeSummary = context.toolSummaries.find((summary) => summary.name === 'Write');
+
+    expect(context.filesModified).toEqual([
+      '/workspaces/acme/widget/src/app.ts',
+      '/workspaces/acme/widget/src/new-file.ts',
+    ]);
+    expect(editSummary?.count).toBe(1);
+    expect(editSummary?.samples[0]?.summary).toContain('edit /workspaces/acme/widget/src/app.ts (+2 -1 lines)');
+    expect(editSummary?.samples[0]?.data).toMatchObject({
+      category: 'edit',
+      filePath: '/workspaces/acme/widget/src/app.ts',
+      diffStats: { added: 2, removed: 1 },
+    });
+    expect(writeSummary?.count).toBe(1);
+    expect(writeSummary?.samples[0]?.summary).toContain('write /workspaces/acme/widget/src/new-file.ts (new file)');
+    expect(writeSummary?.samples[0]?.data).toMatchObject({
+      category: 'write',
+      filePath: '/workspaces/acme/widget/src/new-file.ts',
+      isNewFile: true,
+      diffStats: { added: 1, removed: 0 },
+    });
+  });
+
+  it('generates context with assistant text, reasoning, pending tasks, and token notes', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Finish hardening the parser.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        model: 'qwen3-coder-plus',
+        message: {
+          role: 'model',
+          parts: [
+            { text: 'Need to add the remaining Qwen parser tests next.', thought: true },
+            { text: 'I have the parser changes ready.' },
+          ],
+        },
+        usageMetadata: {
+          promptTokenCount: 100,
+          candidatesTokenCount: 40,
+          cachedContentTokenCount: 25,
+          thoughtsTokenCount: 12,
+        },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+
+    expect(context.recentMessages).toEqual([
+      {
+        role: 'user',
+        content: 'Finish hardening the parser.',
+        timestamp: new Date('2026-01-15T10:00:00.000Z'),
+      },
+      {
+        role: 'assistant',
+        content: 'I have the parser changes ready.',
+        timestamp: new Date('2026-01-15T10:01:00.000Z'),
+      },
+    ]);
+    expect(context.pendingTasks).toEqual(['Need to add the remaining Qwen parser tests next.']);
+    expect(context.sessionNotes).toMatchObject({
+      model: 'qwen3-coder-plus',
+      reasoning: ['Need to add the remaining Qwen parser tests next.'],
+      tokenUsage: { input: 100, output: 40 },
+      cacheTokens: { creation: 0, read: 25 },
+      thinkingTokens: 12,
+    });
+    expect(context.session.model).toBe('qwen3-coder-plus');
+    expect(context.markdown).toContain('Qwen Code');
+    expect(context.markdown).toContain('I have the parser changes ready.');
+  });
+});

--- a/src/__tests__/qwen-code-parser.test.ts
+++ b/src/__tests__/qwen-code-parser.test.ts
@@ -527,6 +527,64 @@ describe('qwen-code parser', () => {
     });
   });
 
+  it('preserves callId-matched file diffs when tool_result displayName is absent', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Patch the app entrypoint.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a-edit',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-edit-app',
+                name: 'Edit',
+                args: { file_path: '/workspaces/acme/widget/src/app.ts' },
+              },
+            },
+          ],
+        },
+      }),
+      qwenRecord({
+        uuid: 't-edit',
+        parentUuid: 'a-edit',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        type: 'tool_result',
+        toolCallResult: {
+          callId: 'call-edit-app',
+          status: 'success',
+          resultDisplay: {
+            fileName: 'app.ts',
+            fileDiff: '--- app.ts\n+++ app.ts\n-console.log("old");\n+console.log("new");',
+            originalContent: 'console.log("old");',
+            newContent: 'console.log("new");',
+            diffStat: { model_added_lines: 1, model_removed_lines: 1 },
+          },
+        },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+    const editSummary = context.toolSummaries.find((summary) => summary.name === 'Edit');
+
+    expect(context.filesModified).toEqual(['/workspaces/acme/widget/src/app.ts']);
+    expect(editSummary?.count).toBe(1);
+    expect(editSummary?.samples[0]?.summary).toContain('edit /workspaces/acme/widget/src/app.ts (+1 -1 lines)');
+    expect(editSummary?.samples[0]?.data).toMatchObject({
+      category: 'edit',
+      filePath: '/workspaces/acme/widget/src/app.ts',
+      diffStats: { added: 1, removed: 1 },
+    });
+  });
+
   it('generates context with assistant text, reasoning, pending tasks, and token notes', async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);

--- a/src/__tests__/qwen-code-parser.test.ts
+++ b/src/__tests__/qwen-code-parser.test.ts
@@ -209,6 +209,114 @@ describe('qwen-code parser', () => {
     ]);
   });
 
+  it('recovers a valid JSON object that follows a malformed fragment on the same line', async () => {
+    const runtimeDir = makeTempDir();
+    process.env.QWEN_RUNTIME_DIR = runtimeDir;
+    delete process.env.QWEN_HOME;
+
+    const validRecord = qwenRecord({
+      uuid: 'u-recovered',
+      timestamp: '2026-01-15T10:05:00.000Z',
+      message: { role: 'user', parts: [{ text: 'Recover after a leading malformed fragment.' }] },
+    });
+
+    // The first object opens a string that never closes ("garbage), so depth
+    // never returns to zero. The recovery scan must skip past that opening
+    // brace and still find the trailing valid object on the same line.
+    writeRuntimeSession(runtimeDir, [`{"unterminated": "garbage${JSON.stringify(validRecord)}`]);
+
+    const sessions = await parseQwenCodeSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.summary).toBe('Recover after a leading malformed fragment.');
+  });
+
+  it('silently skips top-level arrays and scalars while keeping intervening objects', async () => {
+    const runtimeDir = makeTempDir();
+    process.env.QWEN_RUNTIME_DIR = runtimeDir;
+    delete process.env.QWEN_HOME;
+
+    const validRecord = qwenRecord({
+      uuid: 'u-around-garbage',
+      timestamp: '2026-01-15T10:06:00.000Z',
+      message: { role: 'user', parts: [{ text: 'Top-level garbage must not produce records.' }] },
+    });
+
+    writeRuntimeSession(runtimeDir, [`[1,2,3] "string" 42 ${JSON.stringify(validRecord)} null`]);
+
+    const sessions = await parseQwenCodeSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.summary).toBe('Top-level garbage must not produce records.');
+  });
+
+  it('preserves earlier function calls when an assistant uuid is appended in multiple fragments', async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Run two distinct shell calls across fragments.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a-frag',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [{ functionCall: { id: 'call-first', name: 'Bash', args: { command: 'echo first' } } }],
+        },
+      }),
+      qwenRecord({
+        uuid: 'a-frag',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [{ functionCall: { id: 'call-second', name: 'Bash', args: { command: 'echo second' } } }],
+        },
+      }),
+      qwenRecord({
+        uuid: 't1',
+        parentUuid: 'a-frag',
+        timestamp: '2026-01-15T10:03:00.000Z',
+        type: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                callId: 'call-first',
+                name: 'Bash',
+                response: { output: 'first output', status: 'ok' },
+              },
+            },
+            {
+              functionResponse: {
+                callId: 'call-second',
+                name: 'Bash',
+                response: { output: 'second output', status: 'ok' },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+    const bashSummary = context.toolSummaries.find((summary) => summary.name === 'Bash');
+
+    // Both function calls (one per fragment) must survive aggregation and
+    // reach `extractToolData`, so we expect two paired Bash summaries — not
+    // just the latest fragment's call.
+    expect(bashSummary?.count).toBe(2);
+    const summaries = (bashSummary?.samples ?? []).map((sample) => sample.summary);
+    expect(summaries.some((line) => line.includes('$ echo first') && line.includes('first output'))).toBe(true);
+    expect(summaries.some((line) => line.includes('$ echo second') && line.includes('second output'))).toBe(true);
+  });
+
   it('uses append-order main path instead of a newer abandoned branch', async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
@@ -640,5 +748,109 @@ describe('qwen-code parser', () => {
     expect(context.session.model).toBe('qwen3-coder-plus');
     expect(context.markdown).toContain('Qwen Code');
     expect(context.markdown).toContain('I have the parser changes ready.');
+  });
+
+  it('skips oversized JSONL records (16MB threshold) without dropping later valid records', async () => {
+    const runtimeDir = makeTempDir();
+    process.env.QWEN_RUNTIME_DIR = runtimeDir;
+    delete process.env.QWEN_HOME;
+
+    const goodRecord = qwenRecord({
+      uuid: 'u-good',
+      timestamp: '2026-01-15T10:00:00.000Z',
+      message: { role: 'user', parts: [{ text: 'Survive past the oversized line.' }] },
+    });
+    // Build a > 16 MiB single physical line. The shared scanner skips it via
+    // MAX_QWEN_JSONL_RECORD_CHARS (16 * 1024 * 1024) without buffering the
+    // full payload — protecting Node's readline buffer on tool-output-heavy
+    // sessions.
+    const oversizedPayload = 'x'.repeat(17 * 1024 * 1024);
+    const oversizedRecord = JSON.stringify(
+      qwenRecord({
+        uuid: 'u-oversized',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        message: { role: 'user', parts: [{ text: oversizedPayload }] },
+      }),
+    );
+    const trailingRecord = qwenRecord({
+      uuid: 'a-trailing',
+      parentUuid: 'u-good',
+      timestamp: '2026-01-15T10:02:00.000Z',
+      type: 'assistant',
+      message: { role: 'model', parts: [{ text: 'Trailing assistant turn survives.' }] },
+    });
+
+    const sessionPath = writeRuntimeSession(runtimeDir, [goodRecord, oversizedRecord, trailingRecord]);
+    expect(fs.statSync(sessionPath).size).toBeGreaterThan(16 * 1024 * 1024);
+
+    const sessions = await parseQwenCodeSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.summary).toBe('Survive past the oversized line.');
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+
+    // Trailing record after the skipped oversized line must still appear.
+    expect(context.recentMessages.map((message) => message.content)).toEqual([
+      'Survive past the oversized line.',
+      'Trailing assistant turn survives.',
+    ]);
+    // The oversized payload must NOT have been buffered (otherwise the skip
+    // is just a fiction): the parsed messages stay short.
+    for (const message of context.recentMessages) {
+      expect(message.content.length).toBeLessThan(1024);
+    }
+  });
+
+  it('omits ambiguous same-tool calls when both lack a callId rather than mispairing outputs', async () => {
+    // Two `Bash` calls in one assistant turn, no callIds, two function
+    // responses without callIds — the parser cannot prove which response
+    // belongs to which call. It must record the two calls (so the count is
+    // accurate) but decline to attach either ambiguous output to a specific
+    // call. Anything else is silently confident in a guess.
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, `${SESSION_ID}.jsonl`);
+    writeJsonl(sessionPath, [
+      qwenRecord({
+        uuid: 'u1',
+        message: { role: 'user', parts: [{ text: 'Run two bash calls without ids.' }] },
+      }),
+      qwenRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-15T10:01:00.000Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [
+            { functionCall: { name: 'Bash', args: { command: 'echo first' } } },
+            { functionCall: { name: 'Bash', args: { command: 'echo second' } } },
+          ],
+        },
+      }),
+      qwenRecord({
+        uuid: 't1',
+        parentUuid: 'a1',
+        timestamp: '2026-01-15T10:02:00.000Z',
+        type: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [
+            { functionResponse: { name: 'Bash', response: { output: 'ambiguous A', status: 'ok' } } },
+            { functionResponse: { name: 'Bash', response: { output: 'ambiguous B', status: 'ok' } } },
+          ],
+        },
+      }),
+    ]);
+
+    const context = await extractQwenCodeContext(sessionFor(sessionPath));
+    const bashSummary = context.toolSummaries.find((summary) => summary.name === 'Bash');
+
+    expect(bashSummary?.count).toBe(2);
+    // Neither sample may carry a specific output — that would imply a
+    // pairing the parser cannot defend.
+    for (const sample of bashSummary?.samples ?? []) {
+      expect(sample.summary).not.toContain('ambiguous A');
+      expect(sample.summary).not.toContain('ambiguous B');
+    }
   });
 });

--- a/src/parsers/qwen-code.ts
+++ b/src/parsers/qwen-code.ts
@@ -391,7 +391,7 @@ function collectParentFunctionCalls(records: QwenChatRecord[]): Map<string, Pare
 function findParentFunctionCall(
   callsByParent: Map<string, ParentFunctionCall[]>,
   record: QwenChatRecord,
-  displayName: string,
+  displayName: string | undefined,
 ): ParentFunctionCall | undefined {
   if (!record.parentUuid) return undefined;
   const calls = callsByParent.get(record.parentUuid);
@@ -402,6 +402,8 @@ function findParentFunctionCall(
     const byId = calls.find((call) => call.callId === resultCallId);
     if (byId) return byId;
   }
+
+  if (!displayName) return undefined;
 
   const byName = calls.filter((call) => call.name === displayName);
   if (byName.length === 1) return byName[0];
@@ -668,6 +670,11 @@ function findExternalToolResponse(
   return byParentName.length === 1 ? byParentName[0] : undefined;
 }
 
+function findToolResultResponse(responses: ToolResponses, record: QwenChatRecord): ToolResponseInfo | undefined {
+  const callId = getCallId(record.toolCallResult);
+  return callId ? responses.byCallId.get(callId) : undefined;
+}
+
 function hasConfirmedDiffForCall(
   refs: ConfirmedDiffRefs,
   parentUuid: string,
@@ -826,11 +833,15 @@ function extractToolData(
     // Extract confirmed file modifications from tool_result records.
     if (record.type === 'tool_result' && record.toolCallResult) {
       const tcr = record.toolCallResult;
-      const displayName = tcr.displayName || '';
       const isError = isToolResultError(tcr.status);
 
-      if (displayName && isFileDiff(tcr.resultDisplay)) {
-        const parentCall = findParentFunctionCall(callsByParent, record, displayName);
+      if (isFileDiff(tcr.resultDisplay)) {
+        const response = findToolResultResponse(responses, record);
+        const resultDisplayName = tcr.displayName || undefined;
+        const parentCall = findParentFunctionCall(callsByParent, record, resultDisplayName ?? response?.name);
+        const displayName = resultDisplayName ?? parentCall?.name ?? response?.name;
+        if (!displayName) continue;
+
         addFileDiffSummary(collector, displayName, tcr.resultDisplay, parentCall, isError);
       }
     }

--- a/src/parsers/qwen-code.ts
+++ b/src/parsers/qwen-code.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as readline from 'node:readline';
+import { StringDecoder } from 'node:string_decoder';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
@@ -15,16 +15,108 @@ import type { QwenChatRecord, QwenContent, QwenFileDiff, QwenPart } from '../typ
 import { QwenChatRecordSchema } from '../types/schemas.js';
 import { classifyToolName } from '../types/tool-names.js';
 import { listSubdirectories } from '../utils/fs-helpers.js';
+import { getFileStats } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
 import { fileSummary, mcpSummary, SummaryCollector, shellSummary, truncate } from '../utils/tool-summarizer.js';
 
-const qwenHome = process.env.QWEN_HOME || homeDir();
-// Qwen Code stores chats under ~/.qwen/projects/<sanitized-cwd>/chats/
-// sanitizeCwd replaces all non-alphanumeric chars with '-'
-const QWEN_PROJECTS_DIR = path.join(qwenHome, '.qwen', 'projects');
+// Qwen Code stores chats under <runtime-base>/projects/<sanitized-cwd>/chats/.
+// The official runtime base is QWEN_RUNTIME_DIR, falling back to ~/.qwen.
+// QWEN_HOME is kept as a legacy test/user override and points at a home dir.
+
+const MAX_QWEN_JSONL_RECORD_CHARS = 16 * 1024 * 1024;
+
+interface ToolResponseInfo {
+  name: string;
+  output?: string;
+  status?: string;
+  callId?: string;
+}
+
+interface ToolResponses {
+  byCallId: Map<string, ToolResponseInfo>;
+  byParentName: Map<string, ToolResponseInfo[]>;
+}
+
+interface ParentFunctionCall {
+  name: string;
+  args?: Record<string, unknown>;
+  category?: ReturnType<typeof classifyToolName>;
+  filePath?: string;
+  callId?: string;
+}
+
+interface ConfirmedDiffRefs {
+  byCallId: Set<string>;
+  byParentName: Set<string>;
+}
+
+interface QwenSessionMeta {
+  sessionId: string;
+  cwd: string;
+  gitBranch?: string;
+  summary?: string;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  model?: string;
+  lineCount: number;
+  bytes: number;
+}
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+function resolveConfiguredDir(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value === '~') return homeDir();
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return path.join(homeDir(), value.slice(2));
+  }
+  return path.isAbsolute(value) ? value : path.resolve(value);
+}
+
+function getQwenRuntimeBaseDir(): string {
+  const runtimeDir = resolveConfiguredDir(process.env.QWEN_RUNTIME_DIR);
+  if (runtimeDir) return runtimeDir;
+
+  const qwenHome = resolveConfiguredDir(process.env.QWEN_HOME);
+  if (qwenHome) {
+    return path.basename(qwenHome) === '.qwen' ? qwenHome : path.join(qwenHome, '.qwen');
+  }
+
+  return path.join(homeDir(), '.qwen');
+}
+
+function getQwenProjectsDir(): string {
+  return path.join(getQwenRuntimeBaseDir(), 'projects');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getStringField(value: unknown, field: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const fieldValue = value[field];
+  return typeof fieldValue === 'string' ? fieldValue : undefined;
+}
+
+function getBooleanField(value: unknown, field: string): boolean | undefined {
+  if (!isRecord(value)) return undefined;
+  const fieldValue = value[field];
+  return typeof fieldValue === 'boolean' ? fieldValue : undefined;
+}
+
+function stringifyValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch (err) {
+    logger.debug('qwen-code: failed to stringify JSON value', err);
+    return undefined;
+  }
+}
 
 /** Type guard: is resultDisplay a FileDiff object (not a string or todo)? */
 function isFileDiff(rd: unknown): rd is QwenFileDiff {
@@ -33,30 +125,290 @@ function isFileDiff(rd: unknown): rd is QwenFileDiff {
 }
 
 /** Parse a timestamp string defensively, falling back to a given Date */
-function parseTimestamp(ts: string, fallback: Date): Date {
+function parseTimestamp(ts: string | undefined, fallback: Date): Date {
   if (!ts) return fallback;
   const d = new Date(ts);
   return Number.isNaN(d.getTime()) ? fallback : d;
 }
 
+function parseQwenChatRecord(parsed: unknown, filePath: string, lineIndex: number): QwenChatRecord | undefined {
+  const result = QwenChatRecordSchema.safeParse(parsed);
+  if (result.success) return result.data;
+  logger.debug('qwen-code: skipping invalid record at index', lineIndex, 'in', filePath);
+  return undefined;
+}
+
+function getToolFilePath(args: Record<string, unknown> | undefined): string | undefined {
+  return getStringField(args, 'file_path') ?? getStringField(args, 'path') ?? getStringField(args, 'filePath');
+}
+
+function getCallId(value: unknown): string | undefined {
+  return (
+    getStringField(value, 'id') ??
+    getStringField(value, 'callId') ??
+    getStringField(value, 'call_id') ??
+    getStringField(value, 'toolCallId')
+  );
+}
+
+function responseKey(parentUuid: string, name: string): string {
+  return `${parentUuid}\u0000${name}`;
+}
+
+function isToolResultError(status: string | undefined): boolean {
+  return status ? !['ok', 'success', 'completed'].includes(status.toLowerCase()) : false;
+}
+
 // ── JSONL reading ───────────────────────────────────────────────────────────
 
-async function readJsonlRecords(filePath: string): Promise<QwenChatRecord[]> {
-  const records: QwenChatRecord[] = [];
-  const input = fs.createReadStream(filePath, 'utf8');
-  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+function splitJsonObjects(text: string): string[] {
+  const objects: string[] = [];
+  let start: number | undefined;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
 
-  for await (const line of rl) {
-    if (!line.trim()) continue;
-    try {
-      const parsed = QwenChatRecordSchema.safeParse(JSON.parse(line));
-      if (parsed.success) records.push(parsed.data);
-    } catch {
-      logger.debug('qwen-code: skipping malformed JSONL line in', filePath);
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index];
+
+    if (start === undefined) {
+      if (/\s/.test(char)) continue;
+      if (char !== '{') continue;
+      start = index;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === '{') {
+      depth++;
+      continue;
+    }
+
+    if (char === '}') {
+      depth--;
+      if (depth === 0 && start !== undefined) {
+        objects.push(text.slice(start, index + 1));
+        start = undefined;
+      }
     }
   }
 
+  return objects;
+}
+
+async function scanQwenJsonlFile(
+  filePath: string,
+  visitor: (parsed: unknown, lineIndex: number) => 'continue' | 'stop',
+): Promise<void> {
+  if (!fs.existsSync(filePath)) return;
+
+  const decoder = new StringDecoder('utf8');
+  const stream = fs.createReadStream(filePath);
+  let lineBuffer = '';
+  let lineIndex = 0;
+  let skippingOversizedLine = false;
+  let stopped = false;
+
+  const finishLine = (): 'continue' | 'stop' => {
+    const line = lineBuffer.endsWith('\r') ? lineBuffer.slice(0, -1) : lineBuffer;
+    lineBuffer = '';
+
+    if (skippingOversizedLine) {
+      logger.debug('qwen-code: skipping oversized JSONL line at index', lineIndex, 'in', filePath);
+      skippingOversizedLine = false;
+      lineIndex++;
+      return 'continue';
+    }
+
+    const chunks = splitJsonObjects(line);
+    if (chunks.length === 0 && line.trim()) {
+      logger.debug('qwen-code: skipping malformed JSONL line at index', lineIndex, 'in', filePath);
+    }
+
+    for (const chunk of chunks) {
+      try {
+        if (visitor(JSON.parse(chunk), lineIndex) === 'stop') {
+          lineIndex++;
+          return 'stop';
+        }
+      } catch (err) {
+        logger.debug('qwen-code: skipping invalid JSON object at index', lineIndex, 'in', filePath, err);
+      }
+    }
+
+    lineIndex++;
+    return 'continue';
+  };
+
+  const consumeText = (text: string): 'continue' | 'stop' => {
+    let start = 0;
+
+    while (start < text.length) {
+      const newlineIndex = text.indexOf('\n', start);
+      const segmentEnd = newlineIndex === -1 ? text.length : newlineIndex;
+      const segment = text.slice(start, segmentEnd);
+
+      if (!skippingOversizedLine) {
+        if (lineBuffer.length + segment.length > MAX_QWEN_JSONL_RECORD_CHARS) {
+          skippingOversizedLine = true;
+          lineBuffer = '';
+        } else {
+          lineBuffer += segment;
+        }
+      }
+
+      if (newlineIndex === -1) break;
+      if (finishLine() === 'stop') return 'stop';
+      start = newlineIndex + 1;
+    }
+
+    return 'continue';
+  };
+
+  try {
+    for await (const chunk of stream) {
+      if (consumeText(decoder.write(chunk as Buffer)) === 'stop') {
+        stopped = true;
+        stream.destroy();
+        break;
+      }
+    }
+
+    if (!stopped) {
+      const remaining = decoder.end();
+      if (remaining && consumeText(remaining) === 'stop') {
+        stopped = true;
+      }
+
+      if (!stopped && (lineBuffer.length > 0 || skippingOversizedLine)) {
+        finishLine();
+      }
+    }
+  } catch (err) {
+    logger.debug('qwen-code: failed to stream JSONL file', filePath, err);
+  }
+}
+
+async function readJsonlRecords(filePath: string): Promise<QwenChatRecord[]> {
+  const records: QwenChatRecord[] = [];
+  await scanQwenJsonlFile(filePath, (parsed, lineIndex) => {
+    const record = parseQwenChatRecord(parsed, filePath, lineIndex);
+    if (record) records.push(record);
+    return 'continue';
+  });
   return records;
+}
+
+function extractCustomTitle(record: QwenChatRecord): string | undefined {
+  if (record.type !== 'system' || record.subtype !== 'custom_title') return undefined;
+  return getStringField(isRecord(record) ? record.systemPayload : undefined, 'customTitle');
+}
+
+function extractFunctionResponseOutput(part: QwenPart): string | undefined {
+  const response = part.functionResponse?.response;
+  return (
+    getStringField(response, 'output') ??
+    stringifyValue(isRecord(response) ? response.result : undefined) ??
+    stringifyValue(isRecord(response) ? response.content : undefined)
+  );
+}
+
+function extractFunctionResponseStatus(part: QwenPart): string | undefined {
+  return getStringField(part.functionResponse?.response, 'status');
+}
+
+function getFunctionResponseCallId(part: QwenPart): string | undefined {
+  return getCallId(part.functionResponse) ?? getCallId(part.functionResponse?.response);
+}
+
+function collectToolResponses(records: QwenChatRecord[]): ToolResponses {
+  const byCallId = new Map<string, ToolResponseInfo>();
+  const byParentName = new Map<string, ToolResponseInfo[]>();
+
+  for (const record of records) {
+    if (record.type !== 'tool_result' || !record.parentUuid || !record.message?.parts) continue;
+
+    for (const part of record.message.parts) {
+      const name = part.functionResponse?.name;
+      if (!name) continue;
+      const response: ToolResponseInfo = {
+        name,
+        output: extractFunctionResponseOutput(part),
+        status: extractFunctionResponseStatus(part),
+        callId: getFunctionResponseCallId(part) ?? getCallId(record.toolCallResult),
+      };
+      if (response.callId) byCallId.set(response.callId, response);
+
+      const key = responseKey(record.parentUuid, name);
+      const responsesForParent = byParentName.get(key) ?? [];
+      responsesForParent.push(response);
+      byParentName.set(key, responsesForParent);
+    }
+  }
+
+  return { byCallId, byParentName };
+}
+
+function collectParentFunctionCalls(records: QwenChatRecord[]): Map<string, ParentFunctionCall[]> {
+  const callsByParent = new Map<string, ParentFunctionCall[]>();
+
+  for (const record of records) {
+    if (record.type !== 'assistant' || !record.message?.parts) continue;
+
+    const calls: ParentFunctionCall[] = [];
+    for (const part of record.message.parts) {
+      if (!part.functionCall) continue;
+      const { name, args } = part.functionCall;
+      calls.push({
+        name,
+        args,
+        category: classifyToolName(name),
+        filePath: getToolFilePath(args),
+        callId: getCallId(part.functionCall),
+      });
+    }
+
+    if (calls.length > 0) callsByParent.set(record.uuid, calls);
+  }
+
+  return callsByParent;
+}
+
+function findParentFunctionCall(
+  callsByParent: Map<string, ParentFunctionCall[]>,
+  record: QwenChatRecord,
+  displayName: string,
+): ParentFunctionCall | undefined {
+  if (!record.parentUuid) return undefined;
+  const calls = callsByParent.get(record.parentUuid);
+  if (!calls || calls.length === 0) return undefined;
+
+  const resultCallId = getCallId(record.toolCallResult);
+  if (resultCallId) {
+    const byId = calls.find((call) => call.callId === resultCallId);
+    if (byId) return byId;
+  }
+
+  const byName = calls.filter((call) => call.name === displayName);
+  if (byName.length === 1) return byName[0];
+
+  const displayCategory = classifyToolName(displayName);
+  const byCategory = calls.filter((call) => call.category === displayCategory);
+  return byCategory.length === 1 ? byCategory[0] : undefined;
 }
 
 // ── Text extraction ─────────────────────────────────────────────────────────
@@ -85,10 +437,11 @@ function extractContentText(content: QwenContent | undefined): string {
 
 async function findSessionFiles(): Promise<string[]> {
   const results: string[] = [];
+  const qwenProjectsDir = getQwenProjectsDir();
 
-  if (!fs.existsSync(QWEN_PROJECTS_DIR)) return results;
+  if (!fs.existsSync(qwenProjectsDir)) return results;
 
-  for (const projectDir of listSubdirectories(QWEN_PROJECTS_DIR)) {
+  for (const projectDir of listSubdirectories(qwenProjectsDir)) {
     const chatsDir = path.join(projectDir, 'chats');
     if (!fs.existsSync(chatsDir)) continue;
 
@@ -109,95 +462,268 @@ async function findSessionFiles(): Promise<string[]> {
 
 // ── Session metadata extraction ─────────────────────────────────────────────
 
-async function extractSessionMeta(filePath: string): Promise<{
-  sessionId: string;
-  cwd: string;
-  gitBranch?: string;
-  firstUserMessage: string;
-  firstTimestamp: string;
-  lastTimestamp: string;
-  model?: string;
-  lineCount: number;
-} | null> {
-  const input = fs.createReadStream(filePath, 'utf8');
-  const rl = readline.createInterface({ input, crlfDelay: Infinity });
-
+async function extractSessionMeta(filePath: string): Promise<QwenSessionMeta | null> {
+  const fileStats = await getFileStats(filePath);
   let sessionId = '';
   let cwd = '';
   let gitBranch: string | undefined;
   let firstUserMessage = '';
-  let firstTimestamp = '';
-  let lastTimestamp = '';
+  let customTitle: string | undefined;
+  let firstTimestamp: string | undefined;
+  let lastTimestamp: string | undefined;
   let model: string | undefined;
-  let lineCount = 0;
 
-  for await (const line of rl) {
-    if (!line.trim()) continue;
-    lineCount++;
+  await scanQwenJsonlFile(filePath, (parsed, lineIndex) => {
+    const record = parseQwenChatRecord(parsed, filePath, lineIndex);
+    if (!record) return 'continue';
 
-    try {
-      const parsed = QwenChatRecordSchema.safeParse(JSON.parse(line));
-      if (!parsed.success) continue;
-      const record = parsed.data;
+    if (!sessionId && record.sessionId) sessionId = record.sessionId;
+    if (!cwd && record.cwd) cwd = record.cwd;
+    if (!gitBranch && record.gitBranch) gitBranch = record.gitBranch;
+    if (!model && record.model) model = record.model;
 
-      if (!sessionId && record.sessionId) sessionId = record.sessionId;
-      if (!cwd && record.cwd) cwd = record.cwd;
-      if (!gitBranch && record.gitBranch) gitBranch = record.gitBranch;
-      if (!model && record.model) model = record.model;
+    if (!firstTimestamp && record.timestamp) firstTimestamp = record.timestamp;
+    if (record.timestamp) lastTimestamp = record.timestamp;
 
-      if (!firstTimestamp && record.timestamp) firstTimestamp = record.timestamp;
-      if (record.timestamp) lastTimestamp = record.timestamp;
-
-      if (!firstUserMessage && record.type === 'user') {
-        firstUserMessage = extractContentText(record.message);
-      }
-    } catch {
-      // skip malformed line
+    if (record.type === 'user' && !firstUserMessage) {
+      firstUserMessage = extractContentText(record.message);
     }
-  }
+
+    const title = extractCustomTitle(record);
+    if (title) customTitle = title;
+
+    return 'continue';
+  });
 
   if (!sessionId) return null;
 
-  return { sessionId, cwd, gitBranch, firstUserMessage, firstTimestamp, lastTimestamp, model, lineCount };
+  return {
+    sessionId,
+    cwd,
+    gitBranch,
+    summary: customTitle ?? firstUserMessage,
+    firstTimestamp,
+    lastTimestamp,
+    model,
+    lineCount: fileStats.lines,
+    bytes: fileStats.bytes,
+  };
 }
 
 // ── Tool data extraction ────────────────────────────────────────────────────
+
+function collectConfirmedDiffRefs(records: QwenChatRecord[]): ConfirmedDiffRefs {
+  const refs: ConfirmedDiffRefs = { byCallId: new Set(), byParentName: new Set() };
+
+  for (const record of records) {
+    if (record.type !== 'tool_result' || !record.parentUuid || !record.toolCallResult) continue;
+    const status = record.toolCallResult.status;
+    if (isToolResultError(status)) continue;
+    if (!isFileDiff(record.toolCallResult.resultDisplay)) continue;
+
+    const callId = getCallId(record.toolCallResult);
+    if (callId) refs.byCallId.add(callId);
+
+    const displayName = record.toolCallResult.displayName;
+    if (displayName) {
+      refs.byParentName.add(responseKey(record.parentUuid, displayName));
+      const category = classifyToolName(displayName);
+      if (category) refs.byParentName.add(responseKey(record.parentUuid, category));
+    }
+  }
+
+  return refs;
+}
+
+function extractDiffStat(rd: QwenFileDiff): { added: number; removed: number } | undefined {
+  if (rd.diffStat) {
+    return {
+      added: rd.diffStat.model_added_lines ?? 0,
+      removed: rd.diffStat.model_removed_lines ?? 0,
+    };
+  }
+
+  if (!rd.fileDiff) return undefined;
+
+  const lines = rd.fileDiff.split('\n');
+  return {
+    added: lines.filter((line) => line.startsWith('+') && !line.startsWith('+++')).length,
+    removed: lines.filter((line) => line.startsWith('-') && !line.startsWith('---')).length,
+  };
+}
+
+function getFileDiffPath(rd: QwenFileDiff, parentCall: ParentFunctionCall | undefined): string {
+  return getStringField(rd, 'filePath') ?? parentCall?.filePath ?? rd.fileName ?? '';
+}
+
+function getFileDiffOperation(
+  displayName: string,
+  rd: QwenFileDiff,
+  parentCall: ParentFunctionCall | undefined,
+): { operation: 'write' | 'edit'; isNewFile: boolean } {
+  const isNewFile =
+    rd.originalContent === null ||
+    ['create', 'new', 'new_file'].includes((getStringField(rd, 'type') ?? '').toLowerCase());
+  const category = classifyToolName(displayName) ?? parentCall?.category;
+  return { operation: isNewFile || category === 'write' ? 'write' : 'edit', isNewFile };
+}
+
+function addFileDiffSummary(
+  collector: SummaryCollector,
+  displayName: string,
+  rd: QwenFileDiff,
+  parentCall: ParentFunctionCall | undefined,
+  isError: boolean,
+): void {
+  const filePath = getFileDiffPath(rd, parentCall);
+  const diffStat = extractDiffStat(rd);
+  const { operation, isNewFile } = getFileDiffOperation(displayName, rd, parentCall);
+  const diff = rd.fileDiff || undefined;
+
+  if (operation === 'write') {
+    collector.add(displayName, fileSummary('write', filePath, diffStat, isNewFile), {
+      data: {
+        category: 'write',
+        filePath,
+        isNewFile,
+        ...(diff ? { diff } : {}),
+        ...(diffStat ? { diffStats: diffStat } : {}),
+      },
+      filePath,
+      isWrite: true,
+      isError,
+    });
+    return;
+  }
+
+  collector.add(displayName, fileSummary('edit', filePath, diffStat), {
+    data: {
+      category: 'edit',
+      filePath,
+      ...(diff ? { diff } : {}),
+      ...(diffStat ? { diffStats: diffStat } : {}),
+    },
+    filePath,
+    isWrite: true,
+    isError,
+  });
+}
+
+function countFunctionCallsByName(parts: QwenPart[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const part of parts) {
+    const name = part.functionCall?.name;
+    if (!name) continue;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function findInlineFunctionResponse(
+  parts: QwenPart[],
+  name: string,
+  callId: string | undefined,
+  hasDuplicateName: boolean,
+): ToolResponseInfo | undefined {
+  if (callId) {
+    for (const part of parts) {
+      if (!part.functionResponse || getFunctionResponseCallId(part) !== callId) continue;
+      return {
+        name: part.functionResponse.name,
+        output: extractFunctionResponseOutput(part),
+        status: extractFunctionResponseStatus(part),
+        callId,
+      };
+    }
+  }
+
+  if (hasDuplicateName) return undefined;
+
+  const responsePart = parts.find((part) => part.functionResponse?.name === name);
+  if (!responsePart?.functionResponse) return undefined;
+
+  return {
+    name,
+    output: extractFunctionResponseOutput(responsePart),
+    status: extractFunctionResponseStatus(responsePart),
+    callId: getFunctionResponseCallId(responsePart),
+  };
+}
+
+function findExternalToolResponse(
+  responses: ToolResponses,
+  parentUuid: string,
+  name: string,
+  callId: string | undefined,
+  hasDuplicateName: boolean,
+): ToolResponseInfo | undefined {
+  if (callId) {
+    const byCallId = responses.byCallId.get(callId);
+    if (byCallId) return byCallId;
+  }
+
+  if (hasDuplicateName) return undefined;
+
+  const byParentName = responses.byParentName.get(responseKey(parentUuid, name)) ?? [];
+  return byParentName.length === 1 ? byParentName[0] : undefined;
+}
+
+function hasConfirmedDiffForCall(
+  refs: ConfirmedDiffRefs,
+  parentUuid: string,
+  name: string,
+  category: ReturnType<typeof classifyToolName>,
+  callId: string | undefined,
+  hasDuplicateName: boolean,
+): boolean {
+  if (callId && refs.byCallId.has(callId)) return true;
+  if (hasDuplicateName) return false;
+  return (
+    refs.byParentName.has(responseKey(parentUuid, name)) ||
+    (!!category && refs.byParentName.has(responseKey(parentUuid, category)))
+  );
+}
 
 function extractToolData(
   records: QwenChatRecord[],
   config?: VerbosityConfig,
 ): { summaries: ToolUsageSummary[]; filesModified: string[] } {
   const collector = new SummaryCollector(config);
-  const processedCallUuids = new Set<string>();
+  const responses = collectToolResponses(records);
+  const callsByParent = collectParentFunctionCalls(records);
+  const confirmedDiffRefs = collectConfirmedDiffRefs(records);
 
   for (const record of records) {
     // Extract from functionCall parts in assistant messages
     if (record.type === 'assistant' && record.message?.parts) {
-      const hasFunctionCalls = record.message.parts.some((p: QwenPart) => p.functionCall);
-      if (hasFunctionCalls) processedCallUuids.add(record.uuid);
+      const callNameCounts = countFunctionCallsByName(record.message.parts);
+
       for (const part of record.message.parts) {
         if (!part.functionCall) continue;
         const { name, args } = part.functionCall;
         const category = classifyToolName(name);
         if (!category) continue;
+        const callId = getCallId(part.functionCall);
+        const hasDuplicateName = (callNameCounts.get(name) ?? 0) > 1;
 
-        const fp = (args?.file_path as string) || (args?.path as string) || '';
-
-        // Try to extract result from a matching functionResponse in the same parts array
-        let resultStr: string | undefined;
-        for (const rp of record.message.parts) {
-          if (rp.functionResponse?.name === name && rp.functionResponse.response?.output) {
-            resultStr = String(rp.functionResponse.response.output);
-            break;
-          }
+        if (
+          (category === 'write' || category === 'edit') &&
+          hasConfirmedDiffForCall(confirmedDiffRefs, record.uuid, name, category, callId, hasDuplicateName)
+        ) {
+          continue;
         }
-        const isResponseError = record.message.parts.some(
-          (rp: QwenPart) => rp.functionResponse?.name === name && rp.functionResponse.response?.status === 'error',
-        );
+
+        const fp = getToolFilePath(args) ?? '';
+
+        const inlineResponse = findInlineFunctionResponse(record.message.parts, name, callId, hasDuplicateName);
+        const externalResponse = findExternalToolResponse(responses, record.uuid, name, callId, hasDuplicateName);
+        const resultStr = inlineResponse?.output ?? externalResponse?.output;
+        const responseStatus = inlineResponse?.status ?? externalResponse?.status;
+        const isResponseError = isToolResultError(responseStatus);
 
         switch (category) {
           case 'shell': {
-            const cmd = (args?.command as string) || (args?.cmd as string) || '';
+            const cmd = getStringField(args, 'command') ?? getStringField(args, 'cmd') ?? '';
             collector.add(name, shellSummary(cmd, resultStr), {
               data: { category: 'shell', command: cmd, ...(resultStr ? { stdoutTail: resultStr.slice(-500) } : {}) },
               isError: isResponseError,
@@ -229,7 +755,7 @@ function extractToolData(
             });
             break;
           case 'grep': {
-            const pattern = (args?.pattern as string) || (args?.query as string) || '';
+            const pattern = getStringField(args, 'pattern') ?? getStringField(args, 'query') ?? '';
             collector.add(name, `grep "${truncate(pattern, 40)}"`, {
               data: { category: 'grep', pattern, ...(fp ? { targetPath: fp } : {}) },
               isError: isResponseError,
@@ -237,21 +763,23 @@ function extractToolData(
             break;
           }
           case 'glob': {
-            const pattern = (args?.pattern as string) || fp;
+            const pattern = getStringField(args, 'pattern') ?? fp;
             collector.add(name, `glob ${truncate(pattern, 50)}`, {
               data: { category: 'glob', pattern },
               isError: isResponseError,
             });
             break;
           }
-          case 'search':
-            collector.add(name, `search "${truncate((args?.query as string) || '', 50)}"`, {
-              data: { category: 'search', query: (args?.query as string) || '' },
+          case 'search': {
+            const query = getStringField(args, 'query') ?? '';
+            collector.add(name, `search "${truncate(query, 50)}"`, {
+              data: { category: 'search', query },
               isError: isResponseError,
             });
             break;
+          }
           case 'fetch': {
-            const url = (args?.url as string) || '';
+            const url = getStringField(args, 'url') ?? '';
             collector.add(name, `fetch ${truncate(url, 60)}`, {
               data: {
                 category: 'fetch',
@@ -263,8 +791,8 @@ function extractToolData(
             break;
           }
           case 'task': {
-            const desc = (args?.description as string) || (args?.prompt as string) || '';
-            const agentType = (args?.subagent_type as string) || undefined;
+            const desc = getStringField(args, 'description') ?? getStringField(args, 'prompt') ?? '';
+            const agentType = getStringField(args, 'subagent_type');
             collector.add(name, `task "${truncate(desc, 60)}"${agentType ? ` (${agentType})` : ''}`, {
               data: { category: 'task', description: desc, ...(agentType ? { agentType } : {}) },
               isError: isResponseError,
@@ -272,7 +800,7 @@ function extractToolData(
             break;
           }
           case 'ask': {
-            const question = truncate((args?.question as string) || (args?.prompt as string) || '', 80);
+            const question = truncate(getStringField(args, 'question') ?? getStringField(args, 'prompt') ?? '', 80);
             collector.add(name, `ask: "${question}"`, {
               data: { category: 'ask', question },
               isError: isResponseError,
@@ -295,47 +823,15 @@ function extractToolData(
       }
     }
 
-    // Extract from tool_result records (skip if parent already processed via functionCall)
+    // Extract confirmed file modifications from tool_result records.
     if (record.type === 'tool_result' && record.toolCallResult) {
-      if (record.parentUuid && processedCallUuids.has(record.parentUuid)) continue;
       const tcr = record.toolCallResult;
       const displayName = tcr.displayName || '';
-      const isError = tcr.status ? !['ok', 'success', 'completed'].includes(tcr.status.toLowerCase()) : false;
+      const isError = isToolResultError(tcr.status);
 
       if (displayName && isFileDiff(tcr.resultDisplay)) {
-        const rd = tcr.resultDisplay;
-        const fp = rd.fileName || '';
-
-        let diffStat: { added: number; removed: number } | undefined;
-        if (rd.diffStat) {
-          diffStat = {
-            added: rd.diffStat.model_added_lines || 0,
-            removed: rd.diffStat.model_removed_lines || 0,
-          };
-        } else if (rd.fileDiff) {
-          // Fallback: count +/- lines from fileDiff
-          const lines = rd.fileDiff.split('\n');
-          diffStat = {
-            added: lines.filter((l: string) => l.startsWith('+')).length,
-            removed: lines.filter((l: string) => l.startsWith('-')).length,
-          };
-        }
-
-        // isNewFile is determined by originalContent === null
-        const isNew = rd.originalContent === null;
-        const diff = rd.fileDiff || undefined;
-        collector.add(displayName, fileSummary(isNew ? 'write' : 'edit', fp, diffStat, isNew), {
-          data: {
-            category: isNew ? 'write' : 'edit',
-            filePath: fp,
-            isNewFile: isNew,
-            ...(diff ? { diff } : {}),
-            ...(diffStat ? { diffStats: diffStat } : {}),
-          },
-          filePath: fp,
-          isWrite: true,
-          isError,
-        });
+        const parentCall = findParentFunctionCall(callsByParent, record, displayName);
+        addFileDiffSummary(collector, displayName, tcr.resultDisplay, parentCall, isError);
       }
     }
   }
@@ -383,40 +879,79 @@ function extractSessionNotes(records: QwenChatRecord[]): SessionNotes {
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
-/** Reconstruct main conversation path by walking from latest leaf back via parentUuid */
+function aggregateRecordGroup(records: QwenChatRecord[]): QwenChatRecord {
+  const base: QwenChatRecord = { ...records[0] };
+
+  for (const record of records.slice(1)) {
+    if (record.message) {
+      base.message = {
+        role: base.message?.role ?? record.message.role,
+        parts: [...(base.message?.parts ?? []), ...(record.message.parts ?? [])],
+      };
+    }
+
+    if (record.usageMetadata) base.usageMetadata = record.usageMetadata;
+    if (record.toolCallResult && !base.toolCallResult) base.toolCallResult = record.toolCallResult;
+    if (record.model && !base.model) base.model = record.model;
+    if (record.timestamp > base.timestamp) base.timestamp = record.timestamp;
+  }
+
+  return base;
+}
+
+function aggregateRecordsByUuid(records: QwenChatRecord[]): QwenChatRecord[] {
+  const groups = new Map<string, QwenChatRecord[]>();
+  const order: string[] = [];
+
+  for (const record of records) {
+    if (!groups.has(record.uuid)) {
+      groups.set(record.uuid, []);
+      order.push(record.uuid);
+    }
+    groups.get(record.uuid)!.push(record);
+  }
+
+  return order.map((uuid) => aggregateRecordGroup(groups.get(uuid)!));
+}
+
+function getLastMainRecordUuid(records: QwenChatRecord[]): string | undefined {
+  for (let i = records.length - 1; i >= 0; i--) {
+    if (!getBooleanField(records[i], 'isSidechain')) return records[i].uuid;
+  }
+  return records.at(-1)?.uuid;
+}
+
+/** Reconstruct main conversation path by walking from the last appended record via parentUuid. */
 function reconstructMainPath(records: QwenChatRecord[]): QwenChatRecord[] {
   if (records.length === 0) return [];
 
-  const byUuid = new Map<string, QwenChatRecord>();
-  const parentUuids = new Set<string>();
+  const aggregated = aggregateRecordsByUuid(records);
+  const byUuid = new Map(aggregated.map((record) => [record.uuid, record]));
+  const startUuid = getLastMainRecordUuid(records);
+  if (!startUuid) return aggregated;
 
-  for (const r of records) {
-    byUuid.set(r.uuid, r);
-    if (r.parentUuid) parentUuids.add(r.parentUuid);
-  }
-
-  // Find the latest leaf (record with no children, latest timestamp)
-  let latestLeaf = records[records.length - 1];
-  let latestTime = 0;
-  for (const r of records) {
-    if (!parentUuids.has(r.uuid)) {
-      const t = new Date(r.timestamp).getTime();
-      if (!Number.isNaN(t) && t > latestTime) {
-        latestTime = t;
-        latestLeaf = r;
-      }
-    }
-  }
-
-  // Walk back from leaf to root via parentUuid
   const pathResult: QwenChatRecord[] = [];
-  let current: QwenChatRecord | undefined = latestLeaf;
+  const visited = new Set<string>();
+  let current = byUuid.get(startUuid);
+  let brokenChain = false;
+
   while (current) {
+    if (visited.has(current.uuid)) {
+      brokenChain = true;
+      break;
+    }
+    visited.add(current.uuid);
     pathResult.unshift(current);
-    current = current.parentUuid ? byUuid.get(current.parentUuid) : undefined;
+    if (!current.parentUuid) break;
+    const parent = byUuid.get(current.parentUuid);
+    if (!parent) {
+      brokenChain = true;
+      break;
+    }
+    current = parent;
   }
 
-  return pathResult;
+  return brokenChain || pathResult.length === 0 ? aggregated : pathResult;
 }
 
 export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
@@ -429,6 +964,7 @@ export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
       if (!meta) continue;
 
       const fileStats = fs.statSync(filePath);
+      const summary = cleanSummary(meta.summary ?? '') || undefined;
 
       sessions.push({
         id: meta.sessionId,
@@ -437,11 +973,11 @@ export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
         repo: extractRepoFromCwd(meta.cwd),
         branch: meta.gitBranch,
         lines: meta.lineCount,
-        bytes: fileStats.size,
+        bytes: meta.bytes,
         createdAt: parseTimestamp(meta.firstTimestamp, fileStats.mtime),
         updatedAt: parseTimestamp(meta.lastTimestamp, fileStats.mtime),
         originalPath: filePath,
-        summary: cleanSummary(meta.firstUserMessage) || undefined,
+        summary,
         model: meta.model,
       });
     } catch (err) {

--- a/src/parsers/qwen-code.ts
+++ b/src/parsers/qwen-code.ts
@@ -1,6 +1,5 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { StringDecoder } from 'node:string_decoder';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
@@ -15,14 +14,26 @@ import type { QwenChatRecord, QwenContent, QwenFileDiff, QwenPart } from '../typ
 import { QwenChatRecordSchema } from '../types/schemas.js';
 import { classifyToolName } from '../types/tool-names.js';
 import { listSubdirectories } from '../utils/fs-helpers.js';
-import { getFileStats } from '../utils/jsonl.js';
+import { scanJsonlLines } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
 import { fileSummary, mcpSummary, SummaryCollector, shellSummary, truncate } from '../utils/tool-summarizer.js';
 
-// Qwen Code stores chats under <runtime-base>/projects/<sanitized-cwd>/chats/.
-// The official runtime base is QWEN_RUNTIME_DIR, falling back to ~/.qwen.
-// QWEN_HOME is kept as a legacy test/user override and points at a home dir.
+// Qwen Code stores chats under <runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.jsonl.
+//
+// Runtime base resolution mirrors upstream Qwen Code
+// (packages/core/src/config/storage.ts: Storage.getRuntimeBaseDir):
+//   1. QWEN_RUNTIME_DIR env var (canonical Qwen override)
+//   2. ~/.qwen (Storage.getGlobalQwenDir fallback)
+// QWEN_HOME is a continues-side override (no upstream equivalent) for
+// fixtures and sandboxed installs that want to redirect lookups at a custom
+// home dir without touching real user data. We treat its value as a home dir
+// (joining `.qwen` when not already terminated by it).
+//
+// cwd sanitization mirrors upstream sanitizeCwd
+// (packages/core/src/utils/paths.ts:243): replace /[^a-zA-Z0-9]/g with `-`,
+// lowercased on Windows. Tests rely on the same scheme so fixture writes and
+// parser reads stay in lockstep.
 
 const MAX_QWEN_JSONL_RECORD_CHARS = 16 * 1024 * 1024;
 
@@ -61,6 +72,7 @@ interface QwenSessionMeta {
   model?: string;
   lineCount: number;
   bytes: number;
+  mtime: Date;
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -161,50 +173,90 @@ function isToolResultError(status: string | undefined): boolean {
 
 // ── JSONL reading ───────────────────────────────────────────────────────────
 
+/**
+ * Recover top-level JSON objects from a single physical JSONL line, even when
+ * Qwen Code has glued multiple records together (rare runtime races) or
+ * truncated one mid-write.
+ *
+ * **Scope: top-level objects only.** Upstream Qwen Code writes one
+ * `ChatRecord` object per line via `chatRecordingService.ts` (which calls
+ * `jsonl.writeLine`/`writeLineSync` with a single `ChatRecord`). It never
+ * writes top-level arrays, scalars, or non-object records. Anything that is
+ * not a `{ ... }` object — bare arrays, strings, numbers, garbage between
+ * records — is intentionally skipped by this splitter so a corrupt fragment
+ * cannot spoof a record. If upstream ever changes the on-disk shape, this
+ * function has to be updated explicitly; the existing test
+ * `'silently skips top-level arrays and scalars while keeping intervening objects'`
+ * pins the contract.
+ *
+ * Recovery semantics: scan forward looking for `{`, track string/escape
+ * state, balance `{`/`}`. If the running object never closes (truncated
+ * write, unterminated string), skip past the failed `{` and keep scanning
+ * for later valid objects on the same line — preventing a single garbled
+ * fragment from poisoning trailing valid records glued onto the same line.
+ */
 function splitJsonObjects(text: string): string[] {
   const objects: string[] = [];
-  let start: number | undefined;
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
+  let cursor = 0;
 
-  for (let index = 0; index < text.length; index++) {
-    const char = text[index];
+  while (cursor < text.length) {
+    let start: number | undefined;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    let closedAt: number | undefined;
 
-    if (start === undefined) {
-      if (/\s/.test(char)) continue;
-      if (char !== '{') continue;
-      start = index;
-    }
+    for (let index = cursor; index < text.length; index++) {
+      const char = text[index];
 
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === '\\') {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
+      if (start === undefined) {
+        // Skip whitespace and any garbage (incl. top-level arrays/scalars)
+        // before the next opening brace. See block comment above.
+        if (char !== '{') continue;
+        start = index;
       }
-      continue;
-    }
 
-    if (char === '"') {
-      inString = true;
-      continue;
-    }
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === '\\') {
+          escaped = true;
+        } else if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
 
-    if (char === '{') {
-      depth++;
-      continue;
-    }
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
 
-    if (char === '}') {
-      depth--;
-      if (depth === 0 && start !== undefined) {
-        objects.push(text.slice(start, index + 1));
-        start = undefined;
+      if (char === '{') {
+        depth++;
+        continue;
+      }
+
+      if (char === '}') {
+        depth--;
+        if (depth === 0) {
+          closedAt = index;
+          objects.push(text.slice(start, index + 1));
+          break;
+        }
       }
     }
+
+    if (closedAt !== undefined) {
+      cursor = closedAt + 1;
+      continue;
+    }
+
+    // The trailing object never closed (unterminated string or missing brace).
+    // Skip past the failed opening brace and try to recover later top-level
+    // objects on the same line. If no opening brace was found at all, stop.
+    if (start === undefined) break;
+    cursor = start + 1;
   }
 
   return objects;
@@ -216,91 +268,24 @@ async function scanQwenJsonlFile(
 ): Promise<void> {
   if (!fs.existsSync(filePath)) return;
 
-  const decoder = new StringDecoder('utf8');
-  const stream = fs.createReadStream(filePath);
-  let lineBuffer = '';
-  let lineIndex = 0;
-  let skippingOversizedLine = false;
-  let stopped = false;
-
-  const finishLine = (): 'continue' | 'stop' => {
-    const line = lineBuffer.endsWith('\r') ? lineBuffer.slice(0, -1) : lineBuffer;
-    lineBuffer = '';
-
-    if (skippingOversizedLine) {
-      logger.debug('qwen-code: skipping oversized JSONL line at index', lineIndex, 'in', filePath);
-      skippingOversizedLine = false;
-      lineIndex++;
+  await scanJsonlLines(
+    filePath,
+    (line, lineIndex) => {
+      const chunks = splitJsonObjects(line);
+      if (chunks.length === 0 && line.trim()) {
+        logger.debug('qwen-code: skipping malformed JSONL line at index', lineIndex, 'in', filePath);
+      }
+      for (const chunk of chunks) {
+        try {
+          if (visitor(JSON.parse(chunk), lineIndex) === 'stop') return 'stop';
+        } catch (err) {
+          logger.debug('qwen-code: skipping invalid JSON object at index', lineIndex, 'in', filePath, err);
+        }
+      }
       return 'continue';
-    }
-
-    const chunks = splitJsonObjects(line);
-    if (chunks.length === 0 && line.trim()) {
-      logger.debug('qwen-code: skipping malformed JSONL line at index', lineIndex, 'in', filePath);
-    }
-
-    for (const chunk of chunks) {
-      try {
-        if (visitor(JSON.parse(chunk), lineIndex) === 'stop') {
-          lineIndex++;
-          return 'stop';
-        }
-      } catch (err) {
-        logger.debug('qwen-code: skipping invalid JSON object at index', lineIndex, 'in', filePath, err);
-      }
-    }
-
-    lineIndex++;
-    return 'continue';
-  };
-
-  const consumeText = (text: string): 'continue' | 'stop' => {
-    let start = 0;
-
-    while (start < text.length) {
-      const newlineIndex = text.indexOf('\n', start);
-      const segmentEnd = newlineIndex === -1 ? text.length : newlineIndex;
-      const segment = text.slice(start, segmentEnd);
-
-      if (!skippingOversizedLine) {
-        if (lineBuffer.length + segment.length > MAX_QWEN_JSONL_RECORD_CHARS) {
-          skippingOversizedLine = true;
-          lineBuffer = '';
-        } else {
-          lineBuffer += segment;
-        }
-      }
-
-      if (newlineIndex === -1) break;
-      if (finishLine() === 'stop') return 'stop';
-      start = newlineIndex + 1;
-    }
-
-    return 'continue';
-  };
-
-  try {
-    for await (const chunk of stream) {
-      if (consumeText(decoder.write(chunk as Buffer)) === 'stop') {
-        stopped = true;
-        stream.destroy();
-        break;
-      }
-    }
-
-    if (!stopped) {
-      const remaining = decoder.end();
-      if (remaining && consumeText(remaining) === 'stop') {
-        stopped = true;
-      }
-
-      if (!stopped && (lineBuffer.length > 0 || skippingOversizedLine)) {
-        finishLine();
-      }
-    }
-  } catch (err) {
-    logger.debug('qwen-code: failed to stream JSONL file', filePath, err);
-  }
+    },
+    { maxLineChars: MAX_QWEN_JSONL_RECORD_CHARS },
+  );
 }
 
 async function readJsonlRecords(filePath: string): Promise<QwenChatRecord[]> {
@@ -382,7 +367,13 @@ function collectParentFunctionCalls(records: QwenChatRecord[]): Map<string, Pare
       });
     }
 
-    if (calls.length > 0) callsByParent.set(record.uuid, calls);
+    if (calls.length > 0) {
+      // Merge across duplicate-UUID assistant fragments so earlier function
+      // calls aren't overwritten when the same record id is appended to the
+      // log multiple times.
+      const existing = callsByParent.get(record.uuid);
+      callsByParent.set(record.uuid, existing ? [...existing, ...calls] : calls);
+    }
   }
 
   return callsByParent;
@@ -465,7 +456,16 @@ async function findSessionFiles(): Promise<string[]> {
 // ── Session metadata extraction ─────────────────────────────────────────────
 
 async function extractSessionMeta(filePath: string): Promise<QwenSessionMeta | null> {
-  const fileStats = await getFileStats(filePath);
+  // One async stat covers both bytes and mtime, replacing two synchronous
+  // statSync calls on the parser hot path.
+  let fileStat: fs.Stats;
+  try {
+    fileStat = await fs.promises.stat(filePath);
+  } catch (err) {
+    logger.debug('qwen-code: failed to stat session file', filePath, err);
+    return null;
+  }
+
   let sessionId = '';
   let cwd = '';
   let gitBranch: string | undefined;
@@ -474,28 +474,46 @@ async function extractSessionMeta(filePath: string): Promise<QwenSessionMeta | n
   let firstTimestamp: string | undefined;
   let lastTimestamp: string | undefined;
   let model: string | undefined;
+  let lineCount = 0;
 
-  await scanQwenJsonlFile(filePath, (parsed, lineIndex) => {
-    const record = parseQwenChatRecord(parsed, filePath, lineIndex);
-    if (!record) return 'continue';
+  await scanJsonlLines(
+    filePath,
+    (line, lineIndex) => {
+      lineCount = lineIndex + 1;
+      const trimmed = line.trim();
+      if (!trimmed) return 'continue';
 
-    if (!sessionId && record.sessionId) sessionId = record.sessionId;
-    if (!cwd && record.cwd) cwd = record.cwd;
-    if (!gitBranch && record.gitBranch) gitBranch = record.gitBranch;
-    if (!model && record.model) model = record.model;
+      const chunks = splitJsonObjects(line);
+      for (const chunk of chunks) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(chunk);
+        } catch {
+          continue;
+        }
 
-    if (!firstTimestamp && record.timestamp) firstTimestamp = record.timestamp;
-    if (record.timestamp) lastTimestamp = record.timestamp;
+        const record = parseQwenChatRecord(parsed, filePath, lineIndex);
+        if (!record) continue;
 
-    if (record.type === 'user' && !firstUserMessage) {
-      firstUserMessage = extractContentText(record.message);
-    }
+        if (!sessionId && record.sessionId) sessionId = record.sessionId;
+        if (!cwd && record.cwd) cwd = record.cwd;
+        if (!gitBranch && record.gitBranch) gitBranch = record.gitBranch;
+        if (!model && record.model) model = record.model;
 
-    const title = extractCustomTitle(record);
-    if (title) customTitle = title;
+        if (!firstTimestamp && record.timestamp) firstTimestamp = record.timestamp;
+        if (record.timestamp) lastTimestamp = record.timestamp;
 
-    return 'continue';
-  });
+        if (record.type === 'user' && !firstUserMessage) {
+          firstUserMessage = extractContentText(record.message);
+        }
+
+        const title = extractCustomTitle(record);
+        if (title) customTitle = title;
+      }
+      return 'continue';
+    },
+    { maxLineChars: MAX_QWEN_JSONL_RECORD_CHARS },
+  );
 
   if (!sessionId) return null;
 
@@ -507,8 +525,9 @@ async function extractSessionMeta(filePath: string): Promise<QwenSessionMeta | n
     firstTimestamp,
     lastTimestamp,
     model,
-    lineCount: fileStats.lines,
-    bytes: fileStats.bytes,
+    lineCount,
+    bytes: fileStat.size,
+    mtime: fileStat.mtime,
   };
 }
 
@@ -932,7 +951,25 @@ function getLastMainRecordUuid(records: QwenChatRecord[]): string | undefined {
   return records.at(-1)?.uuid;
 }
 
-/** Reconstruct main conversation path by walking from the last appended record via parentUuid. */
+/**
+ * Reconstruct the main conversation path by walking parentUuid backwards from
+ * the last appended non-sidechain record. Mirrors upstream Qwen Code's
+ * `sessionService.reconstructHistory` (packages/core/src/services/sessionService.ts)
+ * which starts at `records[records.length - 1].uuid` (or a supplied leafUuid)
+ * and walks parents until the chain breaks.
+ *
+ * **Broken-chain policy:** when a parentUuid does not resolve in the current
+ * record set (incomplete log, deleted ancestor, or fork merge artefacts), we
+ * fall back to the full append-ordered `aggregated` set instead of truncating
+ * at the last valid ancestor. Upstream truncates because it owns the live
+ * session. We're a *handoff* — surfacing every appended turn keeps the
+ * receiving tool from silently losing work the user could see in Qwen Code's
+ * UI. The trade-off is that abandoned branches reappear on broken chains;
+ * that is the lesser evil for a one-shot context dump (open question #2 in
+ * the PR description, resolved deliberately).
+ *
+ * Cycle protection: `visited` guard breaks if a parent loop is detected.
+ */
 function reconstructMainPath(records: QwenChatRecord[]): QwenChatRecord[] {
   if (records.length === 0) return [];
 
@@ -974,7 +1011,6 @@ export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
       const meta = await extractSessionMeta(filePath);
       if (!meta) continue;
 
-      const fileStats = fs.statSync(filePath);
       const summary = cleanSummary(meta.summary ?? '') || undefined;
 
       sessions.push({
@@ -985,8 +1021,8 @@ export async function parseQwenCodeSessions(): Promise<UnifiedSession[]> {
         branch: meta.gitBranch,
         lines: meta.lineCount,
         bytes: meta.bytes,
-        createdAt: parseTimestamp(meta.firstTimestamp, fileStats.mtime),
-        updatedAt: parseTimestamp(meta.lastTimestamp, fileStats.mtime),
+        createdAt: parseTimestamp(meta.firstTimestamp, meta.mtime),
+        updatedAt: parseTimestamp(meta.lastTimestamp, meta.mtime),
         originalPath: filePath,
         summary,
         model: meta.model,

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -903,9 +903,15 @@ register({
 register({
   name: 'qwen-code',
   label: 'Qwen Code',
+  // Upstream Qwen Code (packages/core/src/config/storage.ts: Storage.getRuntimeBaseDir)
+  // resolves the runtime base via QWEN_RUNTIME_DIR before falling back to
+  // ~/.qwen, then writes chats under <runtime-base>/projects/<sanitized-cwd>/chats/.
+  // QWEN_HOME is a continues-side override kept for fixtures and sandboxed installs;
+  // both must invalidate the index cache when changed.
   color: chalk.hex('#6366F1'),
-  storagePath: '~/.qwen/projects/*/chats/',
-  envVar: 'QWEN_HOME',
+  storagePath: '$QWEN_RUNTIME_DIR/projects/*/chats/ (default: ~/.qwen/projects/*/chats/)',
+  envVar: 'QWEN_RUNTIME_DIR',
+  extraEnvVars: ['QWEN_HOME'],
   binaryName: 'qwen',
   parseSessions: parseQwenCodeSessions,
   extractContext: extractQwenCodeContext,

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -18,7 +18,13 @@ export interface JsonlReadOptions {
   maxBytes?: number;
 }
 
-async function scanJsonlLines(
+/**
+ * Stream a JSONL file line by line, invoking `visitor` for each raw line
+ * (without JSON.parse). Newline handling, CR trimming, and oversized-line
+ * skipping are shared. Used by parsers that need their own per-line decoding
+ * (e.g. recovering glued JSON objects from a single physical line).
+ */
+export async function scanJsonlLines(
   filePath: string,
   visitor: (line: string, lineIndex: number) => 'continue' | 'stop',
   options: JsonlReadOptions = {},


### PR DESCRIPTION
# fix(parser): harden qwen code jsonl parsing

## Summary
Hardens the Qwen Code parser around current runtime storage and malformed JSONL records. The parser now discovers sessions under `QWEN_RUNTIME_DIR` with legacy `QWEN_HOME` fallback, reads project `chats/*.jsonl` files, recovers valid objects from damaged lines, reconstructs the active main conversation path by append order, and pairs duplicate tool results by call id instead of tool name.

## Context / Why now
Qwen Code runtime files are not guaranteed to look like clean one-record-per-line JSONL, and newer runtime layouts store project chats under the runtime base rather than the old home-derived path. The previous parser could miss sessions, drop glued records, pick an abandoned branch as the main conversation, or attach the wrong output when the same tool was called multiple times in one assistant turn.

## The 4 Items

### Item 1: Runtime directory and project chat discovery
- Files: `src/parsers/qwen-code.ts`, `src/__tests__/qwen-code-parser.test.ts`
- What: Resolves `QWEN_RUNTIME_DIR` first, keeps `QWEN_HOME` as a legacy fallback, and discovers JSONL files under `<runtime-base>/projects/<sanitized-cwd>/chats/`.
- Why this shape: The parser follows Qwen Code's runtime layout while preserving the existing override path for older tests and users.
- Verified by: Added coverage for runtime-dir precedence, legacy fallback, project chat path discovery, metadata extraction, line counts, bytes, timestamps, repo, branch, summary, and model.

### Item 2: Robust JSONL recovery
- Files: `src/parsers/qwen-code.ts`, `src/__tests__/qwen-code-parser.test.ts`
- What: Replaces readline parsing with a streaming scanner that can split glued JSON objects, skip malformed fragments, skip oversized records, and continue parsing valid records.
- Why this shape: Streaming keeps memory bounded and lets the parser recover useful session data without treating one bad physical line as a whole-file failure.
- Verified by: Added coverage for glued records on one line plus malformed fragments, including session discovery and extracted recent messages.

### Item 3: Main path reconstruction
- Files: `src/parsers/qwen-code.ts`, `src/__tests__/qwen-code-parser.test.ts`
- What: Aggregates duplicate UUID records, starts the main path from the last appended non-sidechain record, walks `parentUuid` links back to root, and falls back to append order when links are broken.
- Why this shape: Append order better reflects the active Qwen Code transcript than selecting the newest leaf by timestamp, which can revive abandoned branches.
- Verified by: Added coverage for abandoned newer branches, broken parent links, duplicate UUID aggregation, reasoning preservation, pending tasks, token notes, and handoff markdown context.

### Item 4: Tool result pairing and file diffs
- Files: `src/parsers/qwen-code.ts`, `src/__tests__/qwen-code-parser.test.ts`
- What: Collects inline and external tool responses by call id, only falls back to parent/name when unambiguous, and uses confirmed `tool_result` file diffs for edit/write summaries without double-counting inline calls.
- Why this shape: Same-tool duplicate calls are common enough that name-based pairing can attach the wrong output; call ids are the stronger key when available.
- Verified by: Added coverage for separate `tool_result` function responses, duplicate `Bash` calls with call ids, edit/write result displays, diff stats, new-file detection, and `filesModified`.

## Files touched
| File | +/- | Purpose |
|---|---:|---|
| `src/parsers/qwen-code.ts` | +816 / -140 | Harden Qwen runtime lookup, JSONL scanning, context reconstruction, and tool result summarization. |
| `src/__tests__/qwen-code-parser.test.ts` | +586 / -0 | Add focused parser regression coverage for runtime layout, malformed JSONL, main path selection, duplicate records, tool pairing, and file diffs. |

## Verification
- Passed: `git diff --check origin/main...HEAD`
- Attempted: `pnpm test` failed before tests ran because this worktree has no `node_modules`; `vitest` was not found.
- Attempted: `pnpm run check` failed before lint/build because this worktree has no `node_modules`; `biome` was not found.
- Full-check baseline blocker: I could not establish the full `pnpm run check` baseline locally from this worktree without installing dependencies, which was left out of scope for this PR creation pass.

## Weaknesses and Open Questions
1. Important: The JSON object splitter is intentionally permissive and recovers `{...}{...}` sequences from a physical line, but it only emits top-level objects. If Qwen starts writing arrays or non-object records, they will be skipped.
2. Important: Main-path reconstruction falls back to append order on broken chains. That preserves data, but it can include side branches if the final chain is damaged.
3. Minor: Dependency-backed checks were not completed in this worktree because `node_modules` is absent; CI or a dependency-installed checkout needs to validate the new tests.

## Request to the Reviewer
1. Please confirm whether `QWEN_RUNTIME_DIR` should always take precedence over `QWEN_HOME`, or whether there is a Qwen Code configuration path that should outrank both.
2. Please examine the append-order main path reconstruction and explain whether broken parent chains should fall back to full append order or truncate at the last valid ancestor.
3. Please review the duplicate tool result pairing logic, especially call-id matching versus parent/name fallback, and explain whether ambiguous same-tool calls should be omitted as this patch does.

## Follow-ups
- No runtime dependency changes are included.
- No CLI flags or user-facing command output are changed directly.
- No migration is added for already-exported handoff markdown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Qwen Code JSONL parser more robust and accurate. It now prefers `QWEN_RUNTIME_DIR`, recovers valid objects from glued/malformed lines, reconstructs the main path reliably, and preserves file diffs by `callId`.

- **Bug Fixes**
  - Discover chats under `<runtime>/projects/<sanitized-cwd>/chats/`, preferring `QWEN_RUNTIME_DIR` with `QWEN_HOME` fallback; registry now tracks both so the index invalidates when either changes.
  - Stream-parse JSONL to split glued `{...}{...}` objects, recover after a malformed leading fragment, skip top‑level arrays/scalars, and skip oversized fragments (>16MB).
  - Rebuild the main path by append order starting from the last non‑sidechain; fall back cleanly on broken links and merge duplicate‑UUID assistant fragments so earlier function calls aren’t lost.
  - Pair tool outputs by `callId` (name/category fallback only when unambiguous); use confirmed `tool_result` file diffs for edits/writes, and preserve diffs when `displayName` is missing by resolving to the parent call. Accurate diff stats and `filesModified`.

- **New Features**
  - Capture session summary from custom titles (fallback to first user message) and record lines, bytes, timestamps, repo, branch, and model in a single async scan.
  - Richer tool summaries for shell/grep/glob/fetch/search/task/ask with error detection and key args included.

<sup>Written for commit 5b7cb19a4e1e5a859b52461d46db0ac34d203299. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/56?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

