### PR TITLE
fix(cline): harden session discovery and context

### DIFF
--- a/src/__tests__/cline-parser.test.ts
+++ b/src/__tests__/cline-parser.test.ts
@@ -6,6 +6,10 @@ import type { SessionSource, UnifiedSession } from '../types/index.js';
 
 const tempDirs: string[] = [];
 
+interface LoadClineParserOptions {
+  onReadFile?: (filePath: string) => void;
+}
+
 function makeHome(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cline-parser-'));
   tempDirs.push(dir);
@@ -29,8 +33,26 @@ function clineCliTasksRoot(clineDir: string): string {
   return path.join(clineDir, 'data', 'tasks');
 }
 
-async function loadClineParser(home: string): Promise<typeof import('../parsers/cline.js')> {
+async function loadClineParser(
+  home: string,
+  options: LoadClineParserOptions = {},
+): Promise<typeof import('../parsers/cline.js')> {
   vi.resetModules();
+  if (options.onReadFile) {
+    vi.doMock('node:fs/promises', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs/promises')>();
+      return {
+        ...actual,
+        readFile: (
+          filePath: Parameters<typeof actual.readFile>[0],
+          readOptions?: Parameters<typeof actual.readFile>[1],
+        ) => {
+          options.onReadFile?.(String(filePath));
+          return actual.readFile(filePath, readOptions);
+        },
+      };
+    });
+  }
   vi.stubEnv('APPDATA', path.join(home, 'AppData', 'Roaming'));
   vi.doMock('../utils/parser-helpers.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../utils/parser-helpers.js')>();
@@ -107,6 +129,7 @@ function sessionFor(source: SessionSource, originalPath: string, id = `${source}
 }
 
 afterEach(() => {
+  vi.doUnmock('node:fs/promises');
   vi.doUnmock('../utils/parser-helpers.js');
   vi.doUnmock('../utils/markdown.js');
   vi.unstubAllEnvs();
@@ -412,6 +435,80 @@ describe('Cline-family parser hardening', () => {
     });
     expect(context.sessionNotes?.tokenUsage).toEqual({ input: 123, output: 45 });
     expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 6, read: 7 });
+  });
+
+  it('loads shared task history once per storage root while listing sessions', async () => {
+    const home = makeHome();
+    const firstPath = writeTask(home, 'saoudrizwan.claude-dev', 'history-cache-a', [
+      { ts: 1770000450000, type: 'say', say: 'task', text: 'Cache task history for first task' },
+    ]);
+    writeTask(home, 'saoudrizwan.claude-dev', 'history-cache-b', [
+      { ts: 1770000451000, type: 'say', say: 'task', text: 'Cache task history for second task' },
+    ]);
+    writeTaskHistory(firstPath, [
+      {
+        id: 'history-cache-a',
+        ts: 1770000452000,
+        cwdOnTaskInitialization: '/tmp/history-cache-a',
+        modelId: 'history-model-a',
+      },
+      {
+        id: 'history-cache-b',
+        ts: 1770000453000,
+        cwdOnTaskInitialization: '/tmp/history-cache-b',
+        modelId: 'history-model-b',
+      },
+    ]);
+    const taskHistoryReads: string[] = [];
+
+    const { parseClineSessions } = await loadClineParser(home, {
+      onReadFile: (filePath) => {
+        if (path.basename(filePath) === 'taskHistory.json') taskHistoryReads.push(filePath);
+      },
+    });
+    const sessions = await parseClineSessions();
+
+    expect(sessions.map((session) => session.id).sort()).toEqual(['history-cache-a', 'history-cache-b']);
+    expect(sessions.find((session) => session.id === 'history-cache-a')).toMatchObject({
+      cwd: '/tmp/history-cache-a',
+      model: 'history-model-a',
+    });
+    expect(sessions.find((session) => session.id === 'history-cache-b')).toMatchObject({
+      cwd: '/tmp/history-cache-b',
+      model: 'history-model-b',
+    });
+    expect(taskHistoryReads).toHaveLength(1);
+  });
+
+  it('extracts cwd from request strings inside UI API metadata', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'request-string-cwd', [
+      { ts: 1770000460000, type: 'say', say: 'task', text: 'Recover cwd from request metadata' },
+      {
+        ts: 1770000461000,
+        type: 'say',
+        say: 'api_req_started',
+        text: JSON.stringify({
+          request: 'Current Working Directory (/tmp/request-string-project) Files\nsrc/parsers/cline.ts',
+        }),
+      },
+    ]);
+
+    const { parseClineSessions, extractClineContext } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+    const session = sessions.find((item) => item.id === 'request-string-cwd');
+
+    expect(session).toMatchObject({
+      cwd: '/tmp/request-string-project',
+      repo: 'tmp/request-string-project',
+    });
+
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'request-string-cwd'));
+
+    expect(context.session).toMatchObject({
+      cwd: '/tmp/request-string-project',
+      repo: 'tmp/request-string-project',
+    });
   });
 
   it('recovers context from API history and metadata when ui_messages.json is malformed', async () => {

--- a/src/__tests__/cline-parser.test.ts
+++ b/src/__tests__/cline-parser.test.ts
@@ -33,6 +33,16 @@ function clineCliTasksRoot(clineDir: string): string {
   return path.join(clineDir, 'data', 'tasks');
 }
 
+function jetBrainsRoot(home: string): string {
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'JetBrains');
+  }
+  if (process.platform === 'win32') {
+    return path.join(home, 'AppData', 'Roaming', 'JetBrains');
+  }
+  return path.join(home, '.config', 'JetBrains');
+}
+
 async function loadClineParser(
   home: string,
   options: LoadClineParserOptions = {},
@@ -310,8 +320,12 @@ describe('Cline-family parser hardening', () => {
       expect(contents).not.toContain('Draft assistant answer');
       expect(contents).not.toContain('metadata noise');
       expect(contents).not.toContain('npm test');
-      expect(context.sessionNotes?.tokenUsage).toEqual({ input: 17, output: 8 });
-      expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 3, read: 7 });
+      // Only `api_req_started` events carry per-request deltas;
+      // `api_req_finished` carries running cumulative totals, so summing both
+      // would double count. The malformed `api_req_started` ('not json') is
+      // skipped, leaving the single valid event at ts=1770000202000.
+      expect(context.sessionNotes?.tokenUsage).toEqual({ input: 10, output: 0 });
+      expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 2, read: 3 });
       expect(context.sessionNotes?.reasoning).toEqual([
         'Need to cover malformed messages, streaming finalization, and all source variants.',
       ]);
@@ -583,5 +597,77 @@ describe('Cline-family parser hardening', () => {
       expect(context.toolSummaries).toEqual([]);
       expect(context.sessionNotes).toEqual({});
     }
+  });
+
+  it('discovers Cline tasks from JetBrains globalStorage directories', async () => {
+    const home = makeHome();
+    // Simulate a JetBrains IDE storing its globalStorage at depth 3 below the
+    // JetBrains config root (e.g. JetBrains/IntelliJIdea2025.1/options/.../globalStorage).
+    const jbRoot = jetBrainsRoot(home);
+    const jbStorage = path.join(jbRoot, 'IntelliJIdea2026.1', 'options', 'globalStorage');
+    const jbTasksRoot = path.join(jbStorage, 'saoudrizwan.claude-dev', 'tasks');
+    writeTaskAtRoot(jbTasksRoot, 'jetbrains-task', [
+      { ts: 1770000700000, type: 'say', say: 'task', text: 'Discover from JetBrains globalStorage' },
+    ]);
+
+    const { parseClineSessions } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: 'jetbrains-task',
+      source: 'cline',
+      summary: 'Discover from JetBrains globalStorage',
+    });
+    expect(sessions[0].originalPath).toContain(path.join('JetBrains'));
+  });
+
+  it('does not infer cwd from bare path-like strings in API request metadata', async () => {
+    const home = makeHome();
+    // No `cwd` / `currentWorkingDirectory` key, no "Current Working Directory"
+    // marker — only an unrelated path embedded in conversation text. The
+    // previous accept-any-path heuristic would mis-classify `/usr/bin/node`
+    // as the working directory; the constrained version must reject it.
+    writeTask(home, 'saoudrizwan.claude-dev', 'no-cwd-task', [
+      { ts: 1770000800000, type: 'say', say: 'task', text: 'No cwd marker anywhere' },
+      {
+        ts: 1770000801000,
+        type: 'say',
+        say: 'api_req_started',
+        text: JSON.stringify({
+          request: 'The user mentioned /usr/bin/node and /etc/hosts in conversation.',
+        }),
+      },
+    ]);
+
+    const { parseClineSessions } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+    const session = sessions.find((item) => item.id === 'no-cwd-task');
+
+    expect(session).toBeDefined();
+    expect(session?.cwd).toBe('');
+    expect(session?.repo).toBeUndefined();
+  });
+
+  it('normalizes Windows-style cwd separators when deriving repo', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'windows-cwd', [
+      { ts: 1770000900000, type: 'say', say: 'task', text: 'Recover Windows cwd from task history' },
+    ]);
+    writeTaskHistory(originalPath, [
+      {
+        id: 'windows-cwd',
+        ts: 1770000901000,
+        cwdOnTaskInitialization: 'C:\\Users\\dev\\projects\\cli-continues',
+      },
+    ]);
+
+    const { parseClineSessions } = await loadClineParser(home);
+    const session = (await parseClineSessions()).find((item) => item.id === 'windows-cwd');
+
+    expect(session).toMatchObject({
+      cwd: 'C:/Users/dev/projects/cli-continues',
+      repo: 'projects/cli-continues',
+    });
   });
 });

--- a/src/__tests__/cline-parser.test.ts
+++ b/src/__tests__/cline-parser.test.ts
@@ -1,0 +1,490 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SessionSource, UnifiedSession } from '../types/index.js';
+
+const tempDirs: string[] = [];
+
+function makeHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cline-parser-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function globalStorageBase(home: string): string {
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'Code', 'User', 'globalStorage');
+  }
+  if (process.platform === 'linux') {
+    return path.join(home, '.config', 'Code', 'User', 'globalStorage');
+  }
+  if (process.platform === 'win32') {
+    return path.join(home, 'AppData', 'Roaming', 'Code', 'User', 'globalStorage');
+  }
+  return path.join(home, '.config', 'Code', 'User', 'globalStorage');
+}
+
+function clineCliTasksRoot(clineDir: string): string {
+  return path.join(clineDir, 'data', 'tasks');
+}
+
+async function loadClineParser(home: string): Promise<typeof import('../parsers/cline.js')> {
+  vi.resetModules();
+  vi.stubEnv('APPDATA', path.join(home, 'AppData', 'Roaming'));
+  vi.doMock('../utils/parser-helpers.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../utils/parser-helpers.js')>();
+    return {
+      ...actual,
+      homeDir: () => home,
+    };
+  });
+  vi.doMock('../utils/markdown.js', () => ({
+    generateHandoffMarkdown: () => 'mock handoff markdown',
+  }));
+  return import('../parsers/cline.js');
+}
+
+function writeTaskAtRoot(tasksRoot: string, taskId: string, messages: unknown[]): string {
+  const taskDir = path.join(tasksRoot, taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  const filePath = path.join(taskDir, 'ui_messages.json');
+  fs.writeFileSync(filePath, JSON.stringify(messages, null, 2), 'utf8');
+  return filePath;
+}
+
+function writeRawTaskAtRoot(tasksRoot: string, taskId: string, content: string): string {
+  const taskDir = path.join(tasksRoot, taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  const filePath = path.join(taskDir, 'ui_messages.json');
+  fs.writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}
+
+function extensionTasksRoot(home: string, extensionId: string): string {
+  return path.join(globalStorageBase(home), extensionId, 'tasks');
+}
+
+function writeTask(home: string, extensionId: string, taskId: string, messages: unknown[]): string {
+  return writeTaskAtRoot(extensionTasksRoot(home, extensionId), taskId, messages);
+}
+
+function writeRawTask(home: string, extensionId: string, taskId: string, content: string): string {
+  return writeRawTaskAtRoot(extensionTasksRoot(home, extensionId), taskId, content);
+}
+
+function taskDirFor(originalPath: string): string {
+  return path.dirname(originalPath);
+}
+
+function writeCompanion(originalPath: string, fileName: string, content: unknown): string {
+  const filePath = path.join(taskDirFor(originalPath), fileName);
+  fs.writeFileSync(filePath, JSON.stringify(content, null, 2), 'utf8');
+  return filePath;
+}
+
+function writeTaskHistory(originalPath: string, items: unknown[]): string {
+  const storageRoot = path.dirname(path.dirname(taskDirFor(originalPath)));
+  const stateDir = path.join(storageRoot, 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const filePath = path.join(stateDir, 'taskHistory.json');
+  fs.writeFileSync(filePath, JSON.stringify(items, null, 2), 'utf8');
+  return filePath;
+}
+
+function sessionFor(source: SessionSource, originalPath: string, id = `${source}-task`): UnifiedSession {
+  return {
+    id,
+    source,
+    cwd: '',
+    lines: 1,
+    bytes: fs.statSync(originalPath).size,
+    createdAt: new Date('2026-04-15T10:00:00.000Z'),
+    updatedAt: new Date('2026-04-15T10:00:00.000Z'),
+    originalPath,
+    summary: 'Parser hardening',
+  } satisfies UnifiedSession;
+}
+
+afterEach(() => {
+  vi.doUnmock('../utils/parser-helpers.js');
+  vi.doUnmock('../utils/markdown.js');
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+describe('Cline-family parser hardening', () => {
+  it('discovers Cline CLI task roots from CLINE_DIR and ~/.cline without affecting Roo/Kilo', async () => {
+    const home = makeHome();
+    const customClineDir = path.join(home, 'custom-cline-dir');
+    vi.stubEnv('CLINE_DIR', customClineDir);
+
+    writeTaskAtRoot(clineCliTasksRoot(customClineDir), 'env-cli-task', [
+      { ts: 1770000000000, type: 'say', say: 'task', text: 'Parse task from CLINE_DIR' },
+    ]);
+    writeTaskAtRoot(path.join(home, '.cline', 'data', 'tasks'), 'home-cli-task', [
+      { ts: 1770000001000, type: 'say', say: 'task', text: 'Parse task from home Cline dir' },
+    ]);
+
+    const { parseClineSessions, parseRooCodeSessions, parseKiloCodeSessions } = await loadClineParser(home);
+
+    const clineSessions = await parseClineSessions();
+    const rooSessions = await parseRooCodeSessions();
+    const kiloSessions = await parseKiloCodeSessions();
+
+    expect(clineSessions.map((session) => session.id).sort()).toEqual(['env-cli-task', 'home-cli-task']);
+    expect(clineSessions.every((session) => session.source === 'cline')).toBe(true);
+    expect(clineSessions.map((session) => session.summary).sort()).toEqual([
+      'Parse task from CLINE_DIR',
+      'Parse task from home Cline dir',
+    ]);
+    expect(rooSessions).toEqual([]);
+    expect(kiloSessions).toEqual([]);
+  });
+
+  it('discovers and labels Cline, Roo Code, and Kilo Code task storage variants', async () => {
+    const home = makeHome();
+    writeTask(home, 'saoudrizwan.claude-dev', 'cline-task', [
+      { ts: 1770000000000, type: 'say', say: 'task', text: 'Build the Cline parser fixture' },
+    ]);
+    writeTask(home, 'rooveterinaryinc.roo-cline', 'roo-legacy-task', [
+      { ts: 1770000001000, type: 'say', say: 'text', text: 'Build the legacy Roo parser fixture' },
+    ]);
+    writeTask(home, 'roo-code.roo-cline', 'roo-current-task', [
+      { ts: 1770000002000, type: 'say', say: 'text', text: 'Build the current Roo parser fixture' },
+    ]);
+    writeTask(home, 'kilocode.kilo-code', 'kilo-task', [
+      { ts: 1770000003000, type: 'say', say: 'text', text: 'Build the Kilo parser fixture' },
+    ]);
+
+    const { parseClineSessions, parseRooCodeSessions, parseKiloCodeSessions } = await loadClineParser(home);
+
+    const clineSessions = await parseClineSessions();
+    const rooSessions = await parseRooCodeSessions();
+    const kiloSessions = await parseKiloCodeSessions();
+
+    expect(clineSessions).toHaveLength(1);
+    expect(clineSessions[0]).toMatchObject({
+      id: 'cline-task',
+      source: 'cline',
+      summary: 'Build the Cline parser fixture',
+    });
+    expect(clineSessions[0].originalPath).toContain('saoudrizwan.claude-dev');
+
+    expect(rooSessions.map((session) => session.id).sort()).toEqual(['roo-current-task', 'roo-legacy-task']);
+    expect(rooSessions.every((session) => session.source === 'roo-code')).toBe(true);
+    expect(rooSessions.map((session) => session.summary).sort()).toEqual([
+      'Build the current Roo parser fixture',
+      'Build the legacy Roo parser fixture',
+    ]);
+
+    expect(kiloSessions).toHaveLength(1);
+    expect(kiloSessions[0]).toMatchObject({
+      id: 'kilo-task',
+      source: 'kilo-code',
+      summary: 'Build the Kilo parser fixture',
+    });
+    expect(kiloSessions[0].originalPath).toContain('kilocode.kilo-code');
+  });
+
+  it('skips invalid JSON, non-array JSON, malformed entries, and metadata-only tasks during discovery', async () => {
+    const home = makeHome();
+    writeRawTask(home, 'saoudrizwan.claude-dev', 'invalid-json', '{not valid json');
+    writeRawTask(home, 'saoudrizwan.claude-dev', 'non-array-json', JSON.stringify({ type: 'say', say: 'task' }));
+    writeTask(home, 'saoudrizwan.claude-dev', 'metadata-only', [
+      null,
+      42,
+      {},
+      { type: 'say', say: 'api_req_started', text: '{"tokensIn":1}' },
+      { type: 'say', say: 'command_output', text: 'metadata noise' },
+    ]);
+    writeTask(home, 'saoudrizwan.claude-dev', 'valid-task', [
+      null,
+      { type: 'say', say: 'text', text: { nested: 'not text' } },
+      { ts: 1770000100000, type: 'say', say: 'task', text: 'Keep this valid task' },
+    ]);
+
+    const { parseClineSessions } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: 'valid-task',
+      summary: 'Keep this valid task',
+    });
+  });
+
+  it('extracts shared context without duplicating streaming partials or fabricating tool summaries', async () => {
+    const home = makeHome();
+    const messages = [
+      null,
+      42,
+      { ts: 1770000200000, type: 'say', say: 'task', text: 'Implement parser hardening' },
+      { ts: 1770000201000, type: 'say', say: 'api_req_started', text: 'not json' },
+      {
+        ts: 1770000202000,
+        type: 'say',
+        say: 'api_req_started',
+        text: '{"tokensIn":10,"tokensOut":0,"cacheWrites":2,"cacheReads":3,"cost":0.01}',
+      },
+      { ts: 1770000203000, type: 'say', say: 'text', text: 'Draft assistant answer', partial: true },
+      { ts: 1770000204000, type: 'say', say: 'text', text: 'Final assistant answer', partial: false },
+      { ts: 1770000205000, type: 'ask', ask: 'followup', text: 'Should I add parser tests?' },
+      { ts: 1770000206000, type: 'say', say: 'user_feedback', text: 'Yes, add parser tests' },
+      {
+        ts: 1770000207000,
+        type: 'say',
+        say: 'reasoning',
+        reasoning: 'Need to cover malformed messages, streaming finalization, and all source variants.',
+      },
+      {
+        ts: 1770000208000,
+        type: 'say',
+        say: 'api_req_finished',
+        text: '{"totalTokensIn":7,"totalTokensOut":8,"totalCacheWrites":1,"totalCacheReads":4,"totalCost":0.02}',
+      },
+      {
+        ts: 1770000209000,
+        type: 'ask',
+        ask: 'completion_result',
+        text: 'Done with parser hardening.\n- [ ] Run manual release check\nNext step: inspect handoff output',
+      },
+      { ts: 1770000210000, type: 'say', say: 'command_output', text: 'metadata noise' },
+      { ts: 1770000211000, type: 'ask', ask: 'command', text: 'npm test' },
+      { ts: 1770000212000, type: 'say', say: 'text', text: { nested: 'not text' } },
+    ];
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'context-task', messages);
+
+    const { extractClineContext, extractRooCodeContext, extractKiloCodeContext } = await loadClineParser(home);
+    const extractors = [
+      ['cline', extractClineContext],
+      ['roo-code', extractRooCodeContext],
+      ['kilo-code', extractKiloCodeContext],
+    ] as const;
+
+    for (const [source, extractContext] of extractors) {
+      const context = await extractContext(sessionFor(source, originalPath));
+      const contents = context.recentMessages.map((message) => message.content);
+
+      expect(context.recentMessages.map((message) => message.role)).toEqual([
+        'user',
+        'assistant',
+        'assistant',
+        'user',
+        'assistant',
+        'assistant',
+      ]);
+      expect(contents).toEqual([
+        'Implement parser hardening',
+        'Final assistant answer',
+        'Should I add parser tests?',
+        'Yes, add parser tests',
+        'Need to cover malformed messages, streaming finalization, and all source variants.',
+        'Done with parser hardening.\n- [ ] Run manual release check\nNext step: inspect handoff output',
+      ]);
+      expect(contents).not.toContain('Draft assistant answer');
+      expect(contents).not.toContain('metadata noise');
+      expect(contents).not.toContain('npm test');
+      expect(context.sessionNotes?.tokenUsage).toEqual({ input: 17, output: 8 });
+      expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 3, read: 7 });
+      expect(context.sessionNotes?.reasoning).toEqual([
+        'Need to cover malformed messages, streaming finalization, and all source variants.',
+      ]);
+      expect(context.pendingTasks).toEqual(['- [ ] Run manual release check', 'Next step: inspect handoff output']);
+      expect(context.filesModified).toEqual([]);
+      expect(context.toolSummaries).toEqual([]);
+    }
+  });
+
+  it('extracts exact Cline tool activity from api_conversation_history.json', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'api-tool-task', [
+      { ts: 1770000300000, type: 'say', say: 'task', text: 'Use exact API history tool calls' },
+      { ts: 1770000301000, type: 'say', say: 'text', text: 'I will run tests and edit the parser.', partial: false },
+    ]);
+    writeCompanion(originalPath, 'api_conversation_history.json', [
+      {
+        role: 'user',
+        ts: 1770000300000,
+        content: [
+          {
+            type: 'text',
+            text: 'Use exact API history tool calls\n<environment_details>\n# Current Working Directory (/tmp/cline-api-project) Files\n</environment_details>',
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        ts: 1770000301000,
+        modelInfo: { modelId: 'claude-sonnet-4-20260229', providerId: 'anthropic', mode: 'act' },
+        metrics: { tokens: { prompt: 100, completion: 20, cached: 30 }, cost: 0.02 },
+        content: [
+          { type: 'tool_use', id: 'tool-1', name: 'execute_command', input: { command: 'pnpm test' } },
+          {
+            type: 'tool_use',
+            id: 'tool-2',
+            name: 'replace_in_file',
+            input: { path: 'src/parsers/cline.ts', old_string: 'old', new_string: 'new' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        ts: 1770000302000,
+        content: [
+          { type: 'tool_result', tool_use_id: 'tool-1', content: 'Tests passed' },
+          { type: 'tool_result', tool_use_id: 'tool-2', content: [{ type: 'text', text: 'Replaced 1 occurrence' }] },
+        ],
+      },
+    ]);
+
+    const { extractClineContext } = await loadClineParser(home);
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'api-tool-task'));
+    const toolNames = context.toolSummaries.map((summary) => summary.name).sort();
+
+    expect(toolNames).toEqual(['execute_command', 'replace_in_file']);
+    expect(context.toolSummaries.find((summary) => summary.name === 'execute_command')?.samples[0].summary).toContain(
+      'pnpm test',
+    );
+    expect(context.toolSummaries.find((summary) => summary.name === 'execute_command')?.samples[0].summary).toContain(
+      'Tests passed',
+    );
+    expect(context.toolSummaries.find((summary) => summary.name === 'replace_in_file')?.samples[0].summary).toContain(
+      'src/parsers/cline.ts',
+    );
+    expect(context.filesModified).toEqual(['src/parsers/cline.ts']);
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 100, output: 20 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 0, read: 30 });
+  });
+
+  it('recovers Cline cwd, model, and usage from task metadata and state task history without double counting', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'metadata-task', [
+      { ts: 1770000400000, type: 'say', say: 'task', text: 'Recover metadata fields' },
+      {
+        ts: 1770000401000,
+        type: 'say',
+        say: 'api_req_finished',
+        text: '{"totalTokensIn":999,"totalTokensOut":999,"totalCacheWrites":999,"totalCacheReads":999}',
+      },
+      { ts: 1770000402000, type: 'say', say: 'text', text: 'Metadata recovered.', partial: false },
+    ]);
+    writeCompanion(originalPath, 'task_metadata.json', {
+      files_in_context: [],
+      model_usage: [
+        { ts: 1770000401500, model_id: 'claude-4-opus-metadata', model_provider_id: 'anthropic', mode: 'act' },
+      ],
+      environment_history: [],
+    });
+    writeTaskHistory(originalPath, [
+      {
+        id: 'metadata-task',
+        ts: 1770000403000,
+        task: 'Recover metadata fields',
+        tokensIn: 123,
+        tokensOut: 45,
+        cacheWrites: 6,
+        cacheReads: 7,
+        totalCost: 0.03,
+        cwdOnTaskInitialization: '/Users/tester/projects/cline-hardening',
+        modelId: 'history-model-should-not-win',
+      },
+    ]);
+
+    const { parseClineSessions, extractClineContext } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+    const session = sessions.find((item) => item.id === 'metadata-task');
+
+    expect(session).toMatchObject({
+      cwd: '/Users/tester/projects/cline-hardening',
+      repo: 'projects/cline-hardening',
+      model: 'claude-4-opus-metadata',
+    });
+
+    const context = await extractClineContext(session!);
+
+    expect(context.session).toMatchObject({
+      cwd: '/Users/tester/projects/cline-hardening',
+      repo: 'projects/cline-hardening',
+      model: 'claude-4-opus-metadata',
+    });
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 123, output: 45 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 6, read: 7 });
+  });
+
+  it('recovers context from API history and metadata when ui_messages.json is malformed', async () => {
+    const home = makeHome();
+    const originalPath = writeRawTask(home, 'saoudrizwan.claude-dev', 'malformed-ui-fallback', '{not valid json');
+    writeCompanion(originalPath, 'task_metadata.json', {
+      files_in_context: [],
+      model_usage: [
+        { ts: 1770000501000, model_id: 'claude-api-fallback-model', model_provider_id: 'anthropic', mode: 'act' },
+      ],
+      environment_history: [],
+    });
+    writeCompanion(originalPath, 'api_conversation_history.json', [
+      {
+        role: 'user',
+        ts: 1770000500000,
+        content: [
+          {
+            type: 'text',
+            text: 'Recover this malformed UI task\n<environment_details>\nCurrent Working Directory: /tmp/fallback-project\n</environment_details>',
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        ts: 1770000501000,
+        metrics: { tokens: { prompt: 12, completion: 8, cached: 3 } },
+        content: [
+          {
+            type: 'text',
+            text: 'Recovered from API history.\n- [ ] Re-run the parser test\nNext step: verify handoff output',
+          },
+        ],
+      },
+    ]);
+
+    const { extractClineContext } = await loadClineParser(home);
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'malformed-ui-fallback'));
+
+    expect(context.recentMessages.map((message) => message.content)).toEqual([
+      'Recover this malformed UI task',
+      'Recovered from API history.\n- [ ] Re-run the parser test\nNext step: verify handoff output',
+    ]);
+    expect(context.pendingTasks).toEqual(['- [ ] Re-run the parser test', 'Next step: verify handoff output']);
+    expect(context.session).toMatchObject({
+      cwd: '/tmp/fallback-project',
+      repo: 'tmp/fallback-project',
+      model: 'claude-api-fallback-model',
+    });
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 12, output: 8 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 0, read: 3 });
+  });
+
+  it('returns empty context instead of throwing for invalid or non-array ui_messages.json files', async () => {
+    const home = makeHome();
+    const invalidPath = writeRawTask(home, 'saoudrizwan.claude-dev', 'invalid-context', '{not valid json');
+    const nonArrayPath = writeRawTask(
+      home,
+      'saoudrizwan.claude-dev',
+      'non-array-context',
+      JSON.stringify({ ok: true }),
+    );
+
+    const { extractClineContext } = await loadClineParser(home);
+
+    for (const originalPath of [invalidPath, nonArrayPath]) {
+      const context = await extractClineContext(sessionFor('cline', originalPath));
+
+      expect(context.recentMessages).toEqual([]);
+      expect(context.pendingTasks).toEqual([]);
+      expect(context.filesModified).toEqual([]);
+      expect(context.toolSummaries).toEqual([]);
+      expect(context.sessionNotes).toEqual({});
+    }
+  });
+});

--- a/src/__tests__/cline-parser.test.ts
+++ b/src/__tests__/cline-parser.test.ts
@@ -43,6 +43,24 @@ function jetBrainsRoot(home: string): string {
   return path.join(home, '.config', 'JetBrains');
 }
 
+/**
+ * VS Code-fork globalStorage base. Cursor and Windsurf both ship a VS Code
+ * fork that reuses the same per-platform layout. The Cline extension can be
+ * installed inside any of them and stores tasks under its own publisher dir.
+ */
+function ideGlobalStorageBase(home: string, ide: 'Code' | 'Cursor' | 'Windsurf' | 'Code - Insiders'): string {
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', ide, 'User', 'globalStorage');
+  }
+  if (process.platform === 'linux') {
+    return path.join(home, '.config', ide, 'User', 'globalStorage');
+  }
+  if (process.platform === 'win32') {
+    return path.join(home, 'AppData', 'Roaming', ide, 'User', 'globalStorage');
+  }
+  return path.join(home, '.config', ide, 'User', 'globalStorage');
+}
+
 async function loadClineParser(
   home: string,
   options: LoadClineParserOptions = {},
@@ -576,7 +594,7 @@ describe('Cline-family parser hardening', () => {
     expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 0, read: 3 });
   });
 
-  it('returns empty context instead of throwing for invalid or non-array ui_messages.json files', async () => {
+  it('returns empty context with a fidelity warning for invalid or non-array ui_messages.json files', async () => {
     const home = makeHome();
     const invalidPath = writeRawTask(home, 'saoudrizwan.claude-dev', 'invalid-context', '{not valid json');
     const nonArrayPath = writeRawTask(
@@ -588,15 +606,23 @@ describe('Cline-family parser hardening', () => {
 
     const { extractClineContext } = await loadClineParser(home);
 
-    for (const originalPath of [invalidPath, nonArrayPath]) {
-      const context = await extractClineContext(sessionFor('cline', originalPath));
+    const invalidContext = await extractClineContext(sessionFor('cline', invalidPath));
+    expect(invalidContext.recentMessages).toEqual([]);
+    expect(invalidContext.pendingTasks).toEqual([]);
+    expect(invalidContext.filesModified).toEqual([]);
+    expect(invalidContext.toolSummaries).toEqual([]);
+    expect(invalidContext.sessionNotes?.fidelityWarnings).toEqual([
+      'ui_messages.json could not be parsed (invalid JSON)',
+    ]);
 
-      expect(context.recentMessages).toEqual([]);
-      expect(context.pendingTasks).toEqual([]);
-      expect(context.filesModified).toEqual([]);
-      expect(context.toolSummaries).toEqual([]);
-      expect(context.sessionNotes).toEqual({});
-    }
+    const nonArrayContext = await extractClineContext(sessionFor('cline', nonArrayPath));
+    expect(nonArrayContext.recentMessages).toEqual([]);
+    expect(nonArrayContext.pendingTasks).toEqual([]);
+    expect(nonArrayContext.filesModified).toEqual([]);
+    expect(nonArrayContext.toolSummaries).toEqual([]);
+    expect(nonArrayContext.sessionNotes?.fidelityWarnings).toEqual([
+      'ui_messages.json had unexpected shape (expected JSON array)',
+    ]);
   });
 
   it('discovers Cline tasks from JetBrains globalStorage directories', async () => {
@@ -669,5 +695,390 @@ describe('Cline-family parser hardening', () => {
       cwd: 'C:/Users/dev/projects/cli-continues',
       repo: 'projects/cli-continues',
     });
+  });
+
+  // ── IDE-fork storage discovery ──────────────────────────────────────────
+
+  it('discovers Cline tasks installed inside Cursor and Windsurf VS Code forks', async () => {
+    const home = makeHome();
+    // Cursor fork
+    writeTaskAtRoot(path.join(ideGlobalStorageBase(home, 'Cursor'), 'saoudrizwan.claude-dev', 'tasks'), 'cursor-task', [
+      { ts: 1770001000000, type: 'say', say: 'task', text: 'Discover from Cursor fork storage' },
+    ]);
+    // Windsurf fork
+    writeTaskAtRoot(
+      path.join(ideGlobalStorageBase(home, 'Windsurf'), 'saoudrizwan.claude-dev', 'tasks'),
+      'windsurf-task',
+      [{ ts: 1770001001000, type: 'say', say: 'task', text: 'Discover from Windsurf fork storage' }],
+    );
+    // Code Insiders fork (covers the third VS Code variant the parser scans)
+    writeTaskAtRoot(
+      path.join(ideGlobalStorageBase(home, 'Code - Insiders'), 'saoudrizwan.claude-dev', 'tasks'),
+      'insiders-task',
+      [{ ts: 1770001002000, type: 'say', say: 'task', text: 'Discover from VS Code Insiders' }],
+    );
+
+    const { parseClineSessions } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+
+    const ids = sessions.map((session) => session.id).sort();
+    expect(ids).toEqual(['cursor-task', 'insiders-task', 'windsurf-task']);
+    expect(sessions.every((session) => session.source === 'cline')).toBe(true);
+
+    const cursor = sessions.find((session) => session.id === 'cursor-task');
+    const windsurf = sessions.find((session) => session.id === 'windsurf-task');
+    const insiders = sessions.find((session) => session.id === 'insiders-task');
+    expect(cursor?.originalPath).toContain(path.join('Cursor'));
+    expect(windsurf?.originalPath).toContain(path.join('Windsurf'));
+    expect(insiders?.originalPath).toContain(path.join('Code - Insiders'));
+  });
+
+  it('does not duplicate tasks when the same task id exists across multiple IDE forks', async () => {
+    const home = makeHome();
+    // Same task id present in three forks with different summaries — each
+    // fork has its own globalStorage so the parser must surface all three
+    // distinct (storage-root, task-id) pairs, NOT collapse them. This is
+    // the ONLY surface where Cline tasks "appear" twice on disk; users who
+    // copied their saoudrizwan.claude-dev folder between IDE forks would
+    // legitimately see the same id in each fork.
+    writeTaskAtRoot(path.join(ideGlobalStorageBase(home, 'Code'), 'saoudrizwan.claude-dev', 'tasks'), 'shared-id', [
+      { ts: 1770001100000, type: 'say', say: 'task', text: 'task in VS Code' },
+    ]);
+    writeTaskAtRoot(path.join(ideGlobalStorageBase(home, 'Cursor'), 'saoudrizwan.claude-dev', 'tasks'), 'shared-id', [
+      { ts: 1770001101000, type: 'say', say: 'task', text: 'task in Cursor' },
+    ]);
+    writeTaskAtRoot(path.join(ideGlobalStorageBase(home, 'Windsurf'), 'saoudrizwan.claude-dev', 'tasks'), 'shared-id', [
+      { ts: 1770001102000, type: 'say', say: 'task', text: 'task in Windsurf' },
+    ]);
+
+    const { parseClineSessions } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+    const sharedSessions = sessions.filter((session) => session.id === 'shared-id');
+
+    expect(sharedSessions).toHaveLength(3);
+    const summaries = sharedSessions.map((session) => session.summary).sort();
+    expect(summaries).toEqual(['task in Cursor', 'task in VS Code', 'task in Windsurf']);
+    // originalPath includes the IDE folder name so resume can reach the
+    // right disk task even when ids collide.
+    const ides = sharedSessions
+      .map((session) => {
+        if (session.originalPath.includes(path.join('Cursor'))) return 'Cursor';
+        if (session.originalPath.includes(path.join('Windsurf'))) return 'Windsurf';
+        return 'Code';
+      })
+      .sort();
+    expect(ides).toEqual(['Code', 'Cursor', 'Windsurf']);
+  });
+
+  it('returns an empty list silently when no JetBrains plugin storage exists', async () => {
+    // Even with the JetBrains config root absent (no IDE installed), the
+    // parser must not throw or log an error path during discovery — it
+    // should just return zero sessions across all sources.
+    const home = makeHome();
+    expect(fs.existsSync(jetBrainsRoot(home))).toBe(false);
+
+    const { parseClineSessions, parseRooCodeSessions, parseKiloCodeSessions } = await loadClineParser(home);
+    expect(await parseClineSessions()).toEqual([]);
+    expect(await parseRooCodeSessions()).toEqual([]);
+    expect(await parseKiloCodeSessions()).toEqual([]);
+  });
+
+  // ── Per-tool summary categorization ─────────────────────────────────────
+
+  it('categorizes Cline read/write/search/list/MCP tool calls into structured summaries', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'tool-categories', [
+      { ts: 1770001200000, type: 'say', say: 'task', text: 'Exercise every tool category' },
+    ]);
+    writeCompanion(originalPath, 'api_conversation_history.json', [
+      {
+        role: 'user',
+        ts: 1770001200000,
+        content: [{ type: 'text', text: 'run all tools' }],
+      },
+      {
+        role: 'assistant',
+        ts: 1770001201000,
+        content: [
+          { type: 'tool_use', id: 't1', name: 'read_file', input: { path: 'src/index.ts' } },
+          { type: 'tool_use', id: 't2', name: 'write_to_file', input: { path: 'src/new.ts', content: 'hi' } },
+          { type: 'tool_use', id: 't3', name: 'search_files', input: { regex: 'TODO', path: 'src' } },
+          { type: 'tool_use', id: 't4', name: 'list_files', input: { path: 'src', recursive: true } },
+          { type: 'tool_use', id: 't5', name: 'list_code_definition_names', input: { path: 'src/parsers' } },
+          {
+            type: 'tool_use',
+            id: 't6',
+            name: 'use_mcp_tool',
+            input: { server_name: 'github', tool_name: 'list_issues', arguments: { repo: 'cline/cline' } },
+          },
+          { type: 'tool_use', id: 't7', name: 'apply_diff', input: { path: 'src/edit.ts', diff: 'patch' } },
+        ],
+      },
+      {
+        role: 'user',
+        ts: 1770001202000,
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: 'file contents' },
+          { type: 'tool_result', tool_use_id: 't2', content: 'wrote 1 file' },
+          { type: 'tool_result', tool_use_id: 't3', content: 'no TODOs' },
+          { type: 'tool_result', tool_use_id: 't4', content: '12 files' },
+          { type: 'tool_result', tool_use_id: 't5', content: 'parsers/* defs' },
+          { type: 'tool_result', tool_use_id: 't6', content: '0 issues' },
+          { type: 'tool_result', tool_use_id: 't7', content: '+1 -0 lines' },
+        ],
+      },
+    ]);
+
+    const { extractClineContext } = await loadClineParser(home);
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'tool-categories'));
+    const summariesByName = new Map(context.toolSummaries.map((summary) => [summary.name, summary]));
+
+    expect(summariesByName.get('read_file')?.samples[0].data?.category).toBe('read');
+    expect(summariesByName.get('read_file')?.samples[0].summary).toContain('src/index.ts');
+
+    expect(summariesByName.get('write_to_file')?.samples[0].data?.category).toBe('write');
+    expect(summariesByName.get('write_to_file')?.samples[0].summary).toContain('src/new.ts');
+
+    expect(summariesByName.get('search_files')?.samples[0].data?.category).toBe('grep');
+    expect(summariesByName.get('search_files')?.samples[0].summary).toContain('TODO');
+
+    expect(summariesByName.get('list_files')?.samples[0].data?.category).toBe('glob');
+    expect(summariesByName.get('list_code_definition_names')?.samples[0].data?.category).toBe('glob');
+
+    // apply_diff is a known edit verb in the parser — same category as replace_in_file.
+    expect(summariesByName.get('apply_diff')?.samples[0].data?.category).toBe('edit');
+    expect(summariesByName.get('apply_diff')?.samples[0].summary).toContain('src/edit.ts');
+
+    // Unknown / MCP-style tools fall through to the mcp category so handoff
+    // markdown can still describe them generically.
+    expect(summariesByName.get('use_mcp_tool')?.samples[0].data?.category).toBe('mcp');
+
+    // write_to_file and apply_diff both report file modifications.
+    expect([...context.filesModified].sort()).toEqual(['src/edit.ts', 'src/new.ts']);
+  });
+
+  // ── Token aggregation across canonical UI events ────────────────────────
+
+  it('sums per-event token usage across api_req_started, deleted_api_reqs, and subagent_usage', async () => {
+    // Mirrors upstream `getApiMetrics` (src/shared/getApiMetrics.ts): three
+    // canonical event kinds carry per-request token deltas. Earlier
+    // versions of the parser skipped `deleted_api_reqs` and
+    // `subagent_usage`, undercounting tasks that condensed history or
+    // used subagents.
+    const home = makeHome();
+    const originalPath = writeRawTask(home, 'saoudrizwan.claude-dev', 'usage-events', '');
+    fs.writeFileSync(
+      originalPath,
+      JSON.stringify([
+        { ts: 1770001300000, type: 'say', say: 'task', text: 'Aggregate every usage event' },
+        {
+          ts: 1770001301000,
+          type: 'say',
+          say: 'api_req_started',
+          text: JSON.stringify({ tokensIn: 100, tokensOut: 50, cacheWrites: 5, cacheReads: 10 }),
+        },
+        {
+          ts: 1770001302000,
+          type: 'say',
+          say: 'deleted_api_reqs',
+          text: JSON.stringify({ tokensIn: 200, tokensOut: 80, cacheWrites: 0, cacheReads: 20 }),
+        },
+        {
+          ts: 1770001303000,
+          type: 'say',
+          say: 'subagent_usage',
+          text: JSON.stringify({ tokensIn: 300, tokensOut: 120, cacheWrites: 10, cacheReads: 30 }),
+        },
+        // Unrelated event kinds carrying token-shaped JSON must NOT be summed.
+        {
+          ts: 1770001304000,
+          type: 'say',
+          say: 'api_req_finished',
+          text: JSON.stringify({ tokensIn: 999, tokensOut: 999, cacheWrites: 999, cacheReads: 999 }),
+        },
+      ]),
+      'utf8',
+    );
+
+    const { extractClineContext } = await loadClineParser(home);
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'usage-events'));
+
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 600, output: 250 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 15, read: 60 });
+  });
+
+  // ── Pending tasks from API history ──────────────────────────────────────
+
+  it('extracts pending tasks from the last assistant message in api_conversation_history.json', async () => {
+    // ui_messages.json has nothing pending; the parser must fall back to
+    // walking the API conversation backwards to find the last assistant
+    // message and pull TODO/Next-step lines.
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'api-pending', [
+      { ts: 1770001400000, type: 'say', say: 'task', text: 'Recover pending from API history' },
+    ]);
+    writeCompanion(originalPath, 'api_conversation_history.json', [
+      { role: 'user', ts: 1770001400000, content: [{ type: 'text', text: 'do work' }] },
+      {
+        role: 'assistant',
+        ts: 1770001401000,
+        content: [{ type: 'text', text: 'Almost done.\n- [ ] Review the diff\nNext step: open the PR' }],
+      },
+    ]);
+
+    const { extractClineContext } = await loadClineParser(home);
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'api-pending'));
+
+    expect(context.pendingTasks).toEqual(['- [ ] Review the diff', 'Next step: open the PR']);
+  });
+
+  // ── <environment_details> handling ──────────────────────────────────────
+
+  it('strips well-formed environment_details and tolerates missing close tags', async () => {
+    // Drive the test through API history (where the stripper actually runs
+    // on user messages) by leaving ui_messages.json malformed so
+    // `allConversation` falls back to apiConversation in extractContextShared.
+    const home = makeHome();
+    const originalPath = writeRawTask(home, 'saoudrizwan.claude-dev', 'env-details', '{not json');
+    writeCompanion(originalPath, 'api_conversation_history.json', [
+      {
+        role: 'user',
+        ts: 1770001500000,
+        content: [
+          {
+            type: 'text',
+            text: 'work please<environment_details>\n# Current Working Directory (/tmp/closed) Files\n</environment_details>',
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        ts: 1770001501000,
+        content: [{ type: 'text', text: 'on it' }],
+      },
+      {
+        role: 'user',
+        ts: 1770001502000,
+        // Malformed: the closing tag is missing. Stripper must NOT swallow
+        // the message — the regex is non-greedy and anchored on a real
+        // closing tag, so the content is kept verbatim.
+        content: [{ type: 'text', text: 'follow up<environment_details>\nnever closed' }],
+      },
+    ]);
+
+    const { extractClineContext } = await loadClineParser(home);
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'env-details'));
+    const userTexts = context.recentMessages.filter((m) => m.role === 'user').map((m) => m.content);
+
+    // First user turn: the well-formed env-details block is removed
+    // (leaving only "work please"). Second user turn keeps the malformed
+    // tag verbatim because there's nothing for the stripper to match.
+    expect(userTexts).toContain('work please');
+    expect(userTexts.some((text) => text.includes('never closed'))).toBe(true);
+    expect(userTexts.every((text) => !text.includes('Current Working Directory'))).toBe(true);
+  });
+
+  // ── Companion-file fidelity warnings ────────────────────────────────────
+
+  it('flags an unparseable api_conversation_history.json as a fidelity warning', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'api-broken', [
+      { ts: 1770001600000, type: 'say', say: 'task', text: 'API history is broken' },
+    ]);
+    fs.writeFileSync(path.join(taskDirFor(originalPath), 'api_conversation_history.json'), '{not json', 'utf8');
+
+    const { extractClineContext } = await loadClineParser(home);
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'api-broken'));
+
+    expect(context.sessionNotes?.fidelityWarnings).toEqual([
+      'api_conversation_history.json could not be parsed (invalid JSON)',
+    ]);
+  });
+
+  it('flags an unparseable task_metadata.json as a fidelity warning', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'metadata-broken', [
+      { ts: 1770001700000, type: 'say', say: 'task', text: 'Metadata is broken' },
+    ]);
+    fs.writeFileSync(path.join(taskDirFor(originalPath), 'task_metadata.json'), '{nope', 'utf8');
+
+    const { extractClineContext } = await loadClineParser(home);
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'metadata-broken'));
+
+    expect(context.sessionNotes?.fidelityWarnings).toContain('task_metadata.json could not be parsed (invalid JSON)');
+  });
+
+  it('flags an unparseable taskHistory.json as a fidelity warning while still parsing the task', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'history-broken', [
+      { ts: 1770001800000, type: 'say', say: 'task', text: 'History index is broken' },
+    ]);
+    const storageRoot = path.dirname(path.dirname(taskDirFor(originalPath)));
+    fs.mkdirSync(path.join(storageRoot, 'state'), { recursive: true });
+    fs.writeFileSync(path.join(storageRoot, 'state', 'taskHistory.json'), '{not history', 'utf8');
+
+    const { extractClineContext, parseClineSessions } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+
+    expect(sessions.find((session) => session.id === 'history-broken')).toBeDefined();
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'history-broken'));
+    expect(context.sessionNotes?.fidelityWarnings).toContain('taskHistory.json could not be parsed (invalid JSON)');
+  });
+
+  // ── taskHistory.json edge cases ─────────────────────────────────────────
+
+  it('gracefully handles taskHistory.json entries that do not match the current task id', async () => {
+    // The shared taskHistory.json index can carry stale entries, but a
+    // task-dir parse must only attach metadata for the matching id.
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'no-history-match', [
+      { ts: 1770001900000, type: 'say', say: 'task', text: 'No matching history entry' },
+    ]);
+    writeTaskHistory(originalPath, [
+      {
+        id: 'some-other-task',
+        ts: 1770001901000,
+        cwdOnTaskInitialization: '/tmp/wrong-cwd',
+        modelId: 'wrong-model',
+        tokensIn: 9999,
+        tokensOut: 9999,
+      },
+    ]);
+
+    const { parseClineSessions, extractClineContext } = await loadClineParser(home);
+    const sessions = await parseClineSessions();
+    const session = sessions.find((item) => item.id === 'no-history-match');
+
+    expect(session).toBeDefined();
+    expect(session?.cwd).toBe('');
+    expect(session?.model).toBeUndefined();
+
+    const context = await extractClineContext(sessionFor('cline', originalPath, 'no-history-match'));
+    expect(context.sessionNotes?.tokenUsage).toBeUndefined();
+    expect(context.sessionNotes?.cacheTokens).toBeUndefined();
+  });
+
+  it('honors the latest model_usage entry in task_metadata.json over earlier ones', async () => {
+    const home = makeHome();
+    const originalPath = writeTask(home, 'saoudrizwan.claude-dev', 'model-progression', [
+      { ts: 1770002000000, type: 'say', say: 'task', text: 'Model progressed mid-task' },
+    ]);
+    writeCompanion(originalPath, 'task_metadata.json', {
+      files_in_context: [],
+      environment_history: [],
+      model_usage: [
+        { ts: 1770002001000, model_id: 'claude-3-7-sonnet', model_provider_id: 'anthropic', mode: 'plan' },
+        { ts: 1770002002000, model_id: 'claude-4-opus', model_provider_id: 'anthropic', mode: 'act' },
+        { ts: 1770002003000, model_id: 'claude-4-7-opus-final', model_provider_id: 'anthropic', mode: 'act' },
+      ],
+    });
+
+    const { parseClineSessions, extractClineContext } = await loadClineParser(home);
+    const session = (await parseClineSessions()).find((item) => item.id === 'model-progression');
+
+    expect(session?.model).toBe('claude-4-7-opus-final');
+    const context = await extractClineContext(session!);
+    expect(context.session.model).toBe('claude-4-7-opus-final');
+    expect(context.sessionNotes?.model).toBe('claude-4-7-opus-final');
   });
 });

--- a/src/parsers/cline.ts
+++ b/src/parsers/cline.ts
@@ -148,6 +148,13 @@ interface LoadedTaskData {
   apiMessages: ClineApiMessage[];
   taskMetadata?: ClineTaskMetadata;
   taskHistoryItem?: ClineTaskHistoryItem;
+  /**
+   * Companion-file fidelity warnings. Populated when a companion file exists
+   * on disk but cannot be parsed (invalid JSON, wrong shape) so the caller
+   * can surface the downgrade in `sessionNotes.fidelityWarnings`. Missing
+   * files are NOT warnings — only present-but-broken files are.
+   */
+  fidelityWarnings: string[];
 }
 
 interface ToolResultEntry {
@@ -495,38 +502,61 @@ function normalizeTaskHistoryItem(value: unknown): ClineTaskHistoryItem | null {
   };
 }
 
-async function readJson(filePath: string, label: string): Promise<unknown | undefined> {
-  if (!(await pathExists(filePath))) return undefined;
+/**
+ * Companion-file read result. `warning` is set when the file existed but
+ * could not be parsed or had the wrong shape. Missing files produce no
+ * warning. The caller threads warnings into `sessionNotes.fidelityWarnings`.
+ */
+interface ReadResult<T> {
+  value: T;
+  warning?: string;
+}
+
+async function readJson(filePath: string, label: string): Promise<{ parsed?: unknown; warning?: string }> {
+  if (!(await pathExists(filePath))) return {};
   try {
-    return JSON.parse(await fs.readFile(filePath, 'utf8'));
+    return { parsed: JSON.parse(await fs.readFile(filePath, 'utf8')) };
   } catch (err) {
     logger.debug(`cline: failed to parse ${label}`, filePath, err);
-    return undefined;
+    return { warning: `${label} could not be parsed (invalid JSON)` };
   }
 }
 
-/** Read and parse ui_messages.json, returning an empty array on failure */
-async function readUiMessages(filePath: string): Promise<ClineRawMessage[]> {
-  if (!(await pathExists(filePath))) return [];
-  try {
-    const content = await fs.readFile(filePath, 'utf8');
-    const parsed = JSON.parse(content);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.map(normalizeRawMessage).filter((msg): msg is ClineRawMessage => msg !== null);
-  } catch (err) {
-    logger.debug('cline: failed to parse ui_messages.json', filePath, err);
-    return [];
+/** Read and parse ui_messages.json. Returns an empty array on failure. */
+async function readUiMessages(filePath: string): Promise<ReadResult<ClineRawMessage[]>> {
+  const { parsed, warning } = await readJson(filePath, UI_MESSAGES_FILE);
+  if (warning) return { value: [], warning };
+  if (parsed === undefined) return { value: [] };
+  if (!Array.isArray(parsed)) {
+    return {
+      value: [],
+      warning: `${UI_MESSAGES_FILE} had unexpected shape (expected JSON array)`,
+    };
   }
+  return {
+    value: parsed.map(normalizeRawMessage).filter((msg): msg is ClineRawMessage => msg !== null),
+  };
 }
 
-async function readApiConversationHistory(filePath: string): Promise<ClineApiMessage[]> {
-  const parsed = await readJson(filePath, API_CONVERSATION_HISTORY_FILE);
-  if (!Array.isArray(parsed)) return [];
-  return parsed.map(normalizeApiMessage).filter((message): message is ClineApiMessage => message !== null);
+async function readApiConversationHistory(filePath: string): Promise<ReadResult<ClineApiMessage[]>> {
+  const { parsed, warning } = await readJson(filePath, API_CONVERSATION_HISTORY_FILE);
+  if (warning) return { value: [], warning };
+  if (parsed === undefined) return { value: [] };
+  if (!Array.isArray(parsed)) {
+    return {
+      value: [],
+      warning: `${API_CONVERSATION_HISTORY_FILE} had unexpected shape (expected JSON array)`,
+    };
+  }
+  return {
+    value: parsed.map(normalizeApiMessage).filter((message): message is ClineApiMessage => message !== null),
+  };
 }
 
-async function readTaskMetadata(filePath: string): Promise<ClineTaskMetadata | undefined> {
-  return normalizeTaskMetadata(await readJson(filePath, TASK_METADATA_FILE));
+async function readTaskMetadata(filePath: string): Promise<ReadResult<ClineTaskMetadata | undefined>> {
+  const { parsed, warning } = await readJson(filePath, TASK_METADATA_FILE);
+  if (warning) return { value: undefined, warning };
+  return { value: normalizeTaskMetadata(parsed) };
 }
 
 function taskHistoryArray(value: unknown): unknown[] {
@@ -538,19 +568,30 @@ function taskHistoryArray(value: unknown): unknown[] {
   return [];
 }
 
-async function readTaskHistoryMap(paths: string[]): Promise<TaskHistoryMap> {
+interface TaskHistoryReadResult {
+  map: TaskHistoryMap;
+  warnings: string[];
+}
+
+async function readTaskHistoryMap(paths: string[]): Promise<TaskHistoryReadResult> {
   const itemsById: TaskHistoryMap = new Map();
+  const warnings: string[] = [];
   for (const filePath of paths) {
-    const parsed = await readJson(filePath, TASK_HISTORY_FILE);
+    const { parsed, warning } = await readJson(filePath, TASK_HISTORY_FILE);
+    if (warning) warnings.push(warning);
     for (const item of taskHistoryArray(parsed).map(normalizeTaskHistoryItem)) {
       if (item && !itemsById.has(item.id)) itemsById.set(item.id, item);
     }
   }
-  return itemsById;
+  return { map: itemsById, warnings };
 }
 
-async function readTaskHistoryItem(paths: string[], taskId: string): Promise<ClineTaskHistoryItem | undefined> {
-  return (await readTaskHistoryMap(paths)).get(taskId);
+async function readTaskHistoryItem(
+  paths: string[],
+  taskId: string,
+): Promise<{ item?: ClineTaskHistoryItem; warnings: string[] }> {
+  const { map, warnings } = await readTaskHistoryMap(paths);
+  return { item: map.get(taskId), warnings };
 }
 
 function taskHistoryCandidatesFromStorageRoot(storageRoot: string): string[] {
@@ -581,19 +622,36 @@ async function loadTaskData(
   taskDir: string,
   storageRoot: string,
   taskId: string,
-  taskHistoryById?: TaskHistoryMap,
+  cachedHistory?: TaskHistoryReadResult,
 ): Promise<LoadedTaskData> {
   const files = taskFilesFromDir(taskDir, storageRoot);
-  const [uiMessages, apiMessages, taskMetadata, taskHistoryItem] = await Promise.all([
+  const [uiResult, apiResult, metadataResult, historyResult] = await Promise.all([
     readUiMessages(files.uiMessages),
     readApiConversationHistory(files.apiConversationHistory),
     readTaskMetadata(files.taskMetadata),
-    taskHistoryById
-      ? Promise.resolve(taskHistoryById.get(taskId))
+    cachedHistory
+      ? Promise.resolve({ item: cachedHistory.map.get(taskId), warnings: cachedHistory.warnings })
       : readTaskHistoryItem(files.taskHistoryCandidates, taskId),
   ]);
 
-  return { files, uiMessages, apiMessages, taskMetadata, taskHistoryItem };
+  const fidelityWarnings: string[] = [];
+  if (uiResult.warning) fidelityWarnings.push(uiResult.warning);
+  if (apiResult.warning) fidelityWarnings.push(apiResult.warning);
+  if (metadataResult.warning) fidelityWarnings.push(metadataResult.warning);
+  // taskHistory warnings are de-duplicated because the cached result may be
+  // shared across sibling tasks under the same storage root.
+  for (const warning of historyResult.warnings) {
+    if (!fidelityWarnings.includes(warning)) fidelityWarnings.push(warning);
+  }
+
+  return {
+    files,
+    uiMessages: uiResult.value,
+    apiMessages: apiResult.value,
+    taskMetadata: metadataResult.value,
+    taskHistoryItem: historyResult.item,
+    fidelityWarnings,
+  };
 }
 
 async function loadTaskDataFromOriginalPath(originalPath: string, taskId: string): Promise<LoadedTaskData> {
@@ -815,8 +873,24 @@ function buildConversation(messages: ClineRawMessage[]): ConversationMessage[] {
 // ── Token / Cost Extraction ─────────────────────────────────────────────────
 
 /**
- * Aggregate token usage and cost from api_req_started events.
- * Each event's text field contains a JSON object with token counts.
+ * Cline-canonical usage events. Mirrors upstream `getApiMetrics`
+ * (src/shared/getApiMetrics.ts), which iterates these three event kinds and
+ * sums their per-request `tokensIn / tokensOut / cacheWrites / cacheReads`
+ * fields:
+ *   - `api_req_started` — current per-request usage (post-finalization)
+ *   - `deleted_api_reqs` — aggregated usage from history truncation
+ *   - `subagent_usage`  — aggregated usage from subagent batches
+ *
+ * `api_req_finished` is intentionally excluded: upstream comments call it
+ * "legacy" and it's no longer emitted; including it would double-count old
+ * tasks where both events exist with the same per-request fields.
+ */
+const TOKEN_USAGE_SAYS = new Set(['api_req_started', 'deleted_api_reqs', 'subagent_usage']);
+
+/**
+ * Aggregate token usage from Cline UI events. Reads per-request deltas from
+ * `api_req_started`, plus aggregated deltas from `deleted_api_reqs` and
+ * `subagent_usage`, matching upstream `getApiMetrics` exactly.
  */
 function extractTokenUsage(messages: ClineRawMessage[]): SessionNotes {
   const notes: SessionNotes = {};
@@ -826,11 +900,8 @@ function extractTokenUsage(messages: ClineRawMessage[]): SessionNotes {
   let totalCacheReads = 0;
   let found = false;
 
-  // Only sum per-request `api_req_started` events. `api_req_finished` carries
-  // running cumulative totals (`totalTokensIn` etc.), so summing both produces
-  // O(n^2)-style inflated counts — see PR #57 review thread on token usage.
   for (const msg of messages) {
-    if (msg.type !== 'say' || msg.say !== 'api_req_started') continue;
+    if (msg.type !== 'say' || !msg.say || !TOKEN_USAGE_SAYS.has(msg.say)) continue;
     if (!msg.text) continue;
 
     try {
@@ -925,6 +996,28 @@ function extractUsageFromApiHistory(messages: ClineApiMessage[]): SessionNotes {
   return notes;
 }
 
+/**
+ * Resolve token usage notes for a task.
+ *
+ * Precedence (highest first):
+ *   1. `taskHistory.json` `{tokensIn, tokensOut, cacheWrites, cacheReads}` —
+ *      Cline writes the canonical *post-finalization* totals here. Used
+ *      first because it's the same number Cline shows in its history UI.
+ *   2. `api_conversation_history.json` per-message `metrics.tokens` /
+ *      `metrics.tokensIn` — Cline records per-API-turn telemetry on each
+ *      assistant message. Summing these reproduces (1) for tasks where (1)
+ *      hasn't been written yet, and avoids the third source.
+ *   3. `ui_messages.json` per-event aggregation — sums per-request deltas
+ *      from `api_req_started` plus aggregated deltas from
+ *      `deleted_api_reqs` and `subagent_usage`, mirroring upstream
+ *      `getApiMetrics`. Used last because it requires reading the UI log,
+ *      which is the largest of the three companion files.
+ *
+ * The three sources are mutually consistent in current Cline; precedence
+ * picks the cheapest source available, not the "best" number. Because a
+ * single source is chosen, the totals are never double-counted across
+ * UI/API/history.
+ */
 function chooseUsageNotes(data: LoadedTaskData): SessionNotes {
   const fromHistory = extractUsageFromTaskHistory(data.taskHistoryItem);
   if (fromHistory.tokenUsage || fromHistory.cacheTokens) return fromHistory;
@@ -1058,6 +1151,27 @@ function extractModelFromUiMessages(messages: ClineRawMessage[]): string | undef
   return model;
 }
 
+/**
+ * Resolve the active model id for a task.
+ *
+ * Precedence (highest first):
+ *   1. `task_metadata.json` `model_usage` (last entry) — Cline writes a new
+ *      entry every time the user picks a model, so the tail is the latest
+ *      authoritative choice.
+ *   2. `taskHistory.json` `modelId` — Cline updates this index as the task
+ *      progresses; the value reflects the model at last activity.
+ *   3. `api_conversation_history.json` `modelInfo.modelId` — observed model
+ *      on the most recent API turn. Cline persists this on every assistant
+ *      message but it can drift if the user switches mid-task.
+ *   4. `ui_messages.json` `modelInfo.modelId` — same observation surface as
+ *      (3) but in UI form. Used last because it can include UI-only state
+ *      that wasn't actually committed to the API conversation.
+ *
+ * The first three sources are all equally trustworthy for steady-state
+ * tasks; the precedence matters only at the moment the user changes models
+ * mid-task before metadata is flushed. In that race, (2) and (3) may
+ * disagree with (1) and we trust the metadata file as the canonical source.
+ */
 function resolveModel(data: LoadedTaskData): string | undefined {
   return (
     extractModelFromMetadata(data.taskMetadata) ??
@@ -1351,19 +1465,22 @@ function messageTimestamps(data: LoadedTaskData): number[] {
  */
 async function parseSessionsForSource(filterSource?: ClineSource): Promise<UnifiedSession[]> {
   const taskEntries = await discoverTaskDirs(filterSource);
-  const taskHistoryCache = new Map<string, Promise<TaskHistoryMap>>();
+  // Per-call cache. Shared across sessions under the same `storageRoot` so
+  // `taskHistory.json` is read once per discovery pass; new calls always
+  // re-read so live edits to taskHistory.json take effect immediately.
+  const taskHistoryCache = new Map<string, Promise<TaskHistoryReadResult>>();
   const sessions: UnifiedSession[] = [];
 
   for (const { taskDir, taskId, storageRoot, source } of taskEntries) {
     try {
       const storageRootKey = path.resolve(storageRoot);
-      let taskHistoryById = taskHistoryCache.get(storageRootKey);
-      if (!taskHistoryById) {
-        taskHistoryById = readTaskHistoryMap(taskHistoryCandidatesFromStorageRoot(storageRoot));
-        taskHistoryCache.set(storageRootKey, taskHistoryById);
+      let cachedHistory = taskHistoryCache.get(storageRootKey);
+      if (!cachedHistory) {
+        cachedHistory = readTaskHistoryMap(taskHistoryCandidatesFromStorageRoot(storageRoot));
+        taskHistoryCache.set(storageRootKey, cachedHistory);
       }
 
-      const data = await loadTaskData(taskDir, storageRoot, taskId, await taskHistoryById);
+      const data = await loadTaskData(taskDir, storageRoot, taskId, await cachedHistory);
       if (data.uiMessages.length === 0 && data.apiMessages.length === 0 && !data.taskHistoryItem) continue;
 
       const firstUserMsg =
@@ -1432,18 +1549,34 @@ async function extractContextShared(session: UnifiedSession, config?: VerbosityC
   const model = resolveModel(data);
   if (model) sessionNotes.model = model;
 
+  if (data.fidelityWarnings.length > 0) {
+    sessionNotes.fidelityWarnings = [...data.fidelityWarnings];
+  }
+
   // Extract reasoning highlights
   const uiReasoning = extractReasoning(data.uiMessages, cfg.thinking?.maxHighlights ?? 5);
   const reasoning =
     uiReasoning.length > 0 ? uiReasoning : extractApiReasoning(data.apiMessages, cfg.thinking?.maxHighlights ?? 5);
   if (reasoning.length > 0) sessionNotes.reasoning = reasoning;
 
-  // Extract pending tasks
-  const pendingTasksFromUi = extractPendingTasks(data.uiMessages, cfg.pendingTasks?.maxTasks ?? 5);
-  const pendingTasks =
+  // Extract pending tasks. Three layers in order:
+  //   1. UI events (`completion_result` / `text`) — preserves the exact
+  //      assistant statement Cline rendered to the user.
+  //   2. UI-conversation tail — covers tasks where the assistant text is
+  //      structured but not on a `completion_result` event.
+  //   3. API-conversation tail — covers tasks where ui_messages.json is
+  //      thin or malformed but api_conversation_history.json is intact.
+  // Each layer is tried only when the previous one returned no hits.
+  const maxPendingTasks = cfg.pendingTasks?.maxTasks ?? 5;
+  const pendingTasksFromUi = extractPendingTasks(data.uiMessages, maxPendingTasks);
+  const pendingTasksFromAllConversation =
     pendingTasksFromUi.length > 0
       ? pendingTasksFromUi
-      : extractPendingTasksFromConversation(allConversation, cfg.pendingTasks?.maxTasks ?? 5);
+      : extractPendingTasksFromConversation(allConversation, maxPendingTasks);
+  const pendingTasks =
+    pendingTasksFromAllConversation.length > 0 || allConversation === apiConversation
+      ? pendingTasksFromAllConversation
+      : extractPendingTasksFromConversation(apiConversation, maxPendingTasks);
 
   const toolData =
     data.apiMessages.length > 0 ? extractApiToolData(data.apiMessages, cfg) : { summaries: [], filesModified: [] };

--- a/src/parsers/cline.ts
+++ b/src/parsers/cline.ts
@@ -1,13 +1,28 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type { ConversationMessage, SessionContext, SessionNotes, UnifiedSession } from '../types/index.js';
-import type { SessionSource } from '../types/tool-names.js';
+import type {
+  ConversationMessage,
+  SessionContext,
+  SessionNotes,
+  ToolCall,
+  ToolUsageSummary,
+  UnifiedSession,
+} from '../types/index.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
-import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
-import { truncate } from '../utils/tool-summarizer.js';
+import { cleanSummary, extractRepoFromCwd, homeDir } from '../utils/parser-helpers.js';
+import {
+  fileSummary,
+  globSummary,
+  grepSummary,
+  mcpSummary,
+  SummaryCollector,
+  shellSummary,
+  truncate,
+  withResult,
+} from '../utils/tool-summarizer.js';
 
 // ── Extension Configs ───────────────────────────────────────────────────────
 
@@ -24,26 +39,123 @@ const CLINE_EXTENSIONS = [
 
 type ClineSource = (typeof CLINE_EXTENSIONS)[number]['source'];
 
+const UI_MESSAGES_FILE = 'ui_messages.json';
+const API_CONVERSATION_HISTORY_FILE = 'api_conversation_history.json';
+const TASK_METADATA_FILE = 'task_metadata.json';
+const TASK_HISTORY_FILE = 'taskHistory.json';
+const TASK_SIGNAL_FILES = [UI_MESSAGES_FILE, API_CONVERSATION_HISTORY_FILE, TASK_METADATA_FILE] as const;
+
 // ── Raw Message Shape ───────────────────────────────────────────────────────
 
 /** Single entry in ui_messages.json */
 interface ClineRawMessage {
-  ts: number;
+  ts?: number;
   type: string;
   say?: string;
   ask?: string;
   text?: string;
+  reasoning?: string;
   images?: string[];
+  files?: string[];
   partial?: boolean;
+  modelInfo?: ClineModelInfo;
 }
 
-/** Token metadata parsed from api_req_started text field */
-interface ApiReqMeta {
+type ConversationRole = 'user' | 'assistant';
+
+interface ConversationState {
+  hasSeenApiRequest: boolean;
+}
+
+interface StreamState {
+  index: number;
+  role: ConversationRole;
+  kind: string;
+}
+
+interface ClineModelInfo {
+  modelId?: string;
+  providerId?: string;
+  mode?: string;
+}
+
+interface ClineApiContentBlock {
+  type: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+}
+
+interface ClineApiMessage {
+  id?: string;
+  role: ConversationRole;
+  content: string | ClineApiContentBlock[];
+  ts?: number;
+  modelInfo?: ClineModelInfo;
+  metrics?: Record<string, unknown>;
+}
+
+interface ClineTaskMetadata {
+  model_usage?: Array<Record<string, unknown>>;
+  files_in_context?: Array<Record<string, unknown>>;
+  environment_history?: Array<Record<string, unknown>>;
+}
+
+interface ClineTaskHistoryItem {
+  id: string;
+  ts?: number;
+  task?: string;
   tokensIn?: number;
   tokensOut?: number;
   cacheWrites?: number;
   cacheReads?: number;
-  cost?: number;
+  cwdOnTaskInitialization?: string;
+  modelId?: string;
+}
+
+interface TaskRoot {
+  tasksRoot: string;
+  storageRoot: string;
+  source: ClineSource;
+}
+
+interface TaskEntry {
+  taskDir: string;
+  taskId: string;
+  storageRoot: string;
+  source: ClineSource;
+}
+
+interface TaskFiles {
+  taskDir: string;
+  storageRoot: string;
+  uiMessages: string;
+  apiConversationHistory: string;
+  taskMetadata: string;
+  taskHistoryCandidates: string[];
+}
+
+interface LoadedTaskData {
+  files: TaskFiles;
+  uiMessages: ClineRawMessage[];
+  apiMessages: ClineApiMessage[];
+  taskMetadata?: ClineTaskMetadata;
+  taskHistoryItem?: ClineTaskHistoryItem;
+}
+
+interface ToolResultEntry {
+  text: string;
+  isError: boolean;
+}
+
+interface ToolData {
+  summaries: ToolUsageSummary[];
+  filesModified: string[];
 }
 
 // ── Path Discovery ──────────────────────────────────────────────────────────
@@ -69,6 +181,7 @@ function getGlobalStorageBases(): string[] {
       path.join(home, '.config', 'Code', 'User', 'globalStorage'),
       path.join(home, '.config', 'Code - Insiders', 'User', 'globalStorage'),
       path.join(home, '.config', 'Cursor', 'User', 'globalStorage'),
+      path.join(home, '.config', 'Windsurf', 'User', 'globalStorage'),
     );
   } else if (process.platform === 'win32') {
     const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
@@ -76,40 +189,158 @@ function getGlobalStorageBases(): string[] {
       path.join(appData, 'Code', 'User', 'globalStorage'),
       path.join(appData, 'Code - Insiders', 'User', 'globalStorage'),
       path.join(appData, 'Cursor', 'User', 'globalStorage'),
+      path.join(appData, 'Windsurf', 'User', 'globalStorage'),
     );
   }
 
   return bases;
 }
 
+function getJetBrainsRoots(): string[] {
+  const home = homeDir();
+
+  if (process.platform === 'darwin') {
+    return [path.join(home, 'Library', 'Application Support', 'JetBrains')];
+  }
+
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    return [path.join(appData, 'JetBrains')];
+  }
+
+  return [path.join(home, '.config', 'JetBrains')];
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function uniquePaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const results: string[] = [];
+  for (const filePath of paths) {
+    const resolved = path.resolve(filePath);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    results.push(filePath);
+  }
+  return results;
+}
+
+async function findDirsNamed(root: string, dirName: string, maxDepth: number): Promise<string[]> {
+  const found: string[] = [];
+
+  async function walk(current: string, depth: number): Promise<void> {
+    if (depth > maxDepth) return;
+
+    let entries: Array<{ name: string; isDirectory: () => boolean }>;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch (err) {
+      logger.debug(`cline: cannot scan ${current}`, err);
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const child = path.join(current, entry.name);
+      if (entry.name === dirName) {
+        found.push(child);
+        continue;
+      }
+      await walk(child, depth + 1);
+    }
+  }
+
+  if (await pathExists(root)) await walk(root, 0);
+  return found;
+}
+
+async function getJetBrainsGlobalStorageBases(): Promise<string[]> {
+  const bases: string[] = [];
+  for (const root of getJetBrainsRoots()) {
+    bases.push(...(await findDirsNamed(root, 'globalStorage', 3)));
+  }
+  return uniquePaths(bases);
+}
+
+function getClineCliStorageRoots(): string[] {
+  const roots: string[] = [];
+  const clineDir = process.env.CLINE_DIR;
+  if (clineDir) roots.push(path.join(clineDir, 'data'));
+  roots.push(path.join(homeDir(), '.cline', 'data'));
+  return uniquePaths(roots);
+}
+
+async function getTaskRoots(filterSource?: ClineSource): Promise<TaskRoot[]> {
+  const roots: TaskRoot[] = [];
+
+  if (!filterSource || filterSource === 'cline') {
+    for (const storageRoot of getClineCliStorageRoots()) {
+      roots.push({
+        tasksRoot: path.join(storageRoot, 'tasks'),
+        storageRoot,
+        source: 'cline',
+      });
+    }
+  }
+
+  const globalStorageBases = uniquePaths([...getGlobalStorageBases(), ...(await getJetBrainsGlobalStorageBases())]);
+  for (const base of globalStorageBases) {
+    for (const ext of CLINE_EXTENSIONS) {
+      if (filterSource && ext.source !== filterSource) continue;
+      const storageRoot = path.join(base, ext.id);
+      roots.push({
+        tasksRoot: path.join(storageRoot, 'tasks'),
+        storageRoot,
+        source: ext.source,
+      });
+    }
+  }
+
+  const seen = new Set<string>();
+  return roots.filter((root) => {
+    const key = `${root.source}:${path.resolve(root.tasksRoot)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+async function taskHasReadableData(taskDir: string): Promise<boolean> {
+  for (const fileName of TASK_SIGNAL_FILES) {
+    if (await pathExists(path.join(taskDir, fileName))) return true;
+  }
+  return false;
+}
+
 /**
  * Discover all task directories for a given extension across all IDE locations.
  * Returns tuples of (task-id directory path, extension source label).
  */
-function discoverTaskDirs(): Array<{ taskDir: string; taskId: string; source: ClineSource }> {
-  const bases = getGlobalStorageBases();
-  const results: Array<{ taskDir: string; taskId: string; source: ClineSource }> = [];
+async function discoverTaskDirs(filterSource?: ClineSource): Promise<TaskEntry[]> {
+  const taskRoots = await getTaskRoots(filterSource);
+  const results: TaskEntry[] = [];
 
-  for (const base of bases) {
-    if (!fs.existsSync(base)) continue;
+  for (const { tasksRoot, storageRoot, source } of taskRoots) {
+    if (!(await pathExists(tasksRoot))) continue;
 
-    for (const ext of CLINE_EXTENSIONS) {
-      const tasksRoot = path.join(base, ext.id, 'tasks');
-      if (!fs.existsSync(tasksRoot)) continue;
-
-      try {
-        const entries = fs.readdirSync(tasksRoot, { withFileTypes: true });
-        for (const entry of entries) {
-          if (!entry.isDirectory()) continue;
-          const taskDir = path.join(tasksRoot, entry.name);
-          const uiFile = path.join(taskDir, 'ui_messages.json');
-          if (fs.existsSync(uiFile)) {
-            results.push({ taskDir, taskId: entry.name, source: ext.source });
-          }
+    try {
+      const entries = await fs.readdir(tasksRoot, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const taskDir = path.join(tasksRoot, entry.name);
+        if (await taskHasReadableData(taskDir)) {
+          results.push({ taskDir, taskId: entry.name, storageRoot, source });
         }
-      } catch (err) {
-        logger.debug(`cline: cannot read tasks dir ${tasksRoot}`, err);
       }
+    } catch (err) {
+      logger.debug(`cline: cannot read tasks dir ${tasksRoot}`, err);
     }
   }
 
@@ -118,38 +349,373 @@ function discoverTaskDirs(): Array<{ taskDir: string; taskId: string; source: Cl
 
 // ── Message Parsing ─────────────────────────────────────────────────────────
 
-/** Read and parse ui_messages.json, returning an empty array on failure */
-function readUiMessages(filePath: string): ClineRawMessage[] {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readBoolean(record: Record<string, unknown>, key: string): boolean | undefined {
+  const value = record[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function readStringArray(record: Record<string, unknown>, key: string): string[] | undefined {
+  const value = record[key];
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((item): item is string => typeof item === 'string');
+  return strings.length > 0 ? strings : undefined;
+}
+
+function readRecord(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function normalizeModelInfo(value: unknown): ClineModelInfo | undefined {
+  if (!isRecord(value)) return undefined;
+  const modelId = readString(value, 'modelId') ?? readString(value, 'model_id');
+  const providerId = readString(value, 'providerId') ?? readString(value, 'model_provider_id');
+  const mode = readString(value, 'mode');
+  if (!modelId && !providerId && !mode) return undefined;
+  return { modelId, providerId, mode };
+}
+
+function normalizeRawMessage(value: unknown): ClineRawMessage | null {
+  if (!isRecord(value)) return null;
+
+  const type = readString(value, 'type');
+  if (!type) return null;
+
+  return {
+    type,
+    ts: readNumber(value, 'ts'),
+    say: readString(value, 'say'),
+    ask: readString(value, 'ask'),
+    text: readString(value, 'text'),
+    reasoning: readString(value, 'reasoning'),
+    images: readStringArray(value, 'images'),
+    files: readStringArray(value, 'files'),
+    partial: readBoolean(value, 'partial'),
+    modelInfo: normalizeModelInfo(value.modelInfo),
+  };
+}
+
+function normalizeApiContentBlock(value: unknown): ClineApiContentBlock | null {
+  if (!isRecord(value)) return null;
+  const type = readString(value, 'type');
+  if (!type) return null;
+
+  return {
+    type,
+    text: readString(value, 'text'),
+    thinking: readString(value, 'thinking'),
+    id: readString(value, 'id'),
+    name: readString(value, 'name'),
+    input: readRecord(value, 'input'),
+    tool_use_id: readString(value, 'tool_use_id'),
+    content: value.content,
+    is_error: readBoolean(value, 'is_error'),
+  };
+}
+
+function normalizeApiMessage(value: unknown): ClineApiMessage | null {
+  if (!isRecord(value)) return null;
+  const rawRole = readString(value, 'role');
+  if (rawRole !== 'user' && rawRole !== 'assistant') return null;
+
+  const rawContent = value.content;
+  let content: ClineApiMessage['content'] | undefined;
+  if (typeof rawContent === 'string') {
+    content = rawContent;
+  } else if (Array.isArray(rawContent)) {
+    const blocks = rawContent
+      .map(normalizeApiContentBlock)
+      .filter((block): block is ClineApiContentBlock => block !== null);
+    content = blocks;
+  }
+
+  if (content === undefined) return null;
+
+  return {
+    id: readString(value, 'id'),
+    role: rawRole,
+    content,
+    ts: readNumber(value, 'ts'),
+    modelInfo: normalizeModelInfo(value.modelInfo),
+    metrics: readRecord(value, 'metrics'),
+  };
+}
+
+function normalizeTaskMetadata(value: unknown): ClineTaskMetadata | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const readRecordArray = (key: string): Array<Record<string, unknown>> | undefined => {
+    const raw = value[key];
+    if (!Array.isArray(raw)) return undefined;
+    const records = raw.filter(isRecord);
+    return records.length > 0 ? records : undefined;
+  };
+
+  return {
+    model_usage: readRecordArray('model_usage'),
+    files_in_context: readRecordArray('files_in_context'),
+    environment_history: readRecordArray('environment_history'),
+  };
+}
+
+function normalizeTaskHistoryItem(value: unknown): ClineTaskHistoryItem | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value, 'id');
+  if (!id) return null;
+
+  return {
+    id,
+    ts: readNumber(value, 'ts'),
+    task: readString(value, 'task'),
+    tokensIn: readNumber(value, 'tokensIn'),
+    tokensOut: readNumber(value, 'tokensOut'),
+    cacheWrites: readNumber(value, 'cacheWrites'),
+    cacheReads: readNumber(value, 'cacheReads'),
+    cwdOnTaskInitialization: readString(value, 'cwdOnTaskInitialization'),
+    modelId: readString(value, 'modelId'),
+  };
+}
+
+async function readJson(filePath: string, label: string): Promise<unknown | undefined> {
+  if (!(await pathExists(filePath))) return undefined;
   try {
-    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(await fs.readFile(filePath, 'utf8'));
+  } catch (err) {
+    logger.debug(`cline: failed to parse ${label}`, filePath, err);
+    return undefined;
+  }
+}
+
+/** Read and parse ui_messages.json, returning an empty array on failure */
+async function readUiMessages(filePath: string): Promise<ClineRawMessage[]> {
+  if (!(await pathExists(filePath))) return [];
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
     const parsed = JSON.parse(content);
     if (!Array.isArray(parsed)) return [];
-    return parsed as ClineRawMessage[];
+    return parsed.map(normalizeRawMessage).filter((msg): msg is ClineRawMessage => msg !== null);
   } catch (err) {
     logger.debug('cline: failed to parse ui_messages.json', filePath, err);
     return [];
   }
 }
 
+async function readApiConversationHistory(filePath: string): Promise<ClineApiMessage[]> {
+  const parsed = await readJson(filePath, API_CONVERSATION_HISTORY_FILE);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map(normalizeApiMessage).filter((message): message is ClineApiMessage => message !== null);
+}
+
+async function readTaskMetadata(filePath: string): Promise<ClineTaskMetadata | undefined> {
+  return normalizeTaskMetadata(await readJson(filePath, TASK_METADATA_FILE));
+}
+
+function taskHistoryArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (isRecord(value)) {
+    const taskHistory = value.taskHistory ?? value.history ?? value.items;
+    if (Array.isArray(taskHistory)) return taskHistory;
+  }
+  return [];
+}
+
+async function readTaskHistoryItem(paths: string[], taskId: string): Promise<ClineTaskHistoryItem | undefined> {
+  for (const filePath of paths) {
+    const parsed = await readJson(filePath, TASK_HISTORY_FILE);
+    const items = taskHistoryArray(parsed).map(normalizeTaskHistoryItem);
+    const item = items.find((entry): entry is ClineTaskHistoryItem => entry !== null && entry.id === taskId);
+    if (item) return item;
+  }
+  return undefined;
+}
+
+function taskFilesFromDir(taskDir: string, storageRoot: string): TaskFiles {
+  return {
+    taskDir,
+    storageRoot,
+    uiMessages: path.join(taskDir, UI_MESSAGES_FILE),
+    apiConversationHistory: path.join(taskDir, API_CONVERSATION_HISTORY_FILE),
+    taskMetadata: path.join(taskDir, TASK_METADATA_FILE),
+    taskHistoryCandidates: [
+      path.join(storageRoot, 'state', TASK_HISTORY_FILE),
+      path.join(storageRoot, TASK_HISTORY_FILE),
+    ],
+  };
+}
+
+function inferTaskDirFromOriginalPath(originalPath: string): string {
+  return path.extname(originalPath) === '.json' ? path.dirname(originalPath) : originalPath;
+}
+
+function inferStorageRootFromTaskDir(taskDir: string): string {
+  const parent = path.dirname(taskDir);
+  return path.basename(parent) === 'tasks' ? path.dirname(parent) : parent;
+}
+
+async function loadTaskData(taskDir: string, storageRoot: string, taskId: string): Promise<LoadedTaskData> {
+  const files = taskFilesFromDir(taskDir, storageRoot);
+  const [uiMessages, apiMessages, taskMetadata, taskHistoryItem] = await Promise.all([
+    readUiMessages(files.uiMessages),
+    readApiConversationHistory(files.apiConversationHistory),
+    readTaskMetadata(files.taskMetadata),
+    readTaskHistoryItem(files.taskHistoryCandidates, taskId),
+  ]);
+
+  return { files, uiMessages, apiMessages, taskMetadata, taskHistoryItem };
+}
+
+async function loadTaskDataFromOriginalPath(originalPath: string, taskId: string): Promise<LoadedTaskData> {
+  const taskDir = inferTaskDirFromOriginalPath(originalPath);
+  return loadTaskData(taskDir, inferStorageRootFromTaskDir(taskDir), taskId);
+}
+
+function messageText(msg: ClineRawMessage): string | undefined {
+  return msg.say === 'reasoning' ? (msg.reasoning ?? msg.text) : msg.text;
+}
+
+function apiContentBlocks(content: ClineApiMessage['content']): ClineApiContentBlock[] {
+  return Array.isArray(content) ? content : [];
+}
+
+function apiMessageText(message: ClineApiMessage): string {
+  if (typeof message.content === 'string') return message.content.trim();
+
+  const parts: string[] = [];
+  for (const block of message.content) {
+    if (block.type === 'text' && block.text) parts.push(block.text);
+    if (block.type === 'thinking' && block.thinking) parts.push(block.thinking);
+  }
+  return parts.join('\n').trim();
+}
+
+function extractToolResultText(block: ClineApiContentBlock): string {
+  if (typeof block.content === 'string') return block.content;
+  if (!Array.isArray(block.content)) return '';
+
+  const parts: string[] = [];
+  for (const item of block.content) {
+    if (!isRecord(item)) continue;
+    const type = readString(item, 'type');
+    const text = readString(item, 'text');
+    if (type === 'text' && text) parts.push(text);
+  }
+  return parts.join('\n');
+}
+
+function getToolResultMap(messages: ClineApiMessage[]): Map<string, ToolResultEntry> {
+  const results = new Map<string, ToolResultEntry>();
+  for (const message of messages) {
+    for (const block of apiContentBlocks(message.content)) {
+      if (block.type !== 'tool_result' || !block.tool_use_id) continue;
+      results.set(block.tool_use_id, {
+        text: extractToolResultText(block),
+        isError: block.is_error === true,
+      });
+    }
+  }
+  return results;
+}
+
+function buildApiConversation(messages: ClineApiMessage[], config: VerbosityConfig): ConversationMessage[] {
+  const resultMap = getToolResultMap(messages);
+  const conversation: ConversationMessage[] = [];
+
+  for (const message of messages) {
+    const text = message.role === 'user' ? stripEnvironmentDetails(apiMessageText(message)) : apiMessageText(message);
+    const toolCalls: ToolCall[] = [];
+    const hasNonToolResultContent = typeof message.content === 'string' || text.length > 0;
+
+    for (const block of apiContentBlocks(message.content)) {
+      if (block.type !== 'tool_use' || !block.name) continue;
+      const resultEntry = block.id ? resultMap.get(block.id) : undefined;
+      toolCalls.push({
+        name: block.name,
+        id: block.id,
+        arguments: block.input ?? {},
+        ...(resultEntry?.text ? { result: truncate(resultEntry.text, config.mcp.resultChars) } : {}),
+        ...(resultEntry ? { success: !resultEntry.isError } : {}),
+      });
+    }
+
+    if (!hasNonToolResultContent && toolCalls.length === 0) continue;
+    if (!hasNonToolResultContent && apiContentBlocks(message.content).every((block) => block.type === 'tool_result'))
+      continue;
+
+    const content =
+      text || (toolCalls.length > 0 ? `[Used tools: ${toolCalls.map((toolCall) => toolCall.name).join(', ')}]` : '');
+    if (!content) continue;
+
+    conversation.push({
+      role: message.role,
+      content,
+      timestamp: message.ts ? new Date(message.ts) : undefined,
+      sourceId: message.id,
+      ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    });
+  }
+
+  return conversation;
+}
+
+function isApiRequestMetadata(msg: ClineRawMessage): boolean {
+  return msg.type === 'say' && (msg.say === 'api_req_started' || msg.say === 'api_req_finished');
+}
+
 /**
  * Determine conversation role from a raw Cline message.
  * Returns null for messages that aren't conversation turns (metadata, api events).
  */
-function classifyRole(msg: ClineRawMessage): 'user' | 'assistant' | null {
+function classifyRole(msg: ClineRawMessage, state: ConversationState): ConversationRole | null {
+  if (msg.type === 'ask') {
+    switch (msg.ask) {
+      case 'followup':
+      case 'plan_mode_respond':
+      case 'act_mode_respond':
+      case 'completion_result':
+      case 'resume_task':
+      case 'resume_completed_task':
+      case 'mistake_limit_reached':
+      case 'api_req_failed':
+      case 'new_task':
+      case 'condense':
+      case 'summarize_task':
+      case 'report_bug':
+        return 'assistant';
+
+      default:
+        return null;
+    }
+  }
+
   if (msg.type !== 'say') return null;
 
   switch (msg.say) {
+    case 'task':
     case 'user_feedback':
+    case 'user_feedback_diff':
       return 'user';
 
     case 'text':
-      // Streaming assistant chunks have partial: true
-      // Non-partial text without images is user input
-      return msg.partial === true ? 'assistant' : 'user';
+      // Roo Code stores the initial user task as the first text message.
+      // Once an API request exists, text messages are assistant output, including
+      // partial:false finalizations of prior streaming assistant chunks.
+      return state.hasSeenApiRequest || msg.partial !== undefined ? 'assistant' : 'user';
 
     case 'completion_result':
-      return 'assistant';
-
     case 'reasoning':
       return 'assistant';
 
@@ -164,10 +730,9 @@ function classifyRole(msg: ClineRawMessage): 'user' | 'assistant' | null {
  * Used for session summary.
  */
 function extractFirstUserMessage(messages: ClineRawMessage[]): string {
-  for (const msg of messages) {
-    const role = classifyRole(msg);
-    if (role === 'user' && msg.text && msg.text.length > 0) {
-      return msg.text;
+  for (const msg of buildConversation(messages)) {
+    if (msg.role === 'user' && msg.content.length > 0) {
+      return msg.content;
     }
   }
   return '';
@@ -179,38 +744,43 @@ function extractFirstUserMessage(messages: ClineRawMessage[]): string {
  */
 function buildConversation(messages: ClineRawMessage[]): ConversationMessage[] {
   const result: ConversationMessage[] = [];
-  let lastSay: string | undefined;
-  let lastPartial = false;
+  const state: ConversationState = { hasSeenApiRequest: false };
+  let streamState: StreamState | undefined;
 
   for (const msg of messages) {
-    const role = classifyRole(msg);
-    if (!role || !msg.text) continue;
+    const role = classifyRole(msg, state);
+    if (isApiRequestMetadata(msg)) state.hasSeenApiRequest = true;
+    if (!role) continue;
 
-    const text = msg.text.trim();
+    const content = messageText(msg);
+    if (!content) continue;
+
+    const text = content.trim();
     if (!text) continue;
 
     const ts = msg.ts ? new Date(msg.ts) : undefined;
-
-    // Deduplicate: if the previous message is also a streaming assistant text
-    // chunk, replace it with this one (which has more complete text).
-    // Only replace when the previous was also a partial text — never overwrite
-    // reasoning or other non-streaming assistant messages.
-    if (
+    const kind = `${msg.type}:${msg.type === 'ask' ? msg.ask : msg.say}`;
+    const canReplaceStream =
       role === 'assistant' &&
-      msg.say === 'text' &&
-      msg.partial === true &&
-      result.length > 0 &&
-      result[result.length - 1].role === 'assistant' &&
-      lastSay === 'text' &&
-      lastPartial === true
-    ) {
+      streamState?.index === result.length - 1 &&
+      streamState.role === role &&
+      streamState.kind === kind;
+
+    // Consecutive partial updates represent the same assistant message evolving
+    // over time. Keep only the latest visible state, including partial:false
+    // finalizations of the same message.
+    if (canReplaceStream && (msg.partial === true || msg.partial === false)) {
       result[result.length - 1] = { role, content: text, timestamp: ts };
     } else {
       result.push({ role, content: text, timestamp: ts });
     }
 
-    lastSay = msg.say;
-    lastPartial = msg.partial === true;
+    streamState =
+      role === 'assistant' && msg.partial === true
+        ? { index: result.length - 1, role, kind }
+        : msg.partial === false
+          ? undefined
+          : streamState;
   }
 
   return result;
@@ -228,34 +798,38 @@ function extractTokenUsage(messages: ClineRawMessage[]): SessionNotes {
   let totalOut = 0;
   let totalCacheWrites = 0;
   let totalCacheReads = 0;
-  let totalCost = 0;
   let found = false;
 
   for (const msg of messages) {
-    if (msg.type !== 'say' || msg.say !== 'api_req_started') continue;
+    if (msg.type !== 'say' || (msg.say !== 'api_req_started' && msg.say !== 'api_req_finished')) continue;
     if (!msg.text) continue;
 
     try {
-      const meta: ApiReqMeta = JSON.parse(msg.text);
-      if (meta.tokensIn) {
-        totalIn += meta.tokensIn;
+      const parsed: unknown = JSON.parse(msg.text);
+      if (!isRecord(parsed)) continue;
+
+      const tokensIn = readNumber(parsed, 'tokensIn') ?? readNumber(parsed, 'totalTokensIn');
+      if (tokensIn !== undefined) {
+        totalIn += tokensIn;
         found = true;
       }
-      if (meta.tokensOut) {
-        totalOut += meta.tokensOut;
+      const tokensOut = readNumber(parsed, 'tokensOut') ?? readNumber(parsed, 'totalTokensOut');
+      if (tokensOut !== undefined) {
+        totalOut += tokensOut;
         found = true;
       }
-      if (meta.cacheWrites) {
-        totalCacheWrites += meta.cacheWrites;
+      const cacheWrites = readNumber(parsed, 'cacheWrites') ?? readNumber(parsed, 'totalCacheWrites');
+      if (cacheWrites !== undefined) {
+        totalCacheWrites += cacheWrites;
         found = true;
       }
-      if (meta.cacheReads) {
-        totalCacheReads += meta.cacheReads;
+      const cacheReads = readNumber(parsed, 'cacheReads') ?? readNumber(parsed, 'totalCacheReads');
+      if (cacheReads !== undefined) {
+        totalCacheReads += cacheReads;
         found = true;
       }
-      if (meta.cost) totalCost += meta.cost;
-    } catch {
-      // Malformed JSON in api_req_started — skip silently
+    } catch (err) {
+      logger.debug('cline: skipping malformed API request metadata', err);
     }
   }
 
@@ -269,6 +843,69 @@ function extractTokenUsage(messages: ClineRawMessage[]): SessionNotes {
   return notes;
 }
 
+function extractUsageFromTaskHistory(item?: ClineTaskHistoryItem): SessionNotes {
+  const notes: SessionNotes = {};
+  if (!item) return notes;
+
+  if (item.tokensIn !== undefined || item.tokensOut !== undefined) {
+    notes.tokenUsage = {
+      input: item.tokensIn ?? 0,
+      output: item.tokensOut ?? 0,
+    };
+  }
+  if (item.cacheWrites !== undefined || item.cacheReads !== undefined) {
+    notes.cacheTokens = {
+      creation: item.cacheWrites ?? 0,
+      read: item.cacheReads ?? 0,
+    };
+  }
+  return notes;
+}
+
+function extractUsageFromApiHistory(messages: ClineApiMessage[]): SessionNotes {
+  const notes: SessionNotes = {};
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let found = false;
+
+  for (const message of messages) {
+    const metrics = message.metrics;
+    if (!metrics) continue;
+    const tokens = readRecord(metrics, 'tokens');
+
+    const prompt = tokens ? readNumber(tokens, 'prompt') : readNumber(metrics, 'tokensIn');
+    const completion = tokens ? readNumber(tokens, 'completion') : readNumber(metrics, 'tokensOut');
+    const cached = tokens ? readNumber(tokens, 'cached') : readNumber(metrics, 'cacheReads');
+
+    if (prompt !== undefined) {
+      input += prompt;
+      found = true;
+    }
+    if (completion !== undefined) {
+      output += completion;
+      found = true;
+    }
+    if (cached !== undefined) {
+      cacheRead += cached;
+    }
+  }
+
+  if (found) notes.tokenUsage = { input, output };
+  if (cacheRead > 0) notes.cacheTokens = { creation: 0, read: cacheRead };
+  return notes;
+}
+
+function chooseUsageNotes(data: LoadedTaskData): SessionNotes {
+  const fromHistory = extractUsageFromTaskHistory(data.taskHistoryItem);
+  if (fromHistory.tokenUsage || fromHistory.cacheTokens) return fromHistory;
+
+  const fromApiHistory = extractUsageFromApiHistory(data.apiMessages);
+  if (fromApiHistory.tokenUsage || fromApiHistory.cacheTokens) return fromApiHistory;
+
+  return extractTokenUsage(data.uiMessages);
+}
+
 /**
  * Extract reasoning highlights from "reasoning" say events (max N).
  */
@@ -277,8 +914,25 @@ function extractReasoning(messages: ClineRawMessage[], max: number): string[] {
   for (const msg of messages) {
     if (highlights.length >= max) break;
     if (msg.type !== 'say' || msg.say !== 'reasoning') continue;
-    if (!msg.text || msg.text.length < 10) continue;
-    highlights.push(truncate(msg.text.trim(), 200));
+    const content = messageText(msg);
+    if (!content || content.length < 10) continue;
+    highlights.push(truncate(content.trim(), 200));
+  }
+  return highlights;
+}
+
+function extractApiReasoning(messages: ClineApiMessage[], max: number): string[] {
+  const highlights: string[] = [];
+  for (const message of messages) {
+    if (highlights.length >= max) break;
+    if (message.role !== 'assistant' || typeof message.content === 'string') continue;
+
+    for (const block of message.content) {
+      if (highlights.length >= max) break;
+      const text = block.type === 'thinking' ? block.thinking : undefined;
+      if (!text || text.length < 10) continue;
+      highlights.push(truncate(text.trim(), 200));
+    }
   }
   return highlights;
 }
@@ -293,8 +947,10 @@ function extractPendingTasks(messages: ClineRawMessage[], max: number): string[]
   // Walk backwards to find the last completion_result or assistant text
   for (let i = messages.length - 1; i >= 0 && tasks.length < max; i--) {
     const msg = messages[i];
-    if (msg.type !== 'say') continue;
-    if (msg.say !== 'completion_result' && msg.say !== 'text') continue;
+    const isCompletion =
+      (msg.type === 'say' && (msg.say === 'completion_result' || msg.say === 'text')) ||
+      (msg.type === 'ask' && msg.ask === 'completion_result');
+    if (!isCompletion) continue;
     if (!msg.text) continue;
 
     const lines = msg.text.split('\n');
@@ -317,6 +973,310 @@ function extractPendingTasks(messages: ClineRawMessage[], max: number): string[]
   return tasks;
 }
 
+function pendingLinesFromText(text: string, max: number): string[] {
+  const tasks: string[] = [];
+  for (const line of text.split('\n')) {
+    if (tasks.length >= max) break;
+    const trimmed = line.trim();
+    const lower = trimmed.toLowerCase();
+    if ((lower.startsWith('- [ ]') || lower.startsWith('todo:') || lower.includes('next step')) && trimmed.length > 5) {
+      tasks.push(truncate(trimmed, 200));
+    }
+  }
+  return tasks;
+}
+
+function extractPendingTasksFromConversation(messages: ConversationMessage[], max: number): string[] {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role !== 'assistant') continue;
+    const tasks = pendingLinesFromText(messages[i].content, max);
+    if (tasks.length > 0) return tasks;
+  }
+  return [];
+}
+
+function extractFirstApiUserMessage(messages: ClineApiMessage[]): string {
+  for (const message of messages) {
+    if (message.role !== 'user') continue;
+    const text = apiMessageText(message);
+    if (text) return stripEnvironmentDetails(text);
+  }
+  return '';
+}
+
+function stripEnvironmentDetails(text: string): string {
+  return text.replace(/<environment_details>[\s\S]*?<\/environment_details>/giu, '').trim();
+}
+
+function extractModelFromMetadata(metadata?: ClineTaskMetadata): string | undefined {
+  const lastModel = metadata?.model_usage?.at(-1);
+  return lastModel ? (readString(lastModel, 'model_id') ?? readString(lastModel, 'modelId')) : undefined;
+}
+
+function extractModelFromApiHistory(messages: ClineApiMessage[]): string | undefined {
+  let model: string | undefined;
+  for (const message of messages) {
+    if (message.modelInfo?.modelId) model = message.modelInfo.modelId;
+  }
+  return model;
+}
+
+function extractModelFromUiMessages(messages: ClineRawMessage[]): string | undefined {
+  let model: string | undefined;
+  for (const message of messages) {
+    if (message.modelInfo?.modelId) model = message.modelInfo.modelId;
+  }
+  return model;
+}
+
+function resolveModel(data: LoadedTaskData): string | undefined {
+  return (
+    extractModelFromMetadata(data.taskMetadata) ??
+    data.taskHistoryItem?.modelId ??
+    extractModelFromApiHistory(data.apiMessages) ??
+    extractModelFromUiMessages(data.uiMessages)
+  );
+}
+
+function looksLikePath(value: string): boolean {
+  return value.startsWith('/') || value.startsWith('~/') || /^[A-Za-z]:[\\/]/u.test(value);
+}
+
+function findCwdInValue(value: unknown, depth = 0): string | undefined {
+  if (depth > 4) return undefined;
+  if (typeof value === 'string') return looksLikePath(value) ? value : undefined;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const cwd = findCwdInValue(item, depth + 1);
+      if (cwd) return cwd;
+    }
+    return undefined;
+  }
+  if (!isRecord(value)) return undefined;
+
+  const keys = [
+    'cwd',
+    'cwdOnTaskInitialization',
+    'currentWorkingDirectory',
+    'workingDirectory',
+    'workspacePath',
+    'rootPath',
+    'projectRoot',
+  ];
+  for (const key of keys) {
+    const raw = readString(value, key);
+    if (raw && looksLikePath(raw)) return raw;
+  }
+
+  for (const nested of Object.values(value)) {
+    const cwd = findCwdInValue(nested, depth + 1);
+    if (cwd) return cwd;
+  }
+
+  return undefined;
+}
+
+function extractCwdFromUiApiEvents(messages: ClineRawMessage[]): string | undefined {
+  for (const message of messages) {
+    if (!isApiRequestMetadata(message) || !message.text) continue;
+    try {
+      const parsed: unknown = JSON.parse(message.text);
+      const cwd = findCwdInValue(parsed);
+      if (cwd) return cwd;
+    } catch (err) {
+      logger.debug('cline: skipping malformed API request metadata while extracting cwd', err);
+    }
+  }
+  return undefined;
+}
+
+function extractCwdFromText(text: string): string | undefined {
+  const patterns = [
+    /Current Working Directory\s*\(([^)]+)\)/iu,
+    /Current Working Directory\s*:\s*([^\n\r]+)/iu,
+    /\bcwd\s*[:=]\s*([^\n\r]+)/iu,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    const cwd = match?.[1]?.trim();
+    if (cwd && looksLikePath(cwd)) return cwd;
+  }
+  return undefined;
+}
+
+function extractCwdFromApiHistory(messages: ClineApiMessage[]): string | undefined {
+  for (const message of messages) {
+    const cwd = extractCwdFromText(apiMessageText(message));
+    if (cwd) return cwd;
+  }
+  return undefined;
+}
+
+function resolveCwd(data: LoadedTaskData): string {
+  return (
+    data.taskHistoryItem?.cwdOnTaskInitialization ??
+    extractCwdFromUiApiEvents(data.uiMessages) ??
+    extractCwdFromApiHistory(data.apiMessages) ??
+    ''
+  );
+}
+
+function getInputString(input: Record<string, unknown>, key: string): string {
+  const value = input[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function stringifyArgs(input: Record<string, unknown>, maxChars: number): string {
+  try {
+    return truncate(JSON.stringify(input), maxChars);
+  } catch (err) {
+    logger.debug('cline: failed to stringify tool arguments', err);
+    return '';
+  }
+}
+
+function getToolFilePath(input: Record<string, unknown>): string {
+  return getInputString(input, 'path') || getInputString(input, 'file_path') || getInputString(input, 'filePath');
+}
+
+function addClineToolSummary(
+  collector: SummaryCollector,
+  name: string,
+  input: Record<string, unknown>,
+  result: ToolResultEntry | undefined,
+  config: VerbosityConfig,
+): void {
+  const resultText = result?.text;
+  const isError = result?.isError ?? false;
+  const filePath = getToolFilePath(input);
+
+  switch (name) {
+    case 'execute_command': {
+      const command = getInputString(input, 'command') || getInputString(input, 'cmd');
+      collector.add(name, shellSummary(command, resultText), {
+        data: {
+          category: 'shell',
+          command,
+          ...(resultText ? { stdoutTail: truncate(resultText, config.shell.maxChars) } : {}),
+          ...(isError ? { errored: true, errorMessage: truncate(resultText ?? '', config.shell.maxChars) } : {}),
+        },
+        isError,
+      });
+      return;
+    }
+
+    case 'read_file': {
+      collector.add(name, withResult(fileSummary('read', filePath), resultText?.slice(0, 80)), {
+        data: { category: 'read', filePath },
+        filePath,
+        isError,
+      });
+      return;
+    }
+
+    case 'write_to_file': {
+      collector.add(name, withResult(fileSummary('write', filePath, undefined, true), resultText?.slice(0, 80)), {
+        data: { category: 'write', filePath, isNewFile: true },
+        filePath,
+        isWrite: true,
+        isError,
+      });
+      return;
+    }
+
+    case 'replace_in_file':
+    case 'apply_diff': {
+      collector.add(name, withResult(fileSummary('edit', filePath), resultText?.slice(0, 80)), {
+        data: { category: 'edit', filePath },
+        filePath,
+        isWrite: true,
+        isError,
+      });
+      return;
+    }
+
+    case 'search_files': {
+      const pattern =
+        getInputString(input, 'regex') || getInputString(input, 'pattern') || getInputString(input, 'query');
+      collector.add(name, withResult(grepSummary(pattern, filePath), resultText?.slice(0, 80)), {
+        data: { category: 'grep', pattern, ...(filePath ? { targetPath: filePath } : {}) },
+        isError,
+      });
+      return;
+    }
+
+    case 'list_files':
+    case 'list_code_definition_names': {
+      const target = filePath || getInputString(input, 'recursive') || '.';
+      collector.add(name, withResult(globSummary(target), resultText?.slice(0, 80)), {
+        data: { category: 'glob', pattern: target },
+        isError,
+      });
+      return;
+    }
+
+    default: {
+      const args = stringifyArgs(input, config.mcp.paramChars);
+      collector.add(name, mcpSummary(name, args, resultText?.slice(0, 80)), {
+        data: {
+          category: 'mcp',
+          toolName: name,
+          ...(args ? { params: args } : {}),
+          ...(resultText ? { result: resultText.slice(0, config.mcp.resultChars) } : {}),
+        },
+        isError,
+      });
+    }
+  }
+}
+
+function extractApiToolData(messages: ClineApiMessage[], config: VerbosityConfig): ToolData {
+  const collector = new SummaryCollector(config);
+  const resultMap = getToolResultMap(messages);
+
+  for (const message of messages) {
+    for (const block of apiContentBlocks(message.content)) {
+      if (block.type !== 'tool_use' || !block.name) continue;
+      const result = block.id ? resultMap.get(block.id) : undefined;
+      addClineToolSummary(collector, block.name, block.input ?? {}, result, config);
+    }
+  }
+
+  return {
+    summaries: collector.getSummaries(),
+    filesModified: collector.getFilesModified(),
+  };
+}
+
+async function existingCompanionStats(
+  files: TaskFiles,
+): Promise<Array<{ filePath: string; size: number; birthtime: Date; mtime: Date }>> {
+  const stats: Array<{ filePath: string; size: number; birthtime: Date; mtime: Date }> = [];
+  for (const filePath of [files.uiMessages, files.apiConversationHistory, files.taskMetadata]) {
+    if (!(await pathExists(filePath))) continue;
+    try {
+      const fileStats = await fs.stat(filePath);
+      stats.push({ filePath, size: fileStats.size, birthtime: fileStats.birthtime, mtime: fileStats.mtime });
+    } catch (err) {
+      logger.debug(`cline: cannot stat companion file ${filePath}`, err);
+    }
+  }
+  return stats;
+}
+
+function messageTimestamps(data: LoadedTaskData): number[] {
+  const values: number[] = [];
+  for (const message of data.uiMessages) {
+    if (message.ts !== undefined) values.push(message.ts);
+  }
+  for (const message of data.apiMessages) {
+    if (message.ts !== undefined) values.push(message.ts);
+  }
+  if (data.taskHistoryItem?.ts !== undefined) values.push(data.taskHistoryItem.ts);
+  return values;
+}
+
 // ── Session Parsing (shared) ────────────────────────────────────────────────
 
 /**
@@ -324,38 +1284,49 @@ function extractPendingTasks(messages: ClineRawMessage[], max: number): string[]
  * filtering to a single source variant.
  */
 async function parseSessionsForSource(filterSource?: ClineSource): Promise<UnifiedSession[]> {
-  const taskEntries = discoverTaskDirs();
+  const taskEntries = await discoverTaskDirs(filterSource);
   const sessions: UnifiedSession[] = [];
 
-  for (const { taskDir, taskId, source } of taskEntries) {
-    if (filterSource && source !== filterSource) continue;
-
+  for (const { taskDir, taskId, storageRoot, source } of taskEntries) {
     try {
-      const uiFile = path.join(taskDir, 'ui_messages.json');
-      const messages = readUiMessages(uiFile);
-      if (messages.length === 0) continue;
+      const data = await loadTaskData(taskDir, storageRoot, taskId);
+      if (data.uiMessages.length === 0 && data.apiMessages.length === 0 && !data.taskHistoryItem) continue;
 
-      const firstUserMsg = extractFirstUserMessage(messages);
+      const firstUserMsg =
+        extractFirstUserMessage(data.uiMessages) ||
+        extractFirstApiUserMessage(data.apiMessages) ||
+        data.taskHistoryItem?.task ||
+        '';
       const summary = cleanSummary(firstUserMsg);
       if (!summary) continue; // Skip sessions with no real user message
 
-      const fileStats = fs.statSync(uiFile);
+      const stats = await existingCompanionStats(data.files);
+      if (stats.length === 0) continue;
 
-      // Derive timestamps: prefer message timestamps, fall back to file stats
-      const firstTs = messages[0]?.ts;
-      const lastTs = messages[messages.length - 1]?.ts;
-      const createdAt = firstTs ? new Date(firstTs) : fileStats.birthtime;
-      const updatedAt = lastTs ? new Date(lastTs) : fileStats.mtime;
+      // Derive timestamps: prefer message/history timestamps, fall back to file stats.
+      const timestamps = messageTimestamps(data);
+      const createdAt =
+        timestamps.length > 0
+          ? new Date(Math.min(...timestamps))
+          : new Date(Math.min(...stats.map((stat) => stat.birthtime.getTime())));
+      const updatedAt =
+        timestamps.length > 0
+          ? new Date(Math.max(...timestamps))
+          : new Date(Math.max(...stats.map((stat) => stat.mtime.getTime())));
+      const cwd = resolveCwd(data);
+      const model = resolveModel(data);
 
       sessions.push({
         id: taskId,
-        source: source as SessionSource,
-        cwd: '',
-        lines: messages.length,
-        bytes: fileStats.size,
+        source,
+        cwd,
+        ...(cwd ? { repo: extractRepoFromCwd(cwd) } : {}),
+        ...(model ? { model } : {}),
+        lines: data.uiMessages.length || data.apiMessages.length,
+        bytes: stats.reduce((total, stat) => total + stat.size, 0),
         createdAt,
         updatedAt,
-        originalPath: uiFile,
+        originalPath: stats[0].filePath,
         summary,
       });
     } catch (err) {
@@ -374,42 +1345,57 @@ async function parseSessionsForSource(filterSource?: ClineSource): Promise<Unifi
  */
 async function extractContextShared(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const cfg = config ?? getPreset('standard');
-  const messages = readUiMessages(session.originalPath);
+  const data = await loadTaskDataFromOriginalPath(session.originalPath, session.id);
 
   // Build conversation messages
-  const allConversation = buildConversation(messages);
+  const uiConversation = buildConversation(data.uiMessages);
+  const apiConversation = buildApiConversation(data.apiMessages, cfg);
+  const allConversation = uiConversation.length > 0 ? uiConversation : apiConversation;
   const recentMessages = allConversation.slice(-cfg.recentMessages);
 
   // Extract token usage and session notes
-  const sessionNotes: SessionNotes = extractTokenUsage(messages);
+  const sessionNotes: SessionNotes = chooseUsageNotes(data);
+  const model = resolveModel(data);
+  if (model) sessionNotes.model = model;
 
   // Extract reasoning highlights
-  const reasoning = extractReasoning(messages, cfg.thinking?.maxHighlights ?? 5);
+  const uiReasoning = extractReasoning(data.uiMessages, cfg.thinking?.maxHighlights ?? 5);
+  const reasoning =
+    uiReasoning.length > 0 ? uiReasoning : extractApiReasoning(data.apiMessages, cfg.thinking?.maxHighlights ?? 5);
   if (reasoning.length > 0) sessionNotes.reasoning = reasoning;
 
   // Extract pending tasks
-  const pendingTasks = extractPendingTasks(messages, cfg.pendingTasks?.maxTasks ?? 5);
+  const pendingTasksFromUi = extractPendingTasks(data.uiMessages, cfg.pendingTasks?.maxTasks ?? 5);
+  const pendingTasks =
+    pendingTasksFromUi.length > 0
+      ? pendingTasksFromUi
+      : extractPendingTasksFromConversation(allConversation, cfg.pendingTasks?.maxTasks ?? 5);
 
-  // Cline's ui_messages.json doesn't track file-level tool calls,
-  // so filesModified and toolSummaries remain empty
-  const filesModified: string[] = [];
+  const toolData =
+    data.apiMessages.length > 0 ? extractApiToolData(data.apiMessages, cfg) : { summaries: [], filesModified: [] };
+  const cwd = resolveCwd(data) || session.cwd;
+  const sessionWithMetadata: UnifiedSession = {
+    ...session,
+    ...(cwd ? { cwd, repo: session.repo || extractRepoFromCwd(cwd) } : {}),
+    ...(model ? { model } : {}),
+  };
 
   const markdown = generateHandoffMarkdown(
-    session,
+    sessionWithMetadata,
     recentMessages,
-    filesModified,
+    toolData.filesModified,
     pendingTasks,
-    [], // toolSummaries — not available from ui_messages.json
+    toolData.summaries,
     sessionNotes,
     cfg,
   );
 
   return {
-    session: sessionNotes.model ? { ...session, model: sessionNotes.model } : session,
+    session: sessionWithMetadata,
     recentMessages,
-    filesModified,
+    filesModified: toolData.filesModified,
     pendingTasks,
-    toolSummaries: [],
+    toolSummaries: toolData.summaries,
     sessionNotes,
     markdown,
   };

--- a/src/parsers/cline.ts
+++ b/src/parsers/cline.ts
@@ -229,7 +229,10 @@ function uniquePaths(paths: string[]): string[] {
     const resolved = path.resolve(filePath);
     if (seen.has(resolved)) continue;
     seen.add(resolved);
-    results.push(filePath);
+    // Push the resolved (canonical, absolute) path so downstream joins,
+    // existence checks, and de-dup keys stay reliable when `CLINE_DIR` or
+    // other inputs were relative.
+    results.push(resolved);
   }
   return results;
 }
@@ -742,13 +745,21 @@ function classifyRole(msg: ClineRawMessage, state: ConversationState): Conversat
 
 /**
  * Extract the first real user message from a set of raw messages.
- * Used for session summary.
+ * Used for session summary during discovery, where we may scan thousands of
+ * messages but only need the first user hit. Iterates raw messages directly
+ * with the same role classification as `buildConversation`, avoiding the
+ * full conversation rebuild for large sessions.
  */
 function extractFirstUserMessage(messages: ClineRawMessage[]): string {
-  for (const msg of buildConversation(messages)) {
-    if (msg.role === 'user' && msg.content.length > 0) {
-      return msg.content;
-    }
+  const state: ConversationState = { hasSeenApiRequest: false };
+  for (const msg of messages) {
+    const role = classifyRole(msg, state);
+    if (isApiRequestMetadata(msg)) state.hasSeenApiRequest = true;
+    if (role !== 'user') continue;
+    const content = messageText(msg);
+    if (!content) continue;
+    const text = content.trim();
+    if (text) return text;
   }
   return '';
 }
@@ -815,30 +826,33 @@ function extractTokenUsage(messages: ClineRawMessage[]): SessionNotes {
   let totalCacheReads = 0;
   let found = false;
 
+  // Only sum per-request `api_req_started` events. `api_req_finished` carries
+  // running cumulative totals (`totalTokensIn` etc.), so summing both produces
+  // O(n^2)-style inflated counts — see PR #57 review thread on token usage.
   for (const msg of messages) {
-    if (msg.type !== 'say' || (msg.say !== 'api_req_started' && msg.say !== 'api_req_finished')) continue;
+    if (msg.type !== 'say' || msg.say !== 'api_req_started') continue;
     if (!msg.text) continue;
 
     try {
       const parsed: unknown = JSON.parse(msg.text);
       if (!isRecord(parsed)) continue;
 
-      const tokensIn = readNumber(parsed, 'tokensIn') ?? readNumber(parsed, 'totalTokensIn');
+      const tokensIn = readNumber(parsed, 'tokensIn');
       if (tokensIn !== undefined) {
         totalIn += tokensIn;
         found = true;
       }
-      const tokensOut = readNumber(parsed, 'tokensOut') ?? readNumber(parsed, 'totalTokensOut');
+      const tokensOut = readNumber(parsed, 'tokensOut');
       if (tokensOut !== undefined) {
         totalOut += tokensOut;
         found = true;
       }
-      const cacheWrites = readNumber(parsed, 'cacheWrites') ?? readNumber(parsed, 'totalCacheWrites');
+      const cacheWrites = readNumber(parsed, 'cacheWrites');
       if (cacheWrites !== undefined) {
         totalCacheWrites += cacheWrites;
         found = true;
       }
-      const cacheReads = readNumber(parsed, 'cacheReads') ?? readNumber(parsed, 'totalCacheReads');
+      const cacheReads = readNumber(parsed, 'cacheReads');
       if (cacheReads !== undefined) {
         totalCacheReads += cacheReads;
         found = true;
@@ -1057,9 +1071,38 @@ function looksLikePath(value: string): boolean {
   return value.startsWith('/') || value.startsWith('~/') || /^[A-Za-z]:[\\/]/u.test(value);
 }
 
+const CWD_KEYS = [
+  'cwd',
+  'cwdOnTaskInitialization',
+  'currentWorkingDirectory',
+  'workingDirectory',
+  'workspacePath',
+  'rootPath',
+  'projectRoot',
+];
+
+/**
+ * Search a JSON value for a working-directory hint without false positives.
+ *
+ * To avoid mis-classifying arbitrary paths embedded in conversation text
+ * (e.g. `/usr/bin/node`) as the cwd, this only accepts path-like strings
+ * when they appear:
+ *   - directly under a known cwd-bearing key, or
+ *   - inside a string that contains an explicit `Current Working Directory ...`
+ *     / `cwd: ...` marker recognized by `extractCwdFromText`.
+ *
+ * Bare path-like strings (or strings nested in unrelated objects/arrays) are
+ * treated as untrusted and not returned.
+ */
 function findCwdInValue(value: unknown, depth = 0): string | undefined {
   if (depth > 4) return undefined;
-  if (typeof value === 'string') return looksLikePath(value) ? value : extractCwdFromText(value);
+
+  if (typeof value === 'string') {
+    // Only trust strings that carry an explicit "cwd: ..." / "Current Working
+    // Directory ..." marker. A bare path-like string is not enough.
+    return extractCwdFromText(value);
+  }
+
   if (Array.isArray(value)) {
     for (const item of value) {
       const cwd = findCwdInValue(item, depth + 1);
@@ -1067,22 +1110,18 @@ function findCwdInValue(value: unknown, depth = 0): string | undefined {
     }
     return undefined;
   }
+
   if (!isRecord(value)) return undefined;
 
-  const keys = [
-    'cwd',
-    'cwdOnTaskInitialization',
-    'currentWorkingDirectory',
-    'workingDirectory',
-    'workspacePath',
-    'rootPath',
-    'projectRoot',
-  ];
-  for (const key of keys) {
+  // Strongest signal: a known cwd key with a path-like string value.
+  for (const key of CWD_KEYS) {
     const raw = readString(value, key);
     if (raw && looksLikePath(raw)) return raw;
   }
 
+  // Fall back to scanning nested values for marker-bearing strings or nested
+  // cwd keys. Any path-like leaf strings are still rejected by the typeof
+  // 'string' branch above unless they include an explicit marker.
   for (const nested of Object.values(value)) {
     const cwd = findCwdInValue(nested, depth + 1);
     if (cwd) return cwd;
@@ -1109,7 +1148,10 @@ function extractCwdFromText(text: string): string | undefined {
   const patterns = [
     /Current Working Directory\s*\(([^)]+)\)/iu,
     /Current Working Directory\s*:\s*([^\n\r]+)/iu,
-    /\bcwd\s*[:=]\s*([^\n\r]+)/iu,
+    // Stop at whitespace so `cwd: /path some-other-text` does not capture
+    // the trailing words. cwd values written in Cline metadata are
+    // single tokens.
+    /\bcwd\s*[:=]\s*(\S+)/iu,
   ];
 
   for (const pattern of patterns) {
@@ -1128,13 +1170,22 @@ function extractCwdFromApiHistory(messages: ClineApiMessage[]): string | undefin
   return undefined;
 }
 
+/**
+ * Normalize a working directory to POSIX separators so downstream helpers
+ * like `extractRepoFromCwd` (which splits on `/`) handle Windows paths
+ * (`C:\Users\me\repo`) correctly.
+ */
+function normalizeCwd(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
 function resolveCwd(data: LoadedTaskData): string {
-  return (
+  const raw =
     data.taskHistoryItem?.cwdOnTaskInitialization ??
     extractCwdFromUiApiEvents(data.uiMessages) ??
     extractCwdFromApiHistory(data.apiMessages) ??
-    ''
-  );
+    '';
+  return raw ? normalizeCwd(raw) : '';
 }
 
 function getInputString(input: Record<string, unknown>, key: string): string {

--- a/src/parsers/cline.ts
+++ b/src/parsers/cline.ts
@@ -131,6 +131,8 @@ interface TaskEntry {
   source: ClineSource;
 }
 
+type TaskHistoryMap = Map<string, ClineTaskHistoryItem>;
+
 interface TaskFiles {
   taskDir: string;
   storageRoot: string;
@@ -533,14 +535,23 @@ function taskHistoryArray(value: unknown): unknown[] {
   return [];
 }
 
-async function readTaskHistoryItem(paths: string[], taskId: string): Promise<ClineTaskHistoryItem | undefined> {
+async function readTaskHistoryMap(paths: string[]): Promise<TaskHistoryMap> {
+  const itemsById: TaskHistoryMap = new Map();
   for (const filePath of paths) {
     const parsed = await readJson(filePath, TASK_HISTORY_FILE);
-    const items = taskHistoryArray(parsed).map(normalizeTaskHistoryItem);
-    const item = items.find((entry): entry is ClineTaskHistoryItem => entry !== null && entry.id === taskId);
-    if (item) return item;
+    for (const item of taskHistoryArray(parsed).map(normalizeTaskHistoryItem)) {
+      if (item && !itemsById.has(item.id)) itemsById.set(item.id, item);
+    }
   }
-  return undefined;
+  return itemsById;
+}
+
+async function readTaskHistoryItem(paths: string[], taskId: string): Promise<ClineTaskHistoryItem | undefined> {
+  return (await readTaskHistoryMap(paths)).get(taskId);
+}
+
+function taskHistoryCandidatesFromStorageRoot(storageRoot: string): string[] {
+  return [path.join(storageRoot, 'state', TASK_HISTORY_FILE), path.join(storageRoot, TASK_HISTORY_FILE)];
 }
 
 function taskFilesFromDir(taskDir: string, storageRoot: string): TaskFiles {
@@ -550,10 +561,7 @@ function taskFilesFromDir(taskDir: string, storageRoot: string): TaskFiles {
     uiMessages: path.join(taskDir, UI_MESSAGES_FILE),
     apiConversationHistory: path.join(taskDir, API_CONVERSATION_HISTORY_FILE),
     taskMetadata: path.join(taskDir, TASK_METADATA_FILE),
-    taskHistoryCandidates: [
-      path.join(storageRoot, 'state', TASK_HISTORY_FILE),
-      path.join(storageRoot, TASK_HISTORY_FILE),
-    ],
+    taskHistoryCandidates: taskHistoryCandidatesFromStorageRoot(storageRoot),
   };
 }
 
@@ -566,13 +574,20 @@ function inferStorageRootFromTaskDir(taskDir: string): string {
   return path.basename(parent) === 'tasks' ? path.dirname(parent) : parent;
 }
 
-async function loadTaskData(taskDir: string, storageRoot: string, taskId: string): Promise<LoadedTaskData> {
+async function loadTaskData(
+  taskDir: string,
+  storageRoot: string,
+  taskId: string,
+  taskHistoryById?: TaskHistoryMap,
+): Promise<LoadedTaskData> {
   const files = taskFilesFromDir(taskDir, storageRoot);
   const [uiMessages, apiMessages, taskMetadata, taskHistoryItem] = await Promise.all([
     readUiMessages(files.uiMessages),
     readApiConversationHistory(files.apiConversationHistory),
     readTaskMetadata(files.taskMetadata),
-    readTaskHistoryItem(files.taskHistoryCandidates, taskId),
+    taskHistoryById
+      ? Promise.resolve(taskHistoryById.get(taskId))
+      : readTaskHistoryItem(files.taskHistoryCandidates, taskId),
   ]);
 
   return { files, uiMessages, apiMessages, taskMetadata, taskHistoryItem };
@@ -1044,7 +1059,7 @@ function looksLikePath(value: string): boolean {
 
 function findCwdInValue(value: unknown, depth = 0): string | undefined {
   if (depth > 4) return undefined;
-  if (typeof value === 'string') return looksLikePath(value) ? value : undefined;
+  if (typeof value === 'string') return looksLikePath(value) ? value : extractCwdFromText(value);
   if (Array.isArray(value)) {
     for (const item of value) {
       const cwd = findCwdInValue(item, depth + 1);
@@ -1285,11 +1300,19 @@ function messageTimestamps(data: LoadedTaskData): number[] {
  */
 async function parseSessionsForSource(filterSource?: ClineSource): Promise<UnifiedSession[]> {
   const taskEntries = await discoverTaskDirs(filterSource);
+  const taskHistoryCache = new Map<string, Promise<TaskHistoryMap>>();
   const sessions: UnifiedSession[] = [];
 
   for (const { taskDir, taskId, storageRoot, source } of taskEntries) {
     try {
-      const data = await loadTaskData(taskDir, storageRoot, taskId);
+      const storageRootKey = path.resolve(storageRoot);
+      let taskHistoryById = taskHistoryCache.get(storageRootKey);
+      if (!taskHistoryById) {
+        taskHistoryById = readTaskHistoryMap(taskHistoryCandidatesFromStorageRoot(storageRoot));
+        taskHistoryCache.set(storageRootKey, taskHistoryById);
+      }
+
+      const data = await loadTaskData(taskDir, storageRoot, taskId, await taskHistoryById);
       if (data.uiMessages.length === 0 && data.apiMessages.length === 0 && !data.taskHistoryItem) continue;
 
       const firstUserMsg =


### PR DESCRIPTION
# fix(cline): harden session discovery and context

## Summary
This hardens Cline-family parsing so sessions can be discovered from Cline CLI storage, VS Code-compatible extension storage, and JetBrains globalStorage layouts. Context extraction now uses companion files when available, including API conversation history, task metadata, and task history, so handoffs recover tool activity, cwd, repo, model, token usage, and fallback conversation text instead of relying only on `ui_messages.json`.

## Context / Why now
Cline, Roo Code, and Kilo Code can leave useful context outside `ui_messages.json`, and Cline CLI / JetBrains users can store tasks in locations the previous parser did not scan. The old path and UI-only assumptions meant valid sessions could be missed, malformed UI files could drop otherwise recoverable context, and tool summaries could be empty even when API history had exact tool calls.

## The 5 items

### Item 1: Cline CLI and JetBrains discovery
- Files: `src/parsers/cline.ts`, `src/__tests__/cline-parser.test.ts`
- What: Added Cline CLI roots from `CLINE_DIR/data/tasks` and `~/.cline/data/tasks`; added JetBrains globalStorage discovery across platform-specific JetBrains config roots; kept Cline, Roo Code, and Kilo Code source labeling distinct.
- Why this shape: The parser now builds task roots by source and de-duplicates resolved paths, which avoids hardcoding one IDE storage layout while preserving existing source filters.
- Verified by: Added tests for Cline CLI roots, VS Code-compatible extension IDs, Roo legacy/current IDs, and Kilo Code labeling.

### Item 2: Companion file loading
- Files: `src/parsers/cline.ts`, `src/__tests__/cline-parser.test.ts`
- What: Added async loading for `ui_messages.json`, `api_conversation_history.json`, `task_metadata.json`, and `taskHistory.json` candidates, with normalized record parsing and readable-data checks.
- Why this shape: Companion files are optional and can be malformed independently, so each file is parsed defensively and failures are logged at debug level instead of failing the session.
- Verified by: Added tests for invalid JSON, non-array UI files, malformed entries, metadata-only noise, and companion-backed context recovery.

### Item 3: API history conversation and tools
- Files: `src/parsers/cline.ts`, `src/__tests__/cline-parser.test.ts`
- What: Added API-history conversation reconstruction, tool result pairing, `SummaryCollector` integration, file modification extraction, and summaries for shell/read/write/edit/search/list/MCP-style tools.
- Why this shape: API history has exact `tool_use` / `tool_result` blocks, so it is a better source for tool activity than inferring from UI messages.
- Verified by: Added a test that recovers `execute_command` and `replace_in_file` summaries, result snippets, modified files, and token/cache metrics from `api_conversation_history.json`.

### Item 4: Metadata recovery
- Files: `src/parsers/cline.ts`, `src/__tests__/cline-parser.test.ts`
- What: Recovered model, cwd, repo, timestamps, token usage, and cache usage from task metadata, task history, UI API request metadata, and API history in priority order.
- Why this shape: Cline stores overlapping fields in several places; explicit priority prevents double counting and prefers richer metadata when present.
- Verified by: Added tests for model precedence, task-history token usage, cwd/repo extraction, and no double counting when UI aggregate usage is also present.

### Item 5: Malformed fallback behavior
- Files: `src/parsers/cline.ts`, `src/__tests__/cline-parser.test.ts`
- What: Context extraction now falls back to API history and metadata when `ui_messages.json` is invalid, and returns empty context instead of throwing when no recoverable data exists.
- Why this shape: A single broken UI file should not make an otherwise valid handoff unusable.
- Verified by: Added tests for malformed UI fallback with API conversation text, pending tasks, cwd, repo, model, token/cache usage, and empty-context behavior for invalid/non-array UI files.

## Files touched

| File | ± | Purpose |
|---|---:|---|
| `src/parsers/cline.ts` | +1103 / -117 | Harden discovery, companion parsing, context extraction, metadata recovery, and API-history tool summaries. |
| `src/__tests__/cline-parser.test.ts` | +490 / -0 | Add focused parser coverage for discovery variants, malformed inputs, companion files, tool activity, and metadata fallback. |

## Verification
- Automated: `git diff --check origin/main...HEAD` passed.
- Attempted: `pnpm test` failed before running tests because `node_modules` is missing and `vitest` is not installed in this worktree.
- Attempted: `pnpm lint` failed before running Biome because `node_modules` is missing and `biome` is not installed in this worktree.
- Attempted: `pnpm exec tsc --noEmit` failed because dependencies and type packages are unavailable; representative errors include missing Node built-in type declarations, missing `vitest`, and missing runtime package declarations.
- Full-check baseline blocker: I did not run `pnpm run check` because the read-only PR-creation constraint prevented `pnpm install`, and `pnpm run check` would fail at `pnpm lint` for the same missing-dependency baseline before reaching build. If dependencies are installed, `pnpm run check` should be rerun by the author/reviewer.

## Weaknesses and open questions
1. Important: JetBrains discovery recursively scans for directories named `globalStorage` to depth 3. Reviewer question 1: is this depth broad enough for all JetBrains Cline installs we care about, or should the search be narrower with known product directories?
2. Important: API-history tool summaries map known Cline tools into existing summary categories and treat unknown names as MCP-style summaries. Reviewer question 2: should unknown Cline tools stay in the MCP bucket, or do we need a Cline-specific category for review clarity?
3. Important: Metadata precedence currently prefers `task_metadata.json` model usage over task history, API history, and UI messages, while usage totals prefer task history before aggregate UI/API metrics. Reviewer question 3: is that priority correct for mixed Cline CLI and extension sessions, or should API history override task history when both have complete usage?

## Request to the reviewer
Focus review on discovery coverage, metadata precedence, and fallback behavior. The most important question is whether the parser should accept any readable companion file as a task signal, or whether discovery should require a recoverable user prompt during the initial scan.

## Follow-ups (not in scope)
- Installing dependencies or regenerating `dist/` in this worktree.
- Adding real-machine fixture captures from Cline CLI and JetBrains installations.
- Broadening the same companion-file recovery strategy to unrelated parsers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens Cline session discovery and context: safer cwd/repo parsing, canonical paths, upstream-accurate token usage, and graceful handling of malformed companion files. Also recovers pending tasks and tool activity from API history and improves discovery across Code forks and JetBrains.

- **New Features**
  - Discovery across Code Insiders/Cursor/Windsurf; JetBrains search is silent when no plugin is installed.
  - Companion fidelity warnings for malformed `api_conversation_history.json`, `task_metadata.json`, and `taskHistory.json` (missing files don’t warn).
  - Recovery: pending tasks and conversation fall back to API history; expanded tool routing (e.g., `apply_diff`, `list_code_definition_names`, unknown tools → MCP) and better modified-file capture.

- **Bug Fixes**
  - Token usage: aggregates `api_req_started`, `deleted_api_reqs`, and `subagent_usage`; avoids double counting finished aggregates.
  - CWD/paths: reject bare path-like strings, stop at whitespace for `cwd:` markers, normalize Windows separators, and resolve storage roots to canonical absolute paths.
  - Performance: first user message found in a single pass; task history reads are cached.

<sup>Written for commit 57d22ad813566f27301c0ab5f77702b17a1491d8. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/57?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

