### PR TITLE
fix(kimi): harden state and context parsing

### DIFF
--- a/src/__tests__/env-cache-invalidation.test.ts
+++ b/src/__tests__/env-cache-invalidation.test.ts
@@ -127,6 +127,14 @@ describe('env fingerprint cache invalidation (issue #18)', () => {
     expect(indexNeedsRebuild()).toBe(true);
   });
 
+  it('indexNeedsRebuild returns true when KIMI_SHARE_DIR changes', () => {
+    writeIndex(currentFingerprint(), [makeSession('sess-1', 'kimi')]);
+
+    vi.stubEnv('KIMI_SHARE_DIR', '/home/user/.kimi-work');
+
+    expect(indexNeedsRebuild()).toBe(true);
+  });
+
   it('loadIndex skips the fingerprint line and returns only sessions', () => {
     writeIndex('#env:CLAUDE_CONFIG_DIR=', [makeSession('sess-1', 'claude'), makeSession('sess-2', 'codex')]);
 

--- a/src/__tests__/kimi-parser.test.ts
+++ b/src/__tests__/kimi-parser.test.ts
@@ -537,6 +537,39 @@ describe('kimi parser hardening', () => {
     );
   });
 
+  it('reports total context lines and dropped record count from a single streaming pass', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-'));
+    tmpHomes.push(home);
+    const workDirPath = '/tmp/project-single-pass-counts';
+    const sessionId = 'single-pass-counts-session';
+
+    writeKimiConfig(home, [{ path: workDirPath }]);
+    const sessionDir = createKimiSession({
+      homeDir: home,
+      workDirPath,
+      sessionId,
+      messages: [],
+    });
+    // Mix valid + invalid + non-object + missing-role rows to exercise both
+    // counters in a single pass.
+    writeRawContext(path.join(sessionDir, 'context.jsonl'), [
+      JSON.stringify({ role: 'user', content: 'first valid' }),
+      '{ this-is-not-json',
+      'null',
+      JSON.stringify({ role: 'assistant', content: 'second valid' }),
+      JSON.stringify({ no_role_field: true }),
+    ]);
+
+    const { extractKimiContext, parseKimiSessions } = await loadKimiParserWithHome(home);
+    const sessions = await parseKimiSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].lines).toBe(5);
+
+    const context = await extractKimiContext(sessions[0]);
+    expect(context.sessionNotes?.sourceMetadata?.contextLines).toBe(5);
+    expect(context.sessionNotes?.sourceMetadata?.contextDroppedRecords).toBe(3);
+  });
+
   it('discovers and extracts legacy flat context jsonl files without migrating them', async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-'));
     tmpHomes.push(home);

--- a/src/__tests__/kimi-parser.test.ts
+++ b/src/__tests__/kimi-parser.test.ts
@@ -1,11 +1,12 @@
-import { createHash } from 'crypto';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UnifiedSession } from '../types/index.js';
 
 const tmpHomes: string[] = [];
+const originalKimiShareDir = process.env.KIMI_SHARE_DIR;
 
 function md5(value: string): string {
   return createHash('md5').update(value, 'utf8').digest('hex');
@@ -16,8 +17,13 @@ function writeJsonl(filePath: string, rows: unknown[]): void {
   fs.writeFileSync(filePath, `${content}\n`, 'utf8');
 }
 
+function writeRawContext(filePath: string, lines: string[]): void {
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+}
+
 function createKimiSession(opts: {
   homeDir: string;
+  shareDir?: string;
   workDirPath: string;
   sessionId: string;
   messages: unknown[];
@@ -25,7 +31,8 @@ function createKimiSession(opts: {
   rawMetadata?: string;
 }): string {
   const hashDir = md5(opts.workDirPath);
-  const sessionDir = path.join(opts.homeDir, '.kimi', 'sessions', hashDir, opts.sessionId);
+  const shareDir = opts.shareDir ?? path.join(opts.homeDir, '.kimi');
+  const sessionDir = path.join(shareDir, 'sessions', hashDir, opts.sessionId);
   fs.mkdirSync(sessionDir, { recursive: true });
   writeJsonl(path.join(sessionDir, 'context.jsonl'), opts.messages);
 
@@ -38,10 +45,21 @@ function createKimiSession(opts: {
   return sessionDir;
 }
 
+function writeKimiState(sessionDir: string, state: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(sessionDir, 'state.json'), JSON.stringify(state), 'utf8');
+}
+
+function writeKimiWire(sessionDir: string, rows: unknown[]): void {
+  writeJsonl(path.join(sessionDir, 'wire.jsonl'), rows);
+}
+
+function writeKimiConfigToShare(shareDir: string, workDirs: Array<{ path: string; kaos?: string }>): void {
+  fs.mkdirSync(shareDir, { recursive: true });
+  fs.writeFileSync(path.join(shareDir, 'kimi.json'), JSON.stringify({ work_dirs: workDirs }, null, 2), 'utf8');
+}
+
 function writeKimiConfig(homeDir: string, workDirs: Array<{ path: string; kaos?: string }>): void {
-  const kimiDir = path.join(homeDir, '.kimi');
-  fs.mkdirSync(kimiDir, { recursive: true });
-  fs.writeFileSync(path.join(kimiDir, 'kimi.json'), JSON.stringify({ work_dirs: workDirs }, null, 2), 'utf8');
+  writeKimiConfigToShare(path.join(homeDir, '.kimi'), workDirs);
 }
 
 async function loadKimiParserWithHome(homeDir: string): Promise<typeof import('../parsers/kimi.js')> {
@@ -53,11 +71,24 @@ async function loadKimiParserWithHome(homeDir: string): Promise<typeof import('.
       homedir: () => homeDir,
     };
   });
+  vi.doMock('../utils/markdown.js', () => ({
+    generateHandoffMarkdown: () => 'mock kimi handoff markdown',
+  }));
   return import('../parsers/kimi.js');
 }
 
+beforeEach(() => {
+  delete process.env.KIMI_SHARE_DIR;
+});
+
 afterEach(() => {
   vi.doUnmock('os');
+  vi.doUnmock('../utils/markdown.js');
+  if (originalKimiShareDir === undefined) {
+    delete process.env.KIMI_SHARE_DIR;
+  } else {
+    process.env.KIMI_SHARE_DIR = originalKimiShareDir;
+  }
   vi.resetModules();
   for (const tmpHome of tmpHomes) {
     fs.rmSync(tmpHome, { recursive: true, force: true });
@@ -66,6 +97,43 @@ afterEach(() => {
 });
 
 describe('kimi parser hardening', () => {
+  it('uses KIMI_SHARE_DIR as the primary runtime directory when set', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-home-'));
+    const shareDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-share-'));
+    tmpHomes.push(home, shareDir);
+    process.env.KIMI_SHARE_DIR = shareDir;
+    const workDirPath = '/tmp/project-share-dir';
+    const sessionId = 'share-dir-session';
+
+    writeKimiConfig(home, [{ path: '/tmp/fallback-home-project' }]);
+    createKimiSession({
+      homeDir: home,
+      workDirPath: '/tmp/fallback-home-project',
+      sessionId: 'fallback-home-session',
+      messages: [{ role: 'user', content: 'Do not read from fallback home when KIMI_SHARE_DIR is set' }],
+    });
+
+    writeKimiConfigToShare(shareDir, [{ path: workDirPath }]);
+    createKimiSession({
+      homeDir: home,
+      shareDir,
+      workDirPath,
+      sessionId,
+      messages: [
+        { role: 'user', content: 'Read from configured share dir' },
+        { role: 'assistant', content: 'Using KIMI_SHARE_DIR.' },
+      ],
+    });
+
+    const { parseKimiSessions } = await loadKimiParserWithHome(home);
+    const sessions = await parseKimiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe(sessionId);
+    expect(sessions[0].cwd).toBe(workDirPath);
+    expect(sessions[0].originalPath.startsWith(shareDir)).toBe(true);
+  });
+
   it('discovers sessions even when metadata.json is missing', async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-'));
     tmpHomes.push(home);
@@ -256,5 +324,268 @@ describe('kimi parser hardening', () => {
 
     expect(sessions.map((s) => s.id)).toContain('active-session');
     expect(sessions.map((s) => s.id)).not.toContain('archived-session');
+  });
+
+  it('uses current state.json archive, title, and wire_mtime fields when present', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-'));
+    tmpHomes.push(home);
+    const workDirPath = '/tmp/project-state-json';
+    const wireMtime = 1_735_086_302.21;
+
+    writeKimiConfig(home, [{ path: workDirPath }]);
+    const activeDir = createKimiSession({
+      homeDir: home,
+      workDirPath,
+      sessionId: 'state-active-session',
+      messages: [{ role: 'assistant', content: 'No user title source.' }],
+    });
+    writeKimiState(activeDir, {
+      custom_title: 'State title',
+      title_generated: true,
+      wire_mtime: wireMtime,
+      archived: false,
+    });
+
+    const archivedDir = createKimiSession({
+      homeDir: home,
+      workDirPath,
+      sessionId: 'state-archived-session',
+      messages: [{ role: 'user', content: 'Archived state session' }],
+    });
+    writeKimiState(archivedDir, {
+      archived: true,
+      archived_at: wireMtime,
+    });
+
+    const { parseKimiSessions } = await loadKimiParserWithHome(home);
+    const sessions = await parseKimiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('state-active-session');
+    expect(sessions[0].summary).toBe('State title');
+    expect(sessions[0].updatedAt.getTime()).toBe(new Date(wireMtime * 1000).getTime());
+  });
+
+  it('treats state.json metadata as primary and metadata.json as a legacy fallback', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-'));
+    tmpHomes.push(home);
+    const workDirPath = '/tmp/project-state-primary';
+    const sessionId = 'state-primary-session';
+    const stateWireMtime = 1_735_086_500.5;
+
+    writeKimiConfig(home, [{ path: workDirPath }]);
+    const sessionDir = createKimiSession({
+      homeDir: home,
+      workDirPath,
+      sessionId,
+      messages: [{ role: 'assistant', content: 'No user content.' }],
+      metadata: {
+        session_id: sessionId,
+        title: 'Legacy title',
+        archived: true,
+        wire_mtime: 1,
+      },
+    });
+    writeKimiState(sessionDir, {
+      title: 'State title wins',
+      archived: false,
+      wire_mtime: stateWireMtime,
+    });
+
+    const { parseKimiSessions } = await loadKimiParserWithHome(home);
+    const sessions = await parseKimiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].summary).toBe('State title wins');
+    expect(sessions[0].updatedAt.getTime()).toBe(new Date(stateWireMtime * 1000).getTime());
+  });
+
+  it('derives repo and exposes optional wire/state/raw metadata during extraction', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-'));
+    tmpHomes.push(home);
+    const workDirPath = '/Users/alice/example-repo';
+    const sessionId = 'wire-metadata-session';
+
+    writeKimiConfig(home, [{ path: workDirPath }]);
+    const sessionDir = createKimiSession({
+      homeDir: home,
+      workDirPath,
+      sessionId,
+      messages: [
+        { role: 'user', content: 'Inspect wire metadata' },
+        { role: 'assistant', content: 'Wire metadata captured.' },
+      ],
+    });
+    writeKimiState(sessionDir, {
+      title: 'Wire metadata',
+      approval: { yolo: false },
+      additional_dirs: ['/tmp/extra'],
+    });
+    writeKimiWire(sessionDir, [
+      { type: 'metadata', protocol_version: '1.6' },
+      { message: { type: 'TurnBegin', payload: { user_input: 'Inspect wire metadata' } } },
+      { type: 'ToolCall', id: 'tool-call-1' },
+    ]);
+
+    const { parseKimiSessions, extractKimiContext } = await loadKimiParserWithHome(home);
+    const sessions = await parseKimiSessions();
+    const session = sessions[0];
+    const context = await extractKimiContext(session);
+
+    expect(session.repo).toBe('alice/example-repo');
+    expect(context.sessionNotes?.rawAccess).toMatchObject({
+      kind: 'directory',
+      path: sessionDir,
+      redacted: true,
+    });
+    expect(context.sessionNotes?.sourceMetadata).toMatchObject({
+      contextPath: path.join(sessionDir, 'context.jsonl'),
+      statePath: path.join(sessionDir, 'state.json'),
+      wirePath: path.join(sessionDir, 'wire.jsonl'),
+      wireProtocolVersion: '1.6',
+      wireRecordTypes: ['TurnBegin', 'ToolCall'],
+    });
+    expect(context.sessionNotes?.fidelityWarnings).toBeUndefined();
+  });
+
+  it('extracts context despite malformed lines, non-object records, and malformed tool call entries', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-'));
+    tmpHomes.push(home);
+    const workDirPath = '/tmp/project-malformed-context';
+    const sessionId = 'malformed-context-session';
+
+    writeKimiConfig(home, [{ path: workDirPath }]);
+    const sessionDir = createKimiSession({
+      homeDir: home,
+      workDirPath,
+      sessionId,
+      messages: [],
+    });
+    writeRawContext(path.join(sessionDir, 'context.jsonl'), [
+      '{ this-is-not-json',
+      'null',
+      JSON.stringify({ role: '_system_prompt', content: 'Internal prompt should not appear.' }),
+      JSON.stringify({ role: 'user', content: [{ type: 'text', text: 'Please commit the change' }] }),
+      JSON.stringify({
+        role: 'assistant',
+        content: [
+          { type: 'think', think: 'Need to run the shell command next step.' },
+          { type: 'think', think: '  need to run the shell command next step.  ' },
+          { type: 'text', text: 'I will run it.' },
+        ],
+        tool_calls: [
+          {
+            type: 'function',
+            id: 'functions.Shell:22',
+            function: {
+              name: 'Shell',
+              arguments: '{"command":"git commit -m \\"feat: parser hardening\n\nBody line\\""}',
+            },
+          },
+          { type: 'function', id: 'broken-call' },
+          {
+            type: 'function',
+            id: 'functions.Strange:1',
+            function: {
+              name: 'StrangeTool',
+              arguments: '{"path":"src/example.ts"}',
+            },
+          },
+        ],
+      }),
+      JSON.stringify({ role: '_usage', token_count: 250 }),
+    ]);
+
+    const { extractKimiContext } = await loadKimiParserWithHome(home);
+    const session: UnifiedSession = {
+      id: sessionId,
+      source: 'kimi',
+      cwd: workDirPath,
+      repo: '',
+      lines: 6,
+      bytes: fs.statSync(path.join(sessionDir, 'context.jsonl')).size,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      originalPath: sessionDir,
+      summary: 'Malformed context test',
+    };
+
+    const context = await extractKimiContext(session);
+
+    expect(context.recentMessages).toEqual([
+      { role: 'user', content: 'Please commit the change' },
+      { role: 'assistant', content: 'I will run it.' },
+    ]);
+    expect(context.toolSummaries.find((summary) => summary.name === 'Shell')?.samples[0]?.summary).toContain(
+      'git commit -m',
+    );
+    expect(context.toolSummaries.find((summary) => summary.name === 'StrangeTool')?.samples[0]?.summary).toContain(
+      'src/example.ts',
+    );
+    expect(context.pendingTasks).toEqual(['Need to run the shell command next step.']);
+    expect(context.sessionNotes?.tokenUsage).toBeUndefined();
+    expect(context.sessionNotes?.rawAccess).toMatchObject({
+      kind: 'directory',
+      path: sessionDir,
+      redacted: true,
+    });
+    expect(context.sessionNotes?.fidelityWarnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('wire.jsonl was not present'),
+        expect.stringContaining('malformed or unsupported record'),
+      ]),
+    );
+  });
+
+  it('discovers and extracts legacy flat context jsonl files without migrating them', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-parser-'));
+    tmpHomes.push(home);
+    const workDirPath = '/tmp/project-legacy-flat';
+    const sessionId = 'legacy-flat-session';
+
+    writeKimiConfig(home, [{ path: workDirPath }]);
+    const workDirHash = md5(workDirPath);
+    const workDirSessionsDir = path.join(home, '.kimi', 'sessions', workDirHash);
+    fs.mkdirSync(workDirSessionsDir, { recursive: true });
+    const contextPath = path.join(workDirSessionsDir, `${sessionId}.jsonl`);
+    writeJsonl(contextPath, [
+      { role: 'user', content: 'Read legacy flat session' },
+      {
+        role: 'assistant',
+        content: 'Reading.',
+        tool_calls: [
+          {
+            type: 'function',
+            id: 'functions.Read:1',
+            function: { name: 'Read', arguments: '{"file_path":"src/legacy.ts"}' },
+          },
+        ],
+      },
+    ]);
+
+    const { parseKimiSessions, extractKimiContext } = await loadKimiParserWithHome(home);
+    const sessions = await parseKimiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe(sessionId);
+    expect(sessions[0].cwd).toBe(workDirPath);
+    expect(sessions[0].originalPath).toBe(contextPath);
+
+    const context = await extractKimiContext(sessions[0]);
+    expect(context.recentMessages).toEqual([
+      { role: 'user', content: 'Read legacy flat session' },
+      { role: 'assistant', content: 'Reading.' },
+    ]);
+    expect(context.toolSummaries.find((summary) => summary.name === 'Read')?.samples[0]?.summary).toBe(
+      'read src/legacy.ts',
+    );
+    expect(context.sessionNotes?.rawAccess).toMatchObject({
+      kind: 'file',
+      path: contextPath,
+      redacted: true,
+    });
+    expect(context.sessionNotes?.fidelityWarnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('legacy flat JSONL')]),
+    );
   });
 });

--- a/src/parsers/kimi.ts
+++ b/src/parsers/kimi.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
@@ -11,29 +11,86 @@ import type {
   ToolUsageSummary,
   UnifiedSession,
 } from '../types/index.js';
-import type { KimiMessage, KimiMetadata } from '../types/schemas.js';
-import { KimiMetadataSchema } from '../types/schemas.js';
+import type { KimiMessage } from '../types/schemas.js';
 import { classifyToolName } from '../types/tool-names.js';
 import { extractTextFromBlocks } from '../utils/content.js';
 import { listSubdirectories } from '../utils/fs-helpers.js';
-import { readJsonlFile } from '../utils/jsonl.js';
+import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
-import { cleanSummary, homeDir, trimMessages } from '../utils/parser-helpers.js';
+import { cleanSummary, extractRepoFromCwd, homeDir, trimMessages } from '../utils/parser-helpers.js';
 import { fileSummary, mcpSummary, SummaryCollector, shellSummary, truncate } from '../utils/tool-summarizer.js';
 
-const KIMI_SESSIONS_DIR = path.join(homeDir(), '.kimi', 'sessions');
-const KIMI_CONFIG_PATH = path.join(homeDir(), '.kimi', 'kimi.json');
+function getKimiShareDir(): string {
+  const configured = process.env.KIMI_SHARE_DIR?.trim();
+  return configured ? path.resolve(configured) : path.join(homeDir(), '.kimi');
+}
+
+const KIMI_SHARE_DIR = getKimiShareDir();
+const KIMI_SESSIONS_DIR = path.join(KIMI_SHARE_DIR, 'sessions');
+const KIMI_CONFIG_PATH = path.join(KIMI_SHARE_DIR, 'kimi.json');
 
 type KimiWorkDirEntry = { path: string; kaos?: string };
+type KimiSessionMetadata = {
+  sessionId?: string;
+  title?: string;
+  archived?: boolean;
+  wireMtime?: number | null;
+};
+type KimiMetadataFields = KimiSessionMetadata & {
+  archivedPresent: boolean;
+  wireMtimePresent: boolean;
+};
+type KimiContextReadResult = {
+  contextPath: string;
+  messages: KimiMessage[];
+  rawLineCount: number;
+  bytes: number;
+  droppedRecordCount: number;
+};
+type KimiWireMetadata = {
+  path?: string;
+  exists: boolean;
+  bytes?: number;
+  protocolVersion?: string;
+  recordTypes: string[];
+};
+
+type KimiContentBlock = Record<string, unknown> & { type: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | null | undefined {
+  const value = record[key];
+  if (value === null) return null;
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
 
 function hashWorkDirPath(workDirPath: string): string {
   return createHash('md5').update(workDirPath, 'utf8').digest('hex');
 }
 
-function parseKimiWorkDirs(): KimiWorkDirEntry[] {
+async function readJsonObject(filePath: string): Promise<Record<string, unknown> | undefined> {
   try {
-    if (!fs.existsSync(KIMI_CONFIG_PATH)) return [];
-    const raw = JSON.parse(fs.readFileSync(KIMI_CONFIG_PATH, 'utf8')) as { work_dirs?: unknown };
+    if (!fs.existsSync(filePath)) return undefined;
+    const parsed: unknown = JSON.parse(await fs.promises.readFile(filePath, 'utf8'));
+    return isRecord(parsed) ? parsed : undefined;
+  } catch (err) {
+    logger.debug('kimi: failed to parse json file', filePath, err);
+    return undefined;
+  }
+}
+
+async function parseKimiWorkDirs(): Promise<KimiWorkDirEntry[]> {
+  try {
+    const raw = await readJsonObject(KIMI_CONFIG_PATH);
+    if (!raw) return [];
     const workDirs = Array.isArray(raw.work_dirs) ? raw.work_dirs : [];
 
     return workDirs
@@ -81,10 +138,29 @@ function resolveCwdFromSessionDir(sessionDir: string, hashIndex: Map<string, str
   return hashIndex.get(workDirHash) || '';
 }
 
+function resolveContextPath(sessionPath: string): string {
+  return sessionPath.endsWith('.jsonl') ? sessionPath : path.join(sessionPath, 'context.jsonl');
+}
+
+function deriveSessionId(sessionPath: string): string {
+  if (sessionPath.endsWith('.jsonl')) {
+    return path.basename(sessionPath, '.jsonl');
+  }
+  return path.basename(sessionPath);
+}
+
+function getSessionMetadataDir(sessionPath: string): string | undefined {
+  try {
+    return fs.statSync(sessionPath).isDirectory() ? sessionPath : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
- * Find all Kimi session directories
+ * Find all Kimi session directories and legacy flat context files.
  */
-async function findSessionDirs(): Promise<string[]> {
+async function findSessionPaths(): Promise<string[]> {
   const results: string[] = [];
 
   if (!fs.existsSync(KIMI_SESSIONS_DIR)) {
@@ -93,11 +169,20 @@ async function findSessionDirs(): Promise<string[]> {
 
   // Kimi stores sessions as: ~/.kimi/sessions/{workdir_hash}/{session_id}/
   for (const workdirDir of listSubdirectories(KIMI_SESSIONS_DIR)) {
-    for (const sessionDir of listSubdirectories(workdirDir)) {
-      const contextPath = path.join(sessionDir, 'context.jsonl');
-      if (fs.existsSync(contextPath)) {
-        results.push(sessionDir);
+    try {
+      for (const entry of fs.readdirSync(workdirDir, { withFileTypes: true })) {
+        const fullPath = path.join(workdirDir, entry.name);
+        if (entry.isDirectory() || (entry.isSymbolicLink() && fs.existsSync(path.join(fullPath, 'context.jsonl')))) {
+          const contextPath = path.join(fullPath, 'context.jsonl');
+          if (fs.existsSync(contextPath)) {
+            results.push(fullPath);
+          }
+        } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+          results.push(fullPath);
+        }
       }
+    } catch (err) {
+      logger.debug('kimi: cannot read workdir session directory', workdirDir, err);
     }
   }
 
@@ -105,37 +190,163 @@ async function findSessionDirs(): Promise<string[]> {
 }
 
 /**
- * Parse metadata.json from a Kimi session directory
+ * Parse legacy metadata.json and current state.json from a Kimi session directory.
  */
-function parseMetadata(sessionDir: string): KimiMetadata | undefined {
-  const metadataPath = path.join(sessionDir, 'metadata.json');
-  if (!fs.existsSync(metadataPath)) {
-    return undefined;
+function extractMetadataFields(raw: Record<string, unknown>): KimiMetadataFields {
+  const title = stringField(raw, 'custom_title') || stringField(raw, 'title');
+  const wireMtime = numberField(raw, 'wire_mtime');
+  const archivedPresent = typeof raw.archived === 'boolean';
+
+  return {
+    sessionId: stringField(raw, 'session_id'),
+    title: title && title !== 'Untitled' ? title : undefined,
+    archived: archivedPresent ? raw.archived === true : undefined,
+    ...(wireMtime !== undefined ? { wireMtime } : {}),
+    archivedPresent,
+    wireMtimePresent: wireMtime !== undefined,
+  };
+}
+
+function emptyMetadataFields(): KimiMetadataFields {
+  return {
+    archivedPresent: false,
+    wireMtimePresent: false,
+  };
+}
+
+async function parseSessionMetadata(sessionDir: string): Promise<KimiSessionMetadata> {
+  const [legacyRaw, stateRaw] = await Promise.all([
+    readJsonObject(path.join(sessionDir, 'metadata.json')),
+    readJsonObject(path.join(sessionDir, 'state.json')),
+  ]);
+
+  const legacy = legacyRaw ? extractMetadataFields(legacyRaw) : emptyMetadataFields();
+  const state = stateRaw ? extractMetadataFields(stateRaw) : emptyMetadataFields();
+
+  return {
+    sessionId: state.sessionId || legacy.sessionId,
+    title: state.title || legacy.title,
+    archived: state.archivedPresent ? state.archived : legacy.archived,
+    wireMtime: state.wireMtimePresent ? state.wireMtime : legacy.wireMtime,
+  };
+}
+
+function getMetadataCreatedAt(sessionDir: string, fallback: Date): Date {
+  for (const filename of ['state.json', 'metadata.json']) {
+    try {
+      const stats = fs.statSync(path.join(sessionDir, filename));
+      return stats.birthtime;
+    } catch (err) {
+      logger.debug('kimi: metadata stats unavailable', sessionDir, filename, err);
+    }
   }
 
-  try {
-    const content = fs.readFileSync(metadataPath, 'utf8');
-    const result = KimiMetadataSchema.safeParse(JSON.parse(content));
-    if (result.success) return result.data;
-    logger.debug('kimi: metadata validation failed', sessionDir, result.error.message);
-    return undefined;
-  } catch (err) {
-    logger.debug('kimi: failed to parse metadata', sessionDir, err);
-    return undefined;
-  }
+  return fallback;
 }
 
 /**
  * Read context.jsonl from a Kimi session directory
  */
-async function readContextFile(sessionDir: string): Promise<KimiMessage[]> {
+async function readContextData(sessionPath: string): Promise<KimiContextReadResult> {
+  const contextPath = resolveContextPath(sessionPath);
+
   try {
-    const contextPath = path.join(sessionDir, 'context.jsonl');
-    return await readJsonlFile<KimiMessage>(contextPath);
+    const [records, stats] = await Promise.all([readJsonlFile<unknown>(contextPath), getFileStats(contextPath)]);
+    const messages: KimiMessage[] = [];
+    let droppedRecordCount = Math.max(0, stats.lines - records.length);
+
+    for (const record of records) {
+      if (!isRecord(record)) {
+        logger.debug('kimi: skipping non-object context record', contextPath);
+        droppedRecordCount++;
+        continue;
+      }
+      if (typeof record.role !== 'string') {
+        logger.debug('kimi: skipping context record with missing role', contextPath);
+        droppedRecordCount++;
+        continue;
+      }
+      messages.push(record as KimiMessage);
+    }
+
+    return {
+      contextPath,
+      messages,
+      rawLineCount: stats.lines,
+      bytes: stats.bytes,
+      droppedRecordCount,
+    };
   } catch (err) {
-    logger.debug('kimi: failed to read context', sessionDir, err);
-    return [];
+    logger.debug('kimi: failed to read context', sessionPath, err);
+    return {
+      contextPath,
+      messages: [],
+      rawLineCount: 0,
+      bytes: 0,
+      droppedRecordCount: 0,
+    };
   }
+}
+
+async function readWireMetadata(sessionPath: string): Promise<KimiWireMetadata> {
+  const sessionDir = getSessionMetadataDir(sessionPath);
+  if (!sessionDir) return { exists: false, recordTypes: [] };
+
+  const wirePath = path.join(sessionDir, 'wire.jsonl');
+  if (!fs.existsSync(wirePath)) return { exists: false, path: wirePath, recordTypes: [] };
+
+  const recordTypes: string[] = [];
+  let protocolVersion: string | undefined;
+  let bytes: number | undefined;
+
+  try {
+    bytes = fs.statSync(wirePath).size;
+  } catch (err) {
+    logger.debug('kimi: failed to stat wire.jsonl', wirePath, err);
+  }
+
+  await scanJsonlHead(wirePath, 25, (parsed) => {
+    if (!isRecord(parsed)) return 'continue';
+
+    if (parsed.type === 'metadata') {
+      protocolVersion = stringField(parsed, 'protocol_version') || stringField(parsed, 'protocolVersion');
+    }
+
+    const topLevelType = stringField(parsed, 'type');
+    const message = parsed.message;
+    const messageType = isRecord(message) ? stringField(message, 'type') : undefined;
+    const recordType = messageType || (topLevelType && topLevelType !== 'metadata' ? topLevelType : undefined);
+    if (recordType && !recordTypes.includes(recordType)) {
+      recordTypes.push(recordType);
+    }
+
+    return 'continue';
+  });
+
+  return {
+    exists: true,
+    path: wirePath,
+    ...(bytes !== undefined ? { bytes } : {}),
+    ...(protocolVersion ? { protocolVersion } : {}),
+    recordTypes,
+  };
+}
+
+function getContentBlocks(content: unknown): KimiContentBlock[] {
+  if (!Array.isArray(content)) return [];
+  return content.filter((block): block is KimiContentBlock => isRecord(block) && typeof block.type === 'string');
+}
+
+function extractMessageText(content: unknown): string {
+  if (typeof content === 'string' || content === undefined) {
+    return extractTextFromBlocks(content);
+  }
+
+  const blocks = getContentBlocks(content).map((block) => ({
+    type: block.type,
+    text: typeof block.text === 'string' ? block.text : undefined,
+  }));
+  return extractTextFromBlocks(blocks);
 }
 
 /**
@@ -144,22 +355,112 @@ async function readContextFile(sessionDir: string): Promise<KimiMessage[]> {
 function extractFirstUserMessage(messages: KimiMessage[]): string {
   for (const msg of messages) {
     if (msg.role === 'user') {
-      const text = extractTextFromBlocks(msg.content as string | Array<{ type: string; text?: string }>);
+      const text = extractMessageText(msg.content);
       if (text) return text;
     }
   }
   return '';
 }
 
+function parseJsonObject(value: string): Record<string, unknown> | undefined {
+  const parsed: unknown = JSON.parse(value);
+  return isRecord(parsed) ? parsed : undefined;
+}
+
+function escapeJsonStringControlChars(value: string): string {
+  let escapedJson = '';
+  let insideString = false;
+  let escaped = false;
+
+  for (const char of value) {
+    if (escaped) {
+      escapedJson += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escapedJson += char;
+      if (insideString) escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      insideString = !insideString;
+      escapedJson += char;
+      continue;
+    }
+
+    const code = char.charCodeAt(0);
+    if (insideString && code >= 0 && code <= 0x1f) {
+      switch (char) {
+        case '\n':
+          escapedJson += '\\n';
+          break;
+        case '\r':
+          escapedJson += '\\r';
+          break;
+        case '\t':
+          escapedJson += '\\t';
+          break;
+        case '\b':
+          escapedJson += '\\b';
+          break;
+        case '\f':
+          escapedJson += '\\f';
+          break;
+        default:
+          escapedJson += `\\u${code.toString(16).padStart(4, '0')}`;
+      }
+      continue;
+    }
+
+    escapedJson += char;
+  }
+
+  return escapedJson;
+}
+
 /**
  * Parse tool call arguments safely
  */
-function parseToolArgs(argsStr: string): Record<string, unknown> {
-  try {
-    return JSON.parse(argsStr);
-  } catch {
+function parseToolArgs(argsValue: unknown): Record<string, unknown> {
+  if (typeof argsValue !== 'string' || argsValue.trim().length === 0) {
     return {};
   }
+
+  try {
+    return parseJsonObject(argsValue) ?? {};
+  } catch (err) {
+    logger.debug('kimi: failed to parse tool arguments as strict JSON', err);
+  }
+
+  try {
+    return parseJsonObject(escapeJsonStringControlChars(argsValue)) ?? {};
+  } catch (err) {
+    logger.debug('kimi: failed to parse tool arguments after control-char escaping', err);
+    return {};
+  }
+}
+
+function stringArg(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getToolCalls(msg: KimiMessage): Array<{ name: string; arguments: unknown }> {
+  const rawToolCalls = (msg as { tool_calls?: unknown }).tool_calls;
+  if (!Array.isArray(rawToolCalls)) return [];
+
+  const calls: Array<{ name: string; arguments: unknown }> = [];
+  for (const rawCall of rawToolCalls) {
+    if (!isRecord(rawCall) || !isRecord(rawCall.function)) continue;
+    const name = rawCall.function.name;
+    if (typeof name !== 'string' || name.length === 0) continue;
+    calls.push({ name, arguments: rawCall.function.arguments });
+  }
+
+  return calls;
 }
 
 /**
@@ -172,15 +473,15 @@ function extractToolData(
   const collector = new SummaryCollector(config);
 
   for (const msg of messages) {
-    if (msg.role !== 'assistant' || !msg.tool_calls) continue;
+    if (msg.role !== 'assistant') continue;
 
-    for (const tc of msg.tool_calls) {
-      const name = tc.function.name;
-      const args = parseToolArgs(tc.function.arguments);
+    for (const tc of getToolCalls(msg)) {
+      const name = tc.name;
+      const args = parseToolArgs(tc.arguments);
       const category = classifyToolName(name);
       if (!category) continue; // skip internal tools
 
-      const fp = (args.file_path as string) || (args.path as string) || '';
+      const fp = stringArg(args, 'file_path') || stringArg(args, 'path') || '';
 
       switch (category) {
         case 'write': {
@@ -198,7 +499,7 @@ function extractToolData(
           });
           break;
         case 'shell': {
-          const cmd = (args.command as string) || (args.cmd as string) || '';
+          const cmd = stringArg(args, 'command') || stringArg(args, 'cmd') || '';
           collector.add(name, shellSummary(cmd), {
             data: { category: 'shell', command: cmd },
           });
@@ -213,39 +514,39 @@ function extractToolData(
           break;
         }
         case 'grep': {
-          const pattern = (args.pattern as string) || (args.query as string) || '';
+          const pattern = stringArg(args, 'pattern') || stringArg(args, 'query') || '';
           collector.add(name, `grep "${truncate(pattern, 40)}"`, {
             data: { category: 'grep', pattern, ...(fp ? { targetPath: fp } : {}) },
           });
           break;
         }
         case 'glob': {
-          const pattern = (args.pattern as string) || fp;
+          const pattern = stringArg(args, 'pattern') || fp;
           collector.add(name, `glob ${truncate(pattern, 50)}`, {
             data: { category: 'glob', pattern },
           });
           break;
         }
         case 'search':
-          collector.add(name, `search "${truncate((args.query as string) || '', 50)}"`, {
-            data: { category: 'search', query: (args.query as string) || '' },
+          collector.add(name, `search "${truncate(stringArg(args, 'query') || '', 50)}"`, {
+            data: { category: 'search', query: stringArg(args, 'query') || '' },
           });
           break;
         case 'fetch':
-          collector.add(name, `fetch ${truncate((args.url as string) || '', 60)}`, {
-            data: { category: 'fetch', url: (args.url as string) || '' },
+          collector.add(name, `fetch ${truncate(stringArg(args, 'url') || '', 60)}`, {
+            data: { category: 'fetch', url: stringArg(args, 'url') || '' },
           });
           break;
         case 'task': {
-          const desc = (args.description as string) || (args.prompt as string) || '';
-          const agentType = (args.subagent_type as string) || undefined;
+          const desc = stringArg(args, 'description') || stringArg(args, 'prompt') || '';
+          const agentType = stringArg(args, 'subagent_type');
           collector.add(name, `task "${truncate(desc, 60)}"${agentType ? ` (${agentType})` : ''}`, {
             data: { category: 'task', description: desc, ...(agentType ? { agentType } : {}) },
           });
           break;
         }
         case 'ask': {
-          const question = truncate((args.question as string) || (args.prompt as string) || '', 80);
+          const question = truncate(stringArg(args, 'question') || stringArg(args, 'prompt') || '', 80);
           collector.add(name, `ask: "${question}"`, {
             data: { category: 'ask', question },
           });
@@ -265,21 +566,33 @@ function extractToolData(
   return { summaries: collector.getSummaries(), filesModified: collector.getFilesModified() };
 }
 
+function thinkText(block: KimiContentBlock): string | undefined {
+  if (block.type !== 'think' || block.think === undefined || block.think === null) return undefined;
+  return String(block.think).trim();
+}
+
+function normalizedTaskKey(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
 /**
  * Extract session notes (thinking blocks, token usage)
  */
 function extractSessionNotes(messages: KimiMessage[]): SessionNotes {
   const notes: SessionNotes = {};
   const reasoning: string[] = [];
+  const reasoningSet = new Set<string>();
   let latestTokenCount = 0;
 
   for (const msg of messages) {
     // Extract thinking blocks from assistant messages
-    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-      for (const block of msg.content) {
-        if (block.type === 'think' && block.think) {
-          const thought = String(block.think).trim();
-          if (thought.length > 10 && reasoning.length < 5) {
+    if (msg.role === 'assistant') {
+      for (const block of getContentBlocks(msg.content)) {
+        const thought = thinkText(block);
+        if (thought) {
+          const key = normalizedTaskKey(thought);
+          if (thought.length > 10 && reasoning.length < 5 && !reasoningSet.has(key)) {
+            reasoningSet.add(key);
             reasoning.push(truncate(thought, 200));
           }
         }
@@ -309,34 +622,33 @@ function extractSessionNotes(messages: KimiMessage[]): SessionNotes {
  * Parse all Kimi sessions
  */
 export async function parseKimiSessions(): Promise<UnifiedSession[]> {
-  const sessionDirs = await findSessionDirs();
+  const sessionPaths = await findSessionPaths();
   const sessions: UnifiedSession[] = [];
-  const workDirHashIndex = buildWorkDirHashIndex(parseKimiWorkDirs());
+  const workDirHashIndex = buildWorkDirHashIndex(await parseKimiWorkDirs());
 
-  for (const sessionDir of sessionDirs) {
+  for (const sessionPath of sessionPaths) {
     try {
-      const contextPath = path.join(sessionDir, 'context.jsonl');
+      const contextPath = resolveContextPath(sessionPath);
       const contextStats = fs.statSync(contextPath);
 
-      const metadata = parseMetadata(sessionDir);
-      if (metadata?.archived === true) continue;
-      const sessionId = metadata?.session_id || path.basename(sessionDir);
+      const metadataDir = getSessionMetadataDir(sessionPath);
+      const metadata = metadataDir ? await parseSessionMetadata(metadataDir) : {};
+      if (metadata.archived === true) continue;
+      const sessionId = metadata.sessionId || deriveSessionId(sessionPath);
       if (!sessionId) continue;
 
-      const messages = await readContextFile(sessionDir);
-      if (messages.length === 0) continue;
+      const contextData = await readContextData(sessionPath);
+      if (contextData.messages.length === 0) continue;
 
-      const firstUserMessage = extractFirstUserMessage(messages);
+      const firstUserMessage = extractFirstUserMessage(contextData.messages);
       const summary = cleanSummary(firstUserMessage);
 
-      // metadata.json is optional and may be created after context.jsonl
-      const metadataPath = path.join(sessionDir, 'metadata.json');
-      const metadataStats = fs.existsSync(metadataPath) ? fs.statSync(metadataPath) : undefined;
-      const cwd = resolveCwdFromSessionDir(sessionDir, workDirHashIndex);
+      const cwd = resolveCwdFromSessionDir(sessionPath, workDirHashIndex);
+      const repo = extractRepoFromCwd(cwd);
 
       let updatedAt = contextStats.mtime;
-      if (typeof metadata?.wire_mtime === 'number' && Number.isFinite(metadata.wire_mtime) && metadata.wire_mtime > 0) {
-        const wireUpdatedAt = new Date(metadata.wire_mtime * 1000);
+      if (metadata.wireMtime !== null && metadata.wireMtime !== undefined && metadata.wireMtime > 0) {
+        const wireUpdatedAt = new Date(metadata.wireMtime * 1000);
         if (!Number.isNaN(wireUpdatedAt.getTime())) {
           updatedAt = wireUpdatedAt;
         }
@@ -346,16 +658,16 @@ export async function parseKimiSessions(): Promise<UnifiedSession[]> {
         id: sessionId,
         source: 'kimi',
         cwd,
-        repo: '',
-        lines: messages.length,
-        bytes: contextStats.size,
-        createdAt: metadataStats?.birthtime || contextStats.birthtime,
+        repo,
+        lines: contextData.rawLineCount,
+        bytes: contextData.bytes,
+        createdAt: metadataDir ? getMetadataCreatedAt(metadataDir, contextStats.birthtime) : contextStats.birthtime,
         updatedAt,
-        originalPath: sessionDir,
-        summary: summary || metadata?.title || undefined,
+        originalPath: sessionPath,
+        summary: summary || metadata.title || undefined,
       });
     } catch (err) {
-      logger.debug('kimi: skipping unparseable session', sessionDir, err);
+      logger.debug('kimi: skipping unparseable session', sessionPath, err);
       // Skip sessions we can't parse
     }
   }
@@ -368,13 +680,70 @@ export async function parseKimiSessions(): Promise<UnifiedSession[]> {
  */
 export async function extractKimiContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const resolvedConfig = config ?? getPreset('standard');
-  const messages = await readContextFile(session.originalPath);
+  const contextData = await readContextData(session.originalPath);
+  const messages = contextData.messages;
   const recentMessages: ConversationMessage[] = [];
   const pendingTasks: string[] = [];
   const pendingTaskSet = new Set<string>();
 
   const toolData = extractToolData(messages, resolvedConfig);
   const sessionNotes = extractSessionNotes(messages);
+  const wireMetadata = await readWireMetadata(session.originalPath);
+  const metadataDir = getSessionMetadataDir(session.originalPath);
+  const statePath = metadataDir ? path.join(metadataDir, 'state.json') : undefined;
+  const legacyMetadataPath = metadataDir ? path.join(metadataDir, 'metadata.json') : undefined;
+  const sourceMetadata: Record<string, unknown> = {
+    shareDir: KIMI_SHARE_DIR,
+    contextPath: contextData.contextPath,
+    contextLines: contextData.rawLineCount,
+    contextBytes: contextData.bytes,
+  };
+  if (contextData.droppedRecordCount > 0) {
+    sourceMetadata.contextDroppedRecords = contextData.droppedRecordCount;
+  }
+  if (statePath && fs.existsSync(statePath)) {
+    sourceMetadata.statePath = statePath;
+  }
+  if (legacyMetadataPath && fs.existsSync(legacyMetadataPath)) {
+    sourceMetadata.legacyMetadataPath = legacyMetadataPath;
+  }
+  if (wireMetadata.path) {
+    sourceMetadata.wirePath = wireMetadata.path;
+  }
+  if (wireMetadata.protocolVersion) {
+    sourceMetadata.wireProtocolVersion = wireMetadata.protocolVersion;
+  }
+  if (wireMetadata.recordTypes.length > 0) {
+    sourceMetadata.wireRecordTypes = wireMetadata.recordTypes;
+  }
+  if (wireMetadata.bytes !== undefined) {
+    sourceMetadata.wireBytes = wireMetadata.bytes;
+  }
+
+  sessionNotes.sourceMetadata = { ...(sessionNotes.sourceMetadata ?? {}), ...sourceMetadata };
+  sessionNotes.rawAccess = {
+    kind: metadataDir ? 'directory' : 'file',
+    path: metadataDir || contextData.contextPath,
+    redacted: true,
+  };
+
+  const fidelityWarnings: string[] = [];
+  if (!session.cwd) {
+    fidelityWarnings.push('Kimi cwd/repo could not be resolved because the workdir hash was not found in kimi.json.');
+  }
+  if (!metadataDir) {
+    fidelityWarnings.push('Kimi legacy flat JSONL session has no state.json or wire.jsonl sidecar metadata.');
+  } else if (!wireMetadata.exists) {
+    fidelityWarnings.push('Kimi wire.jsonl was not present; wire protocol metadata is unavailable.');
+  }
+  if (contextData.droppedRecordCount > 0) {
+    fidelityWarnings.push(
+      `Kimi context.jsonl contained ${contextData.droppedRecordCount} malformed or unsupported record(s) that were skipped.`,
+    );
+  }
+  if (fidelityWarnings.length > 0) {
+    sessionNotes.fidelityWarnings = [...(sessionNotes.fidelityWarnings ?? []), ...fidelityWarnings];
+  }
 
   // Extract recent conversation messages
   let messageCount = 0;
@@ -382,7 +751,7 @@ export async function extractKimiContext(session: UnifiedSession, config?: Verbo
     const msg = messages[i];
 
     if (msg.role === 'user') {
-      const content = extractTextFromBlocks(msg.content as string | Array<{ type: string; text?: string }>);
+      const content = extractMessageText(msg.content);
       if (content) {
         recentMessages.unshift({
           role: 'user',
@@ -391,7 +760,7 @@ export async function extractKimiContext(session: UnifiedSession, config?: Verbo
         messageCount++;
       }
     } else if (msg.role === 'assistant') {
-      const content = extractTextFromBlocks(msg.content as string | Array<{ type: string; text?: string }>);
+      const content = extractMessageText(msg.content);
       if (content) {
         recentMessages.unshift({
           role: 'assistant',
@@ -401,19 +770,19 @@ export async function extractKimiContext(session: UnifiedSession, config?: Verbo
       }
 
       // Extract pending tasks from thinking blocks
-      if (Array.isArray(msg.content) && pendingTasks.length < 5) {
-        for (const block of msg.content) {
-          if (block.type === 'think' && block.think) {
-            const thought = String(block.think).toLowerCase();
+      if (pendingTasks.length < 5) {
+        for (const block of getContentBlocks(msg.content)) {
+          const taskText = thinkText(block);
+          if (taskText) {
+            const taskKey = normalizedTaskKey(taskText);
             if (
-              thought.includes('need to') ||
-              thought.includes('next step') ||
-              thought.includes('todo') ||
-              thought.includes('remaining')
+              taskKey.includes('need to') ||
+              taskKey.includes('next step') ||
+              taskKey.includes('todo') ||
+              taskKey.includes('remaining')
             ) {
-              const taskText = String(block.think).trim();
-              if (taskText.length > 0 && !pendingTaskSet.has(taskText)) {
-                pendingTaskSet.add(taskText);
+              if (!pendingTaskSet.has(taskKey)) {
+                pendingTaskSet.add(taskKey);
                 pendingTasks.push(taskText);
               }
             }

--- a/src/parsers/kimi.ts
+++ b/src/parsers/kimi.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
@@ -14,8 +15,7 @@ import type {
 import type { KimiMessage } from '../types/schemas.js';
 import { classifyToolName } from '../types/tool-names.js';
 import { extractTextFromBlocks } from '../utils/content.js';
-import { listSubdirectories } from '../utils/fs-helpers.js';
-import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
+import { scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { cleanSummary, extractRepoFromCwd, homeDir, trimMessages } from '../utils/parser-helpers.js';
 import { fileSummary, mcpSummary, SummaryCollector, shellSummary, truncate } from '../utils/tool-summarizer.js';
@@ -46,6 +46,8 @@ type KimiContextReadResult = {
   rawLineCount: number;
   bytes: number;
   droppedRecordCount: number;
+  mtime?: Date;
+  birthtime?: Date;
 };
 type KimiWireMetadata = {
   path?: string;
@@ -149,11 +151,45 @@ function deriveSessionId(sessionPath: string): string {
   return path.basename(sessionPath);
 }
 
-function getSessionMetadataDir(sessionPath: string): string | undefined {
+async function getSessionMetadataDir(sessionPath: string): Promise<string | undefined> {
   try {
-    return fs.statSync(sessionPath).isDirectory() ? sessionPath : undefined;
+    const stats = await fs.promises.stat(sessionPath);
+    return stats.isDirectory() ? sessionPath : undefined;
   } catch {
     return undefined;
+  }
+}
+
+async function listSubdirectoriesAsync(dir: string): Promise<string[]> {
+  try {
+    const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    const subdirs: string[] = [];
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        subdirs.push(fullPath);
+      } else if (entry.isSymbolicLink()) {
+        try {
+          const stat = await fs.promises.stat(fullPath);
+          if (stat.isDirectory()) subdirs.push(fullPath);
+        } catch {
+          // broken symlink — skip
+        }
+      }
+    }
+    return subdirs;
+  } catch (err) {
+    logger.debug('kimi: cannot list subdirectories of', dir, err);
+    return [];
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -161,20 +197,39 @@ function getSessionMetadataDir(sessionPath: string): string | undefined {
  * Find all Kimi session directories and legacy flat context files.
  */
 async function findSessionPaths(): Promise<string[]> {
-  const results: string[] = [];
-
-  if (!fs.existsSync(KIMI_SESSIONS_DIR)) {
-    return results;
+  if (!(await pathExists(KIMI_SESSIONS_DIR))) {
+    return [];
   }
 
+  const results: string[] = [];
+
   // Kimi stores sessions as: ~/.kimi/sessions/{workdir_hash}/{session_id}/
-  for (const workdirDir of listSubdirectories(KIMI_SESSIONS_DIR)) {
+  const workdirDirs = await listSubdirectoriesAsync(KIMI_SESSIONS_DIR);
+  for (const workdirDir of workdirDirs) {
     try {
-      for (const entry of fs.readdirSync(workdirDir, { withFileTypes: true })) {
+      const entries = await fs.promises.readdir(workdirDir, { withFileTypes: true });
+      for (const entry of entries) {
         const fullPath = path.join(workdirDir, entry.name);
-        if (entry.isDirectory() || (entry.isSymbolicLink() && fs.existsSync(path.join(fullPath, 'context.jsonl')))) {
-          const contextPath = path.join(fullPath, 'context.jsonl');
-          if (fs.existsSync(contextPath)) {
+        if (entry.isDirectory() || entry.isSymbolicLink()) {
+          // Directory or symlink (covers symlinked dirs and symlinked flat files).
+          // For symlinks, follow once via stat to decide which branch applies.
+          let isDir = entry.isDirectory();
+          let isFile = false;
+          if (entry.isSymbolicLink()) {
+            try {
+              const stat = await fs.promises.stat(fullPath);
+              isDir = stat.isDirectory();
+              isFile = stat.isFile();
+            } catch {
+              continue; // broken symlink — skip
+            }
+          }
+          if (isDir) {
+            const contextPath = path.join(fullPath, 'context.jsonl');
+            if (await pathExists(contextPath)) {
+              results.push(fullPath);
+            }
+          } else if (isFile && fullPath.endsWith('.jsonl')) {
             results.push(fullPath);
           }
         } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
@@ -231,10 +286,10 @@ async function parseSessionMetadata(sessionDir: string): Promise<KimiSessionMeta
   };
 }
 
-function getMetadataCreatedAt(sessionDir: string, fallback: Date): Date {
+async function getMetadataCreatedAt(sessionDir: string, fallback: Date): Promise<Date> {
   for (const filename of ['state.json', 'metadata.json']) {
     try {
-      const stats = fs.statSync(path.join(sessionDir, filename));
+      const stats = await fs.promises.stat(path.join(sessionDir, filename));
       return stats.birthtime;
     } catch (err) {
       logger.debug('kimi: metadata stats unavailable', sessionDir, filename, err);
@@ -245,65 +300,121 @@ function getMetadataCreatedAt(sessionDir: string, fallback: Date): Date {
 }
 
 /**
- * Read context.jsonl from a Kimi session directory
+ * Read context.jsonl from a Kimi session directory.
+ *
+ * Single-pass implementation: streams the file once, counts every newline-
+ * terminated line (including malformed ones), parses each line as JSON, and
+ * tracks dropped records for fidelity reporting. Uses a single async stat to
+ * obtain bytes/mtime/birthtime. Avoids the previous double-scan approach
+ * (readJsonlFile + getFileStats) which streamed the same file twice.
  */
 async function readContextData(sessionPath: string): Promise<KimiContextReadResult> {
   const contextPath = resolveContextPath(sessionPath);
+  const empty: KimiContextReadResult = {
+    contextPath,
+    messages: [],
+    rawLineCount: 0,
+    bytes: 0,
+    droppedRecordCount: 0,
+  };
+
+  let stats: fs.Stats;
+  try {
+    stats = await fs.promises.stat(contextPath);
+  } catch (err) {
+    logger.debug('kimi: failed to stat context', contextPath, err);
+    return empty;
+  }
+
+  if (stats.size === 0) {
+    return { ...empty, bytes: 0, mtime: stats.mtime, birthtime: stats.birthtime };
+  }
+
+  const messages: KimiMessage[] = [];
+  let rawLineCount = 0;
+  let droppedRecordCount = 0;
+
+  const decoder = new StringDecoder('utf8');
+  const stream = fs.createReadStream(contextPath);
+  let lineBuffer = '';
+
+  const finishLine = (line: string): void => {
+    rawLineCount++;
+    if (line.length === 0) {
+      droppedRecordCount++;
+      return;
+    }
+    const trimmed = line.endsWith('\r') ? line.slice(0, -1) : line;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      logger.debug('kimi: skipping invalid JSON line in', contextPath);
+      droppedRecordCount++;
+      return;
+    }
+    if (!isRecord(parsed)) {
+      logger.debug('kimi: skipping non-object context record', contextPath);
+      droppedRecordCount++;
+      return;
+    }
+    if (typeof parsed.role !== 'string') {
+      logger.debug('kimi: skipping context record with missing role', contextPath);
+      droppedRecordCount++;
+      return;
+    }
+    messages.push(parsed as KimiMessage);
+  };
 
   try {
-    const [records, stats] = await Promise.all([readJsonlFile<unknown>(contextPath), getFileStats(contextPath)]);
-    const messages: KimiMessage[] = [];
-    let droppedRecordCount = Math.max(0, stats.lines - records.length);
-
-    for (const record of records) {
-      if (!isRecord(record)) {
-        logger.debug('kimi: skipping non-object context record', contextPath);
-        droppedRecordCount++;
-        continue;
+    for await (const chunk of stream) {
+      const text = decoder.write(chunk as Buffer);
+      let start = 0;
+      let newlineIndex = text.indexOf('\n', start);
+      while (newlineIndex !== -1) {
+        lineBuffer += text.slice(start, newlineIndex);
+        finishLine(lineBuffer);
+        lineBuffer = '';
+        start = newlineIndex + 1;
+        newlineIndex = text.indexOf('\n', start);
       }
-      if (typeof record.role !== 'string') {
-        logger.debug('kimi: skipping context record with missing role', contextPath);
-        droppedRecordCount++;
-        continue;
-      }
-      messages.push(record as KimiMessage);
+      lineBuffer += text.slice(start);
     }
-
-    return {
-      contextPath,
-      messages,
-      rawLineCount: stats.lines,
-      bytes: stats.bytes,
-      droppedRecordCount,
-    };
+    const remaining = decoder.end();
+    if (remaining.length > 0) lineBuffer += remaining;
+    if (lineBuffer.length > 0) {
+      finishLine(lineBuffer);
+    }
   } catch (err) {
     logger.debug('kimi: failed to read context', sessionPath, err);
-    return {
-      contextPath,
-      messages: [],
-      rawLineCount: 0,
-      bytes: 0,
-      droppedRecordCount: 0,
-    };
+    return empty;
   }
+
+  return {
+    contextPath,
+    messages,
+    rawLineCount,
+    bytes: stats.size,
+    droppedRecordCount,
+    mtime: stats.mtime,
+    birthtime: stats.birthtime,
+  };
 }
 
 async function readWireMetadata(sessionPath: string): Promise<KimiWireMetadata> {
-  const sessionDir = getSessionMetadataDir(sessionPath);
+  const sessionDir = await getSessionMetadataDir(sessionPath);
   if (!sessionDir) return { exists: false, recordTypes: [] };
 
   const wirePath = path.join(sessionDir, 'wire.jsonl');
-  if (!fs.existsSync(wirePath)) return { exists: false, path: wirePath, recordTypes: [] };
+  let bytes: number | undefined;
+  try {
+    bytes = (await fs.promises.stat(wirePath)).size;
+  } catch {
+    return { exists: false, path: wirePath, recordTypes: [] };
+  }
 
   const recordTypes: string[] = [];
   let protocolVersion: string | undefined;
-  let bytes: number | undefined;
-
-  try {
-    bytes = fs.statSync(wirePath).size;
-  } catch (err) {
-    logger.debug('kimi: failed to stat wire.jsonl', wirePath, err);
-  }
 
   await scanJsonlHead(wirePath, 25, (parsed) => {
     if (!isRecord(parsed)) return 'continue';
@@ -628,10 +739,7 @@ export async function parseKimiSessions(): Promise<UnifiedSession[]> {
 
   for (const sessionPath of sessionPaths) {
     try {
-      const contextPath = resolveContextPath(sessionPath);
-      const contextStats = fs.statSync(contextPath);
-
-      const metadataDir = getSessionMetadataDir(sessionPath);
+      const metadataDir = await getSessionMetadataDir(sessionPath);
       const metadata = metadataDir ? await parseSessionMetadata(metadataDir) : {};
       if (metadata.archived === true) continue;
       const sessionId = metadata.sessionId || deriveSessionId(sessionPath);
@@ -639,6 +747,9 @@ export async function parseKimiSessions(): Promise<UnifiedSession[]> {
 
       const contextData = await readContextData(sessionPath);
       if (contextData.messages.length === 0) continue;
+      // readContextData supplies mtime/birthtime from a single async stat, so we
+      // don't need a separate fs.statSync(contextPath) here.
+      if (!contextData.mtime || !contextData.birthtime) continue;
 
       const firstUserMessage = extractFirstUserMessage(contextData.messages);
       const summary = cleanSummary(firstUserMessage);
@@ -646,7 +757,7 @@ export async function parseKimiSessions(): Promise<UnifiedSession[]> {
       const cwd = resolveCwdFromSessionDir(sessionPath, workDirHashIndex);
       const repo = extractRepoFromCwd(cwd);
 
-      let updatedAt = contextStats.mtime;
+      let updatedAt = contextData.mtime;
       if (metadata.wireMtime !== null && metadata.wireMtime !== undefined && metadata.wireMtime > 0) {
         const wireUpdatedAt = new Date(metadata.wireMtime * 1000);
         if (!Number.isNaN(wireUpdatedAt.getTime())) {
@@ -661,7 +772,9 @@ export async function parseKimiSessions(): Promise<UnifiedSession[]> {
         repo,
         lines: contextData.rawLineCount,
         bytes: contextData.bytes,
-        createdAt: metadataDir ? getMetadataCreatedAt(metadataDir, contextStats.birthtime) : contextStats.birthtime,
+        createdAt: metadataDir
+          ? await getMetadataCreatedAt(metadataDir, contextData.birthtime)
+          : contextData.birthtime,
         updatedAt,
         originalPath: sessionPath,
         summary: summary || metadata.title || undefined,
@@ -689,7 +802,7 @@ export async function extractKimiContext(session: UnifiedSession, config?: Verbo
   const toolData = extractToolData(messages, resolvedConfig);
   const sessionNotes = extractSessionNotes(messages);
   const wireMetadata = await readWireMetadata(session.originalPath);
-  const metadataDir = getSessionMetadataDir(session.originalPath);
+  const metadataDir = await getSessionMetadataDir(session.originalPath);
   const statePath = metadataDir ? path.join(metadataDir, 'state.json') : undefined;
   const legacyMetadataPath = metadataDir ? path.join(metadataDir, 'metadata.json') : undefined;
   const sourceMetadata: Record<string, unknown> = {
@@ -701,10 +814,10 @@ export async function extractKimiContext(session: UnifiedSession, config?: Verbo
   if (contextData.droppedRecordCount > 0) {
     sourceMetadata.contextDroppedRecords = contextData.droppedRecordCount;
   }
-  if (statePath && fs.existsSync(statePath)) {
+  if (statePath && (await pathExists(statePath))) {
     sourceMetadata.statePath = statePath;
   }
-  if (legacyMetadataPath && fs.existsSync(legacyMetadataPath)) {
+  if (legacyMetadataPath && (await pathExists(legacyMetadataPath))) {
     sourceMetadata.legacyMetadataPath = legacyMetadataPath;
   }
   if (wireMetadata.path) {

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -890,6 +890,7 @@ register({
   label: 'Kimi CLI',
   color: chalk.hex('#00D4AA'),
   storagePath: '~/.kimi/sessions/',
+  envVar: 'KIMI_SHARE_DIR',
   binaryName: 'kimi',
   parseSessions: parseKimiSessions,
   extractContext: extractKimiContext,


### PR DESCRIPTION
# fix(kimi): harden state and context parsing

## Summary
Fixed the Kimi parser so it can read current `state.json` session metadata, legacy `metadata.json` fallback fields, hashed session directories, and legacy flat JSONL context files from the configured Kimi share directory. Context extraction now surfaces raw access/source metadata, wire protocol hints, repo derivation, malformed-record warnings, and more defensive tool/message parsing. Review should focus on metadata precedence, how much wire/state metadata should be exposed, and whether malformed-context tolerance is conservative enough.

## Context / Why now
Kimi session storage is not limited to `~/.kimi/sessions/<workdir_hash>/<session_id>/metadata.json` plus `context.jsonl`. Current installs may use `KIMI_SHARE_DIR`, `state.json`, `wire.jsonl`, non-local KAOS hash prefixes, or flat legacy JSONL files. The old parser could miss sessions, incorrectly hide or title sessions when state and legacy metadata disagreed, and drop useful handoff fidelity details.

## The 4 items

### Item 1: Respect KIMI_SHARE_DIR and broaden session discovery
- Files: `src/parsers/kimi.ts`, `src/__tests__/kimi-parser.test.ts`
- What: Resolves Kimi storage from `KIMI_SHARE_DIR` when set, otherwise falls back to `~/.kimi`; discovers hashed session directories, symlinked session directories with `context.jsonl`, and legacy flat `*.jsonl` context files.
- Why this shape: The parser remains read-only and works against Kimi's configured share root instead of assuming the home-directory default.
- Verified by: Added fixtures that prove `KIMI_SHARE_DIR` wins over fallback home storage and that legacy flat JSONL files are parsed without migration.

### Item 2: Use state metadata first, legacy metadata second
- Files: `src/parsers/kimi.ts`, `src/__tests__/kimi-parser.test.ts`
- What: Reads both `state.json` and `metadata.json`, with state fields winning for title, archive status, session id, and `wire_mtime` when explicitly present. It also accepts nullable `wire_mtime`, ignores `Untitled`, derives repo from cwd, and preserves metadata creation fallbacks.
- Why this shape: `state.json` represents current Kimi state, while `metadata.json` remains useful for older sessions.
- Verified by: Added state-primary tests for archive filtering, title fallback, `wire_mtime` updatedAt selection, and legacy metadata fallback behavior.

### Item 3: Surface wire, source, and raw-access metadata
- Files: `src/parsers/kimi.ts`, `src/__tests__/kimi-parser.test.ts`
- What: Extracts `wire.jsonl` existence, path, byte size, protocol version, and first-seen record types into `sessionNotes.sourceMetadata`; records `rawAccess` as a redacted directory or file pointer; adds fidelity warnings when cwd, flat metadata, wire metadata, or context records are degraded.
- Why this shape: Reviewers and downstream tools can understand what raw Kimi artifacts were available without embedding secrets or writing into Kimi storage.
- Verified by: Added a wire metadata fixture covering protocol version, `TurnBegin`/`ToolCall` record type extraction, raw access metadata, source metadata, and repo derivation.

### Item 4: Tolerate malformed context and tool-call records
- Files: `src/parsers/kimi.ts`, `src/__tests__/kimi-parser.test.ts`
- What: Reads JSONL with stats, skips malformed/non-object/no-role records, reports dropped records, handles content blocks defensively, dedupes reasoning/pending-task text, ignores malformed tool calls, and recovers tool arguments containing raw control characters.
- Why this shape: A handoff should preserve valid conversation and tool context even when individual JSONL rows or tool-call entries are damaged.
- Verified by: Added malformed-context coverage for invalid JSON, non-object rows, missing-role records, malformed tool calls, control-character tool arguments, pending task dedupe, token-count non-fabrication, and fidelity warnings.

## Files touched

| File | +/- | Purpose |
|---|---:|---|
| `src/parsers/kimi.ts` | +567 / -108 | Add Kimi share-root resolution, state/legacy metadata precedence, flat/directory context discovery, wire metadata extraction, repo derivation, and malformed context tolerance. |
| `src/__tests__/kimi-parser.test.ts` | +349 / -1 | Add focused fixtures for share-dir precedence, state metadata, wire metadata, malformed records/tool calls, and legacy flat contexts. |

## Verification
- Tests run: `pnpm test` - blocked before test execution with `sh: vitest: command not found`.
- Full check: `pnpm run check` - blocked at `pnpm lint` with `sh: biome: command not found`.
- Full-check baseline blocker: this worktree has no installed `node_modules`, so local checks cannot start without installing dependencies. I did not install dependencies in this PR handoff because this pass was constrained to no file edits.
- Not verified: A live production Kimi share directory from a current user install. The parser coverage here uses synthetic fixtures matching expected Kimi file shapes.

## Weaknesses and open questions
1. Important: `state.json` wins only when a field is explicitly present; legacy metadata still fills gaps. Reviewer question: is this the right precedence, or should any existing `state.json` suppress legacy metadata entirely?
2. Important: `wire.jsonl` scanning only reads the first 25 records and stores record types/protocol metadata rather than full wire events. Reviewer question: should Kimi wire metadata stay lightweight, or should more wire event structure be preserved for handoff fidelity?
3. Important: Malformed context records are skipped with fidelity warnings rather than making the session fail discovery. Reviewer question: is this tolerant behavior correct for user-facing continuation, or should malformed sessions be excluded from the list until the user asks for degraded parsing?

## Request to the reviewer
Please review the Kimi state/context compatibility assumptions in depth, especially `KIMI_SHARE_DIR`, state-versus-legacy metadata precedence, and whether degraded flat or malformed contexts should be visible by default.

## Follow-ups
- Re-run `pnpm test` and `pnpm run check` after dependencies are installed in the worktree or CI environment.
- Add an anonymized real Kimi share-dir fixture if one can be safely scrubbed.
- Consider richer wire-event extraction if reviewers want parity with future parser fidelity work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Kimi parser to reliably read sessions from `KIMI_SHARE_DIR`, prefer `state.json`, stream context in one pass, and surface wire/source metadata while tolerating malformed records. It also derives the repo from `cwd` and rebuilds the index when the share dir changes.

- **Bug Fixes**
  - Use `KIMI_SHARE_DIR` when set; otherwise fall back to `~/.kimi`. Discover hashed dirs, symlinked dirs, and legacy flat `*.jsonl` files via async FS.
  - Prefer `state.json` over legacy `metadata.json` for title/archive/session/wire_mtime; accept nullable `wire_mtime`. Derive repo from `cwd`.
  - Stream `context.jsonl` once to get lines/bytes, dropped records, and mtime/birthtime from a single async stat.
  - Expose `wire.jsonl` presence, bytes, protocol version, and first-seen record types; include redacted raw-access, context stats, and source paths.
  - Tolerate malformed JSONL and tool calls: skip bad rows, dedupe think/pending-task text, and recover tool args with embedded control chars.
  - Keep degraded sessions visible with fidelity warnings. Include `KIMI_SHARE_DIR` in the env fingerprint and register it in the Kimi parser so the index rebuilds when the share dir changes.

<sup>Written for commit dd7a363b7ffc1906c7a013242095434481499e11. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/59?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

