### PR TITLE
fix(cursor): harden transcript parsing

### DIFF
--- a/src/__tests__/cursor-parser.test.ts
+++ b/src/__tests__/cursor-parser.test.ts
@@ -12,12 +12,32 @@ function makeCursorHome(): string {
   return dir;
 }
 
-function writeCursorTranscript(home: string, slug: string, sessionId: string, rows: unknown[]): string {
+function writeCursorTranscript(
+  home: string,
+  slug: string,
+  sessionId: string,
+  rows: unknown[],
+  fileName = `${sessionId}.jsonl`,
+): string {
   const dir = path.join(home, '.cursor', 'projects', slug, 'agent-transcripts', sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, fileName);
+  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+  return filePath;
+}
+
+function writeFlatCursorTranscript(home: string, slug: string, sessionId: string, rows: unknown[]): string {
+  const dir = path.join(home, '.cursor', 'projects', slug, 'agent-transcripts');
   fs.mkdirSync(dir, { recursive: true });
   const filePath = path.join(dir, `${sessionId}.jsonl`);
   fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
   return filePath;
+}
+
+function writeCursorRepoJson(home: string, slug: string, data: unknown): void {
+  const dir = path.join(home, '.cursor', 'projects', slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'repo.json'), JSON.stringify(data), 'utf8');
 }
 
 async function loadCursorParser(home: string): Promise<typeof import('../parsers/cursor.js')> {
@@ -40,7 +60,7 @@ afterEach(() => {
 });
 
 describe('cursor parser confidence warnings', () => {
-  it('includes a transcript completeness warning in extracted context', async () => {
+  it('records transcript completeness as a fidelity warning without fabricating tool results', async () => {
     const home = makeCursorHome();
     const sessionId = '11111111-2222-3333-4444-555555555555';
     const originalPath = writeCursorTranscript(home, 'Users-test-project', sessionId, [
@@ -54,6 +74,12 @@ describe('cursor parser confidence warnings', () => {
         role: 'assistant',
         message: {
           content: [{ type: 'text', text: 'I checked the transcript.' }],
+        },
+      },
+      {
+        role: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu_shell', name: 'Bash', input: { command: 'pnpm test' } }],
         },
       },
     ]);
@@ -72,9 +98,167 @@ describe('cursor parser confidence warnings', () => {
       summary: 'Review auth flow',
     } satisfies UnifiedSession);
 
-    expect(context.sessionNotes?.reasoning).toEqual(
+    expect(context.sessionNotes?.fidelityWarnings).toEqual(
       expect.arrayContaining([expect.stringContaining('Cursor transcript completeness warning')]),
     );
-    expect(context.markdown).toContain('Cursor transcript completeness warning');
+    expect(context.sessionNotes?.reasoning).toBeUndefined();
+    expect(context.markdown).not.toContain('Cursor transcript completeness warning');
+
+    const bashSummary = context.toolSummaries.find((summary) => summary.name === 'Bash');
+    expect(bashSummary?.samples[0]?.summary).toBe('$ pnpm test');
+    const bashData = bashSummary?.samples[0]?.data;
+    expect(bashData?.category).toBe('shell');
+    if (bashData?.category === 'shell') {
+      expect(bashData.exitCode).toBeUndefined();
+      expect(bashData.stdoutTail).toBeUndefined();
+      expect(bashData.errorMessage).toBeUndefined();
+    }
+  });
+});
+
+describe('cursor parser hardening', () => {
+  it('discovers nested transcript.jsonl and flat Cursor CLI transcript layouts', async () => {
+    const home = makeCursorHome();
+    const nestedId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const flatId = 'ffffffff-1111-2222-3333-444444444444';
+    writeCursorRepoJson(home, 'Users-test-project', { workspace: '/tmp/cursor-project' });
+    writeCursorTranscript(
+      home,
+      'Users-test-project',
+      nestedId,
+      [
+        {
+          role: 'user',
+          message: {
+            content: [{ type: 'text', text: 'Nested transcript keeps parent id' }],
+          },
+        },
+      ],
+      'transcript.jsonl',
+    );
+    writeFlatCursorTranscript(home, 'Users-test-project', flatId, [
+      {
+        role: 'user',
+        message: {
+          content: [{ type: 'text', text: 'Flat transcript should also be discovered' }],
+        },
+      },
+    ]);
+
+    const { parseCursorSessions } = await loadCursorParser(home);
+    const sessions = await parseCursorSessions();
+
+    expect(sessions.map((session) => session.id)).toEqual(expect.arrayContaining([nestedId, flatId]));
+    expect(sessions.find((session) => session.id === nestedId)?.cwd).toBe('/tmp/cursor-project');
+    expect(sessions.find((session) => session.id === nestedId)?.summary).toBe('Nested transcript keeps parent id');
+    expect(sessions.find((session) => session.id === flatId)?.summary).toBe(
+      'Flat transcript should also be discovered',
+    );
+  });
+
+  it('extracts context from string content, user_query wrappers, tools, and malformed records without throwing', async () => {
+    const home = makeCursorHome();
+    const sessionId = '99999999-8888-7777-6666-555555555555';
+    const originalPath = writeCursorTranscript(home, 'Users-test-project', sessionId, [
+      {
+        role: 'system',
+        message: {
+          content: [{ type: 'text', text: 'hidden prompt' }],
+        },
+      },
+      {
+        role: 'user',
+        message: {
+          content: [
+            {
+              type: 'text',
+              text: '<timestamp>Sunday, Apr 26, 2026, 9:53 PM (UTC-4)</timestamp>\n<user_query>\nFix auth\n</user_query>',
+            },
+          ],
+        },
+      },
+      {
+        role: 'user',
+        message: {
+          content: [{ type: 'text', text: '<system_reminder>not human text</system_reminder>' }],
+        },
+      },
+      {
+        role: 'assistant',
+        model: 'claude-sonnet-4',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 2,
+          cache_read_input_tokens: 3,
+        },
+        message: {
+          content: [
+            { type: 'text', text: 'I will inspect the file.' },
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'Edit',
+              input: {
+                file_path: 'src/auth.ts',
+                old_string: 'bad',
+                new_string: 'good',
+              },
+            },
+          ],
+        },
+      },
+      {
+        role: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu_shell', name: 'Bash', input: { command: 'pnpm test' } }],
+        },
+      },
+      {
+        role: 'assistant',
+        message: {
+          content: 'String content should become assistant text',
+        },
+      },
+      {
+        role: 'assistant',
+        message: {},
+      },
+    ]);
+    fs.appendFileSync(originalPath, '{"broken":\n', 'utf8');
+
+    const { extractCursorContext, parseCursorSessions } = await loadCursorParser(home);
+    const sessions = await parseCursorSessions();
+    const context = await extractCursorContext({
+      id: sessionId,
+      source: 'cursor',
+      cwd: '/Users/test/project',
+      repo: 'test/project',
+      lines: fs.readFileSync(originalPath, 'utf8').split('\n').length - 1,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-04-15T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-15T00:00:00.000Z'),
+      originalPath,
+      summary: 'Fix auth',
+    } satisfies UnifiedSession);
+
+    expect(sessions.find((session) => session.id === sessionId)?.summary).toBe('Fix auth');
+    expect(context.recentMessages.map((message) => message.content)).toEqual([
+      'Fix auth',
+      'I will inspect the file.',
+      'String content should become assistant text',
+    ]);
+    expect(context.recentMessages[0].timestamp?.toISOString()).toBe('2026-04-27T01:53:00.000Z');
+    expect(context.filesModified).toContain('src/auth.ts');
+    expect(context.sessionNotes?.model).toBe('claude-sonnet-4');
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 10, output: 5 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 2, read: 3 });
+    expect(context.sessionNotes?.fidelityWarnings).toEqual(
+      expect.arrayContaining([expect.stringContaining('Cursor transcript completeness warning')]),
+    );
+    expect(context.sessionNotes?.reasoning).toBeUndefined();
+    expect(context.toolSummaries.find((summary) => summary.name === 'Bash')?.samples[0]?.summary).toBe('$ pnpm test');
+    expect(context.markdown).not.toContain('system_reminder');
+    expect(context.markdown).not.toContain('local agent-transcripts are partial exports');
   });
 });

--- a/src/__tests__/cursor-parser.test.ts
+++ b/src/__tests__/cursor-parser.test.ts
@@ -299,4 +299,115 @@ describe('cursor parser hardening', () => {
     expect(context.markdown).not.toContain('system_reminder');
     expect(context.markdown).not.toContain('local agent-transcripts are partial exports');
   });
+
+  it('keeps long transcripts whose first parseable record sits past the head scan window', async () => {
+    const home = makeCursorHome();
+    const sessionId = '44444444-5555-6666-7777-888888888888';
+
+    const rows: unknown[] = [];
+    // 120 prefix records that the normalizer rejects (no role / no content) —
+    // before the gate fix, these would zero out messageCount and drop the
+    // session even though the full-file parse below recovers real messages.
+    for (let i = 0; i < 120; i++) {
+      rows.push({ event: 'noise', i });
+    }
+    rows.push({
+      role: 'user',
+      message: { content: [{ type: 'text', text: 'Real user message after head scan' }] },
+    });
+    rows.push({
+      role: 'assistant',
+      message: { content: [{ type: 'text', text: 'Real assistant reply' }] },
+    });
+
+    const originalPath = writeCursorTranscript(home, 'Users-test-project', sessionId, rows);
+
+    const { parseCursorSessions, extractCursorContext } = await loadCursorParser(home);
+    const sessions = await parseCursorSessions();
+    const session = sessions.find((s) => s.id === sessionId);
+
+    expect(session, 'session past head-scan window must still be discovered').toBeDefined();
+
+    const context = await extractCursorContext({
+      ...(session as UnifiedSession),
+      originalPath,
+    });
+    expect(context.recentMessages.map((m) => m.content)).toEqual([
+      'Real user message after head scan',
+      'Real assistant reply',
+    ]);
+  });
+
+  it('strips every <timestamp> tag, not just the first occurrence', async () => {
+    const home = makeCursorHome();
+    const sessionId = '55555555-6666-7777-8888-999999999999';
+    writeCursorTranscript(home, 'Users-test-project', sessionId, [
+      {
+        role: 'user',
+        message: {
+          content: [
+            {
+              type: 'text',
+              text: '<timestamp>Sunday, Apr 26, 2026, 9:53 PM (UTC-4)</timestamp>\n<user_query>\nFirst question\n</user_query>',
+            },
+          ],
+        },
+      },
+      {
+        role: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'text',
+              text: '<timestamp>Sunday, Apr 26, 2026, 9:54 PM (UTC-4)</timestamp> some answer <timestamp>Sunday, Apr 26, 2026, 9:55 PM (UTC-4)</timestamp> more answer',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const { extractCursorContext, parseCursorSessions } = await loadCursorParser(home);
+    const [session] = await parseCursorSessions();
+    const context = await extractCursorContext(session);
+
+    const assistantMessage = context.recentMessages.find((m) => m.role === 'assistant');
+    expect(assistantMessage?.content).not.toContain('<timestamp>');
+    expect(assistantMessage?.content).not.toContain('</timestamp>');
+    expect(assistantMessage?.content).toContain('some answer');
+    expect(assistantMessage?.content).toContain('more answer');
+  });
+
+  it('deduplicates sessions when both <uuid>/transcript.jsonl and <uuid>.jsonl exist for the same id', async () => {
+    const home = makeCursorHome();
+    const sharedId = '66666666-7777-8888-9999-aaaaaaaaaaaa';
+    const slug = 'Users-test-project';
+
+    // Nested transcript.jsonl
+    const nestedDir = path.join(home, '.cursor', 'projects', slug, 'agent-transcripts', sharedId);
+    fs.mkdirSync(nestedDir, { recursive: true });
+    const nestedPath = path.join(nestedDir, 'transcript.jsonl');
+    fs.writeFileSync(
+      nestedPath,
+      `${JSON.stringify({ role: 'user', message: { content: [{ type: 'text', text: 'older copy' }] } })}\n`,
+      'utf8',
+    );
+
+    // Sibling <uuid>/<uuid>.jsonl in the same dir (legacy lingering file)
+    const siblingPath = path.join(nestedDir, `${sharedId}.jsonl`);
+    fs.writeFileSync(
+      siblingPath,
+      `${JSON.stringify({ role: 'user', message: { content: [{ type: 'text', text: 'newer copy' }] } })}\n`,
+      'utf8',
+    );
+
+    fs.utimesSync(nestedPath, new Date('2026-04-15T10:00:00.000Z'), new Date('2026-04-15T10:00:00.000Z'));
+    fs.utimesSync(siblingPath, new Date('2026-04-15T11:00:00.000Z'), new Date('2026-04-15T11:00:00.000Z'));
+
+    const { parseCursorSessions } = await loadCursorParser(home);
+    const sessions = await parseCursorSessions();
+    const matching = sessions.filter((s) => s.id === sharedId);
+
+    expect(matching).toHaveLength(1);
+    expect(matching[0].updatedAt.toISOString()).toBe('2026-04-15T11:00:00.000Z');
+  });
 });

--- a/src/__tests__/cursor-parser.test.ts
+++ b/src/__tests__/cursor-parser.test.ts
@@ -40,6 +40,16 @@ function writeCursorRepoJson(home: string, slug: string, data: unknown): void {
   fs.writeFileSync(path.join(dir, 'repo.json'), JSON.stringify(data), 'utf8');
 }
 
+function cursorTextRow(role: 'user' | 'assistant', text: string, timestamp: string): unknown {
+  return {
+    role,
+    timestamp,
+    message: {
+      content: [{ type: 'text', text }],
+    },
+  };
+}
+
 async function loadCursorParser(home: string): Promise<typeof import('../parsers/cursor.js')> {
   vi.resetModules();
   vi.doMock('../utils/parser-helpers.js', async (importOriginal) => {
@@ -154,6 +164,34 @@ describe('cursor parser hardening', () => {
     expect(sessions.find((session) => session.id === flatId)?.summary).toBe(
       'Flat transcript should also be discovered',
     );
+  });
+
+  it('orders long transcripts by filesystem recency instead of head-scan timestamps', async () => {
+    const home = makeCursorHome();
+    const olderId = '22222222-3333-4444-5555-666666666666';
+    const newerId = '33333333-4444-5555-6666-777777777777';
+    const olderPath = writeCursorTranscript(home, 'Users-test-project', olderId, [
+      cursorTextRow('user', 'Short transcript', '2026-04-15T11:00:00.000Z'),
+    ]);
+    const newerRows = Array.from({ length: 100 }, (_, index) =>
+      cursorTextRow(
+        index === 0 ? 'user' : 'assistant',
+        index === 0 ? 'Long transcript starts old' : `Filler response ${index}`,
+        new Date(Date.UTC(2026, 3, 15, 10, 0, index)).toISOString(),
+      ),
+    );
+    newerRows.push(cursorTextRow('assistant', 'Tail response after head scan', '2026-04-15T11:30:00.000Z'));
+    const newerPath = writeCursorTranscript(home, 'Users-test-project', newerId, newerRows);
+
+    fs.utimesSync(olderPath, new Date('2026-04-15T11:00:00.000Z'), new Date('2026-04-15T11:00:00.000Z'));
+    fs.utimesSync(newerPath, new Date('2026-04-15T11:30:00.000Z'), new Date('2026-04-15T11:30:00.000Z'));
+
+    const { parseCursorSessions } = await loadCursorParser(home);
+    const sessions = await parseCursorSessions();
+
+    expect(sessions[0].id).toBe(newerId);
+    expect(sessions[0].updatedAt.toISOString()).toBe('2026-04-15T11:30:00.000Z');
+    expect(sessions[1].id).toBe(olderId);
   });
 
   it('extracts context from string content, user_query wrappers, tools, and malformed records without throwing', async () => {

--- a/src/__tests__/cursor-parser.test.ts
+++ b/src/__tests__/cursor-parser.test.ts
@@ -410,4 +410,104 @@ describe('cursor parser hardening', () => {
     expect(matching).toHaveLength(1);
     expect(matching[0].updatedAt.toISOString()).toBe('2026-04-15T11:00:00.000Z');
   });
+
+  it('honors repo.json key precedence: workspace > rootPath > path', async () => {
+    const home = makeCursorHome();
+
+    // Slug A: workspace wins over rootPath and path
+    writeCursorRepoJson(home, 'Users-test-projectA', {
+      workspace: '/tmp/cursor-projectA-workspace',
+      rootPath: '/tmp/cursor-projectA-rootpath',
+      path: '/tmp/cursor-projectA-path',
+    });
+    writeCursorTranscript(home, 'Users-test-projectA', 'aaaaaaaa-1111-2222-3333-444444444444', [
+      { role: 'user', message: { content: [{ type: 'text', text: 'project A' }] } },
+    ]);
+
+    // Slug B: rootPath wins over path when workspace is absent
+    writeCursorRepoJson(home, 'Users-test-projectB', {
+      rootPath: '/tmp/cursor-projectB-rootpath',
+      path: '/tmp/cursor-projectB-path',
+    });
+    writeCursorTranscript(home, 'Users-test-projectB', 'bbbbbbbb-1111-2222-3333-444444444444', [
+      { role: 'user', message: { content: [{ type: 'text', text: 'project B' }] } },
+    ]);
+
+    // Slug C: path is the last resort
+    writeCursorRepoJson(home, 'Users-test-projectC', {
+      path: '/tmp/cursor-projectC-path',
+    });
+    writeCursorTranscript(home, 'Users-test-projectC', 'cccccccc-1111-2222-3333-444444444444', [
+      { role: 'user', message: { content: [{ type: 'text', text: 'project C' }] } },
+    ]);
+
+    // Slug D: empty values fall through to next key
+    writeCursorRepoJson(home, 'Users-test-projectD', {
+      workspace: '',
+      rootPath: '/tmp/cursor-projectD-rootpath',
+      path: '/tmp/cursor-projectD-path',
+    });
+    writeCursorTranscript(home, 'Users-test-projectD', 'dddddddd-1111-2222-3333-444444444444', [
+      { role: 'user', message: { content: [{ type: 'text', text: 'project D' }] } },
+    ]);
+
+    const { parseCursorSessions } = await loadCursorParser(home);
+    const sessions = await parseCursorSessions();
+    const byId = new Map(sessions.map((s) => [s.id, s.cwd]));
+
+    expect(byId.get('aaaaaaaa-1111-2222-3333-444444444444')).toBe('/tmp/cursor-projectA-workspace');
+    expect(byId.get('bbbbbbbb-1111-2222-3333-444444444444')).toBe('/tmp/cursor-projectB-rootpath');
+    expect(byId.get('cccccccc-1111-2222-3333-444444444444')).toBe('/tmp/cursor-projectC-path');
+    expect(byId.get('dddddddd-1111-2222-3333-444444444444')).toBe('/tmp/cursor-projectD-rootpath');
+  });
+
+  it('discovers Cursor sub-agent transcripts under <sid>/subagents/', async () => {
+    // Per Cursor's documented agent-transcripts layout (observed in
+    // dev.to reverse-engineering article + VibeLens parser), sub-agent
+    // sessions live at:
+    //   ~/.cursor/projects/<slug>/agent-transcripts/<parent-sid>/subagents/<child-sid>.jsonl
+    // findFiles' maxDepth=2 lets us reach them; getSessionId returns the
+    // child uuid (parent dir is `subagents`, which is excluded only when the
+    // stem is the literal `transcript` — child stems are uuids, so they pass).
+    const home = makeCursorHome();
+    const parentSid = 'aaaaaaaa-1111-2222-3333-444444444444';
+    const childSid = 'bbbbbbbb-1111-2222-3333-444444444444';
+
+    writeCursorRepoJson(home, 'Users-test-project', { workspace: '/tmp/cursor-project' });
+    writeCursorTranscript(
+      home,
+      'Users-test-project',
+      parentSid,
+      [{ role: 'user', message: { content: [{ type: 'text', text: 'parent transcript' }] } }],
+      'transcript.jsonl',
+    );
+
+    const subDir = path.join(
+      home,
+      '.cursor',
+      'projects',
+      'Users-test-project',
+      'agent-transcripts',
+      parentSid,
+      'subagents',
+    );
+    fs.mkdirSync(subDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(subDir, `${childSid}.jsonl`),
+      `${JSON.stringify({
+        role: 'user',
+        message: { content: [{ type: 'text', text: 'sub-agent prompt' }] },
+      })}\n`,
+      'utf8',
+    );
+
+    const { parseCursorSessions } = await loadCursorParser(home);
+    const sessions = await parseCursorSessions();
+    const ids = sessions.map((s) => s.id);
+
+    expect(ids).toEqual(expect.arrayContaining([parentSid, childSid]));
+    const subagent = sessions.find((s) => s.id === childSid);
+    expect(subagent?.cwd).toBe('/tmp/cursor-project');
+    expect(subagent?.summary).toBe('sub-agent prompt');
+  });
 });

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -4,7 +4,7 @@ import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type { ConversationMessage, SessionContext, SessionNotes, UnifiedSession } from '../types/index.js';
-import type { CursorTranscriptLine } from '../types/schemas.js';
+import { CursorTranscriptLineSchema } from '../types/schemas.js';
 import { cleanUserQueryText, isRealUserMessage, isSystemContent } from '../utils/content.js';
 import { findFiles } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
@@ -18,6 +18,185 @@ import {
 } from '../utils/tool-extraction.js';
 
 const CURSOR_PROJECTS_DIR = path.join(homeDir(), '.cursor', 'projects');
+const CURSOR_FIDELITY_WARNING =
+  'Cursor transcript completeness warning: local agent-transcripts are partial exports and may omit tool outputs, images, reasoning, compaction markers, or other hidden SQLite/session state.';
+const CURSOR_TIMESTAMP_TAG_RE = /<timestamp>([\s\S]*?)<\/timestamp>/i;
+const CURSOR_TIMESTAMP_BODY_RE =
+  /(?:[A-Za-z]+,\s*)?([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4}),\s+(\d{1,2}):(\d{2})\s+([AP]M)\s*(?:\(UTC([+-])(\d{1,2})(?::?(\d{2}))?\))?/i;
+
+interface CursorContentBlock {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+interface NormalizedCursorLine {
+  role: 'user' | 'assistant';
+  content: CursorContentBlock[];
+  raw: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getRecordField(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function getStringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  if (!record) return undefined;
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getNumberField(record: Record<string, unknown> | undefined, key: string): number {
+  if (!record) return 0;
+  const value = record[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function normalizeContentBlock(value: unknown): CursorContentBlock | null {
+  if (!isRecord(value) || typeof value.type !== 'string') return null;
+
+  const block: CursorContentBlock = { ...value, type: value.type };
+  if (typeof value.text === 'string') block.text = value.text;
+  return block;
+}
+
+function normalizeContentBlocks(content: unknown): CursorContentBlock[] {
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  if (!Array.isArray(content)) return [];
+
+  const blocks: CursorContentBlock[] = [];
+  for (const item of content) {
+    const block = normalizeContentBlock(item);
+    if (block) blocks.push(block);
+  }
+  return blocks;
+}
+
+function normalizeCursorLine(record: unknown): NormalizedCursorLine | null {
+  const parsed = CursorTranscriptLineSchema.safeParse(record);
+  if (parsed.success) {
+    return {
+      role: parsed.data.role,
+      content: normalizeContentBlocks(parsed.data.message.content),
+      raw: isRecord(record) ? record : {},
+    };
+  }
+
+  if (!isRecord(record)) return null;
+  const role = record.role;
+  if (role !== 'user' && role !== 'assistant') return null;
+
+  const message = getRecordField(record, 'message');
+  const content = normalizeContentBlocks(message?.content);
+  if (content.length === 0) return null;
+
+  return { role, content, raw: record };
+}
+
+function stripCursorMetadataTags(text: string): string {
+  return text.replace(CURSOR_TIMESTAMP_TAG_RE, '').trim();
+}
+
+function cleanCursorUserText(text: string): string {
+  return stripCursorMetadataTags(cleanUserQueryText(text)).trim();
+}
+
+function isCursorNoiseText(rawText: string, cleanedText: string, role: NormalizedCursorLine['role']): boolean {
+  const raw = rawText.trim();
+  const cleaned = cleanedText.trim();
+  if (!cleaned) return true;
+  if (isSystemContent(raw) || isSystemContent(cleaned)) return true;
+  if (raw.startsWith('<system_reminder>') || cleaned.startsWith('<system_reminder>')) return true;
+  if (role === 'user' && !isRealUserMessage(cleaned)) return true;
+  return false;
+}
+
+function parseCursorTimestampTag(text: string): Date | undefined {
+  const tag = CURSOR_TIMESTAMP_TAG_RE.exec(text);
+  if (!tag?.[1]) return undefined;
+
+  const match = CURSOR_TIMESTAMP_BODY_RE.exec(tag[1]);
+  if (!match) return undefined;
+
+  const [, monthName, dayText, yearText, hourText, minuteText, meridiem, offsetSign, offsetHourText, offsetMinuteText] =
+    match;
+  const month = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'].indexOf(
+    monthName.slice(0, 3).toLowerCase(),
+  );
+  if (month < 0) return undefined;
+
+  const year = Number(yearText);
+  const day = Number(dayText);
+  let hour = Number(hourText);
+  const minute = Number(minuteText);
+  if (!Number.isFinite(year) || !Number.isFinite(day) || !Number.isFinite(hour) || !Number.isFinite(minute)) {
+    return undefined;
+  }
+  if (meridiem.toUpperCase() === 'PM' && hour < 12) hour += 12;
+  if (meridiem.toUpperCase() === 'AM' && hour === 12) hour = 0;
+
+  const offsetHours = offsetHourText ? Number(offsetHourText) : 0;
+  const offsetMinutes = offsetMinuteText ? Number(offsetMinuteText) : 0;
+  const signedOffsetMinutes =
+    offsetSign === '-' ? -(offsetHours * 60 + offsetMinutes) : offsetHours * 60 + offsetMinutes;
+  const utcMillis = Date.UTC(year, month, day, hour, minute) - signedOffsetMinutes * 60_000;
+  const date = new Date(utcMillis);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function extractLineTimestamp(line: NormalizedCursorLine): Date | undefined {
+  const message = getRecordField(line.raw, 'message');
+  const explicit =
+    parseDate(getStringField(line.raw, 'timestamp')) ??
+    parseDate(getStringField(line.raw, 'createdAt')) ??
+    parseDate(getStringField(message, 'timestamp')) ??
+    parseDate(getStringField(message, 'createdAt'));
+  if (explicit) return explicit;
+
+  for (const block of line.content) {
+    if (block.type !== 'text' || !block.text) continue;
+    const tagged = parseCursorTimestampTag(block.text);
+    if (tagged) return tagged;
+  }
+  return undefined;
+}
+
+function extractLineModel(line: NormalizedCursorLine): string | undefined {
+  if (line.role !== 'assistant') return undefined;
+  const message = getRecordField(line.raw, 'message');
+  return getStringField(line.raw, 'model') ?? getStringField(message, 'model');
+}
+
+function extractLineUsage(line: NormalizedCursorLine): Record<string, unknown> | undefined {
+  if (line.role !== 'assistant') return undefined;
+  const message = getRecordField(line.raw, 'message');
+  return getRecordField(line.raw, 'usage') ?? (message ? getRecordField(message, 'usage') : undefined);
+}
+
+async function readNormalizedTranscript(filePath: string): Promise<NormalizedCursorLine[]> {
+  const records = await readJsonlFile<unknown>(filePath);
+  const lines: NormalizedCursorLine[] = [];
+  for (const record of records) {
+    const line = normalizeCursorLine(record);
+    if (line) {
+      lines.push(line);
+    } else {
+      logger.debug('cursor: skipping malformed transcript record', filePath);
+    }
+  }
+  return lines;
+}
 
 /**
  * Find all Cursor agent-transcript JSONL files.
@@ -57,8 +236,44 @@ function getProjectSlug(filePath: string): string {
   return '';
 }
 
+function getProjectDir(filePath: string): string {
+  const parts = filePath.split(path.sep);
+  const projectsIdx = parts.indexOf('projects');
+  if (projectsIdx >= 0 && projectsIdx + 1 < parts.length) {
+    return parts.slice(0, projectsIdx + 2).join(path.sep);
+  }
+  return '';
+}
+
 function getSessionId(filePath: string): string {
-  return path.basename(filePath, '.jsonl');
+  const stem = path.basename(filePath, '.jsonl');
+  if (stem === 'transcript') {
+    const parent = path.basename(path.dirname(filePath));
+    if (parent && parent !== 'agent-transcripts' && parent !== 'subagents') return parent;
+  }
+  return stem;
+}
+
+async function resolveProjectCwd(projectDir: string, slug: string): Promise<string> {
+  const fallback = cwdFromSlug(slug);
+  if (!projectDir) return fallback;
+
+  const repoJsonPath = path.join(projectDir, 'repo.json');
+  if (!fs.existsSync(repoJsonPath)) return fallback;
+
+  try {
+    const content = await fs.promises.readFile(repoJsonPath, 'utf8');
+    const parsed = JSON.parse(content) as unknown;
+    if (!isRecord(parsed)) return fallback;
+    for (const key of ['workspace', 'rootPath', 'path']) {
+      const value = getStringField(parsed, key);
+      if (value) return value;
+    }
+  } catch (err) {
+    logger.debug('cursor: failed to read project metadata', repoJsonPath, err);
+  }
+
+  return fallback;
 }
 
 /**
@@ -66,33 +281,60 @@ function getSessionId(filePath: string): string {
  */
 async function parseSessionInfo(filePath: string): Promise<{
   firstUserMessage: string;
+  firstTimestamp?: Date;
+  lastTimestamp?: Date;
   lineCount: number;
   bytes: number;
+  messageCount: number;
+  model?: string;
 }> {
   let firstUserMessage = '';
+  let firstTimestamp: Date | undefined;
+  let lastTimestamp: Date | undefined;
+  let model: string | undefined;
+  let messageCount = 0;
 
   // Stream-count lines without full JSON parse (fast)
   const stats = await getFileStats(filePath);
 
   // Scan head for first user message
-  await scanJsonlHead(filePath, 50, (parsed) => {
-    if (firstUserMessage) return 'continue';
-    const line = parsed as CursorTranscriptLine;
-    if (line.role === 'user') {
-      for (const block of line.message?.content || []) {
-        if (block.type === 'text' && block.text) {
-          const cleaned = cleanUserQueryText(block.text);
-          if (isRealUserMessage(cleaned)) {
-            firstUserMessage = cleaned;
-            return 'stop';
-          }
+  await scanJsonlHead(filePath, 100, (parsed) => {
+    const line = normalizeCursorLine(parsed);
+    if (!line) return 'continue';
+
+    messageCount++;
+
+    const timestamp = extractLineTimestamp(line);
+    if (timestamp) {
+      if (!firstTimestamp) firstTimestamp = timestamp;
+      lastTimestamp = timestamp;
+    }
+
+    model ??= extractLineModel(line);
+
+    if (!firstUserMessage && line.role === 'user') {
+      for (const block of line.content) {
+        if (block.type !== 'text' || !block.text) continue;
+        const cleaned = cleanCursorUserText(block.text);
+        if (!isCursorNoiseText(block.text, cleaned, line.role)) {
+          firstUserMessage = cleaned;
+          break;
         }
       }
     }
+
     return 'continue';
   });
 
-  return { firstUserMessage, lineCount: stats.lines, bytes: stats.bytes };
+  return {
+    firstUserMessage,
+    firstTimestamp,
+    lastTimestamp,
+    lineCount: stats.lines,
+    bytes: stats.bytes,
+    messageCount,
+    model,
+  };
 }
 
 /**
@@ -104,10 +346,12 @@ export async function parseCursorSessions(): Promise<UnifiedSession[]> {
 
   for (const filePath of files) {
     try {
-      const { firstUserMessage, lineCount, bytes } = await parseSessionInfo(filePath);
+      const { firstUserMessage, firstTimestamp, lastTimestamp, lineCount, bytes, messageCount, model } =
+        await parseSessionInfo(filePath);
+      if (messageCount === 0) continue;
       const fileStats = fs.statSync(filePath);
       const slug = getProjectSlug(filePath);
-      const cwd = cwdFromSlug(slug);
+      const cwd = await resolveProjectCwd(getProjectDir(filePath), slug);
 
       const summary = cleanSummary(firstUserMessage);
 
@@ -118,10 +362,11 @@ export async function parseCursorSessions(): Promise<UnifiedSession[]> {
         repo: extractRepoFromCwd(cwd),
         lines: lineCount,
         bytes,
-        createdAt: fileStats.birthtime,
-        updatedAt: fileStats.mtime,
+        createdAt: firstTimestamp ?? fileStats.birthtime,
+        updatedAt: lastTimestamp ?? fileStats.mtime,
         originalPath: filePath,
         summary: summary || undefined,
+        model,
       });
     } catch (err) {
       logger.debug('cursor: skipping unparseable session', filePath, err);
@@ -129,7 +374,9 @@ export async function parseCursorSessions(): Promise<UnifiedSession[]> {
     }
   }
 
-  return sessions.filter((s) => s.bytes > 100).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  return sessions
+    .filter((s) => s.bytes > 0 && s.lines > 0)
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 }
 
 /**
@@ -137,13 +384,13 @@ export async function parseCursorSessions(): Promise<UnifiedSession[]> {
  */
 export async function extractCursorContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const resolvedConfig = config ?? getPreset('standard');
-  const lines = await readJsonlFile<CursorTranscriptLine>(session.originalPath);
+  const lines = await readNormalizedTranscript(session.originalPath);
   const recentMessages: ConversationMessage[] = [];
 
   // Extract tool data via shared Anthropic utility
   const anthropicMsgs: AnthropicMessage[] = lines.map((l) => ({
     role: l.role,
-    content: l.message.content,
+    content: l.content,
   }));
 
   const { summaries: toolSummaries, filesModified } = extractAnthropicToolData(anthropicMsgs, resolvedConfig);
@@ -152,37 +399,30 @@ export async function extractCursorContext(session: UnifiedSession, config?: Ver
   const sessionNotes: SessionNotes = {};
   const reasoning = extractThinkingHighlights(anthropicMsgs);
   if (reasoning.length > 0) sessionNotes.reasoning = reasoning;
-
-  if (!sessionNotes.reasoning) sessionNotes.reasoning = [];
-  sessionNotes.reasoning.push(
-    'Cursor transcript completeness warning: local agent-transcripts may omit tool outputs and can be less complete than hidden local stores or exported/session state.',
-  );
+  sessionNotes.fidelityWarnings = [CURSOR_FIDELITY_WARNING];
 
   // Aggregate token usage, cache tokens, and model from passthrough fields.
   // Cursor CLI agent-transcripts use Anthropic API format — the schema's
   // .passthrough() preserves `usage` and `model` on each JSONL line.
   for (const line of lines) {
     if (line.role !== 'assistant') continue;
-    const raw = line as Record<string, unknown>;
 
     // Model: take the first one found (all lines in a session use the same model)
-    const model = (raw.model ?? (raw.message as Record<string, unknown> | undefined)?.model) as string | undefined;
+    const model = extractLineModel(line);
     if (model && !sessionNotes.model) {
       sessionNotes.model = model;
     }
 
     // Usage may be at top level or nested under message (both observed in the wild)
-    const usage = (raw.usage ?? (raw.message as Record<string, unknown> | undefined)?.usage) as
-      | Record<string, number>
-      | undefined;
+    const usage = extractLineUsage(line);
     if (!usage) continue;
 
     if (!sessionNotes.tokenUsage) sessionNotes.tokenUsage = { input: 0, output: 0 };
-    sessionNotes.tokenUsage.input += usage.input_tokens || 0;
-    sessionNotes.tokenUsage.output += usage.output_tokens || 0;
+    sessionNotes.tokenUsage.input += getNumberField(usage, 'input_tokens');
+    sessionNotes.tokenUsage.output += getNumberField(usage, 'output_tokens');
 
-    const cacheCreation = usage.cache_creation_input_tokens || 0;
-    const cacheRead = usage.cache_read_input_tokens || 0;
+    const cacheCreation = getNumberField(usage, 'cache_creation_input_tokens');
+    const cacheRead = getNumberField(usage, 'cache_read_input_tokens');
     if (cacheCreation || cacheRead) {
       if (!sessionNotes.cacheTokens) sessionNotes.cacheTokens = { creation: 0, read: 0 };
       sessionNotes.cacheTokens.creation += cacheCreation;
@@ -194,10 +434,10 @@ export async function extractCursorContext(session: UnifiedSession, config?: Ver
 
   for (const line of lines) {
     const textParts: string[] = [];
-    for (const block of line.message.content) {
+    for (const block of line.content) {
       if (block.type === 'text' && block.text) {
-        if (isSystemContent(block.text)) continue;
-        const cleaned = line.role === 'user' ? cleanUserQueryText(block.text) : block.text;
+        const cleaned = line.role === 'user' ? cleanCursorUserText(block.text) : stripCursorMetadataTags(block.text);
+        if (isCursorNoiseText(block.text, cleaned, line.role)) continue;
         if (cleaned) textParts.push(cleaned);
       }
     }
@@ -208,6 +448,7 @@ export async function extractCursorContext(session: UnifiedSession, config?: Ver
     recentMessages.push({
       role: line.role === 'user' ? 'user' : 'assistant',
       content: text,
+      timestamp: extractLineTimestamp(line),
     });
   }
 

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -282,7 +282,6 @@ async function resolveProjectCwd(projectDir: string, slug: string): Promise<stri
 async function parseSessionInfo(filePath: string): Promise<{
   firstUserMessage: string;
   firstTimestamp?: Date;
-  lastTimestamp?: Date;
   lineCount: number;
   bytes: number;
   messageCount: number;
@@ -290,7 +289,6 @@ async function parseSessionInfo(filePath: string): Promise<{
 }> {
   let firstUserMessage = '';
   let firstTimestamp: Date | undefined;
-  let lastTimestamp: Date | undefined;
   let model: string | undefined;
   let messageCount = 0;
 
@@ -307,7 +305,6 @@ async function parseSessionInfo(filePath: string): Promise<{
     const timestamp = extractLineTimestamp(line);
     if (timestamp) {
       if (!firstTimestamp) firstTimestamp = timestamp;
-      lastTimestamp = timestamp;
     }
 
     model ??= extractLineModel(line);
@@ -329,7 +326,6 @@ async function parseSessionInfo(filePath: string): Promise<{
   return {
     firstUserMessage,
     firstTimestamp,
-    lastTimestamp,
     lineCount: stats.lines,
     bytes: stats.bytes,
     messageCount,
@@ -346,7 +342,7 @@ export async function parseCursorSessions(): Promise<UnifiedSession[]> {
 
   for (const filePath of files) {
     try {
-      const { firstUserMessage, firstTimestamp, lastTimestamp, lineCount, bytes, messageCount, model } =
+      const { firstUserMessage, firstTimestamp, lineCount, bytes, messageCount, model } =
         await parseSessionInfo(filePath);
       if (messageCount === 0) continue;
       const fileStats = fs.statSync(filePath);
@@ -363,7 +359,7 @@ export async function parseCursorSessions(): Promise<UnifiedSession[]> {
         lines: lineCount,
         bytes,
         createdAt: firstTimestamp ?? fileStats.birthtime,
-        updatedAt: lastTimestamp ?? fileStats.mtime,
+        updatedAt: fileStats.mtime,
         originalPath: filePath,
         summary: summary || undefined,
         model,

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -21,6 +21,7 @@ const CURSOR_PROJECTS_DIR = path.join(homeDir(), '.cursor', 'projects');
 const CURSOR_FIDELITY_WARNING =
   'Cursor transcript completeness warning: local agent-transcripts are partial exports and may omit tool outputs, images, reasoning, compaction markers, or other hidden SQLite/session state.';
 const CURSOR_TIMESTAMP_TAG_RE = /<timestamp>([\s\S]*?)<\/timestamp>/i;
+const CURSOR_TIMESTAMP_TAG_GLOBAL_RE = /<timestamp>[\s\S]*?<\/timestamp>/gi;
 const CURSOR_TIMESTAMP_BODY_RE =
   /(?:[A-Za-z]+,\s*)?([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4}),\s+(\d{1,2}):(\d{2})\s+([AP]M)\s*(?:\(UTC([+-])(\d{1,2})(?::?(\d{2}))?\))?/i;
 
@@ -60,8 +61,14 @@ function getNumberField(record: Record<string, unknown> | undefined, key: string
 function normalizeContentBlock(value: unknown): CursorContentBlock | null {
   if (!isRecord(value) || typeof value.type !== 'string') return null;
 
+  // Spread the raw fields, then sanitize `text` so a non-string upstream value
+  // can never reach downstream consumers (which assume `block.text: string`).
   const block: CursorContentBlock = { ...value, type: value.type };
-  if (typeof value.text === 'string') block.text = value.text;
+  if (typeof value.text === 'string') {
+    block.text = value.text;
+  } else if ('text' in block) {
+    delete block.text;
+  }
   return block;
 }
 
@@ -99,7 +106,7 @@ function normalizeCursorLine(record: unknown): NormalizedCursorLine | null {
 }
 
 function stripCursorMetadataTags(text: string): string {
-  return text.replace(CURSOR_TIMESTAMP_TAG_RE, '').trim();
+  return text.replace(CURSOR_TIMESTAMP_TAG_GLOBAL_RE, '').trim();
 }
 
 function cleanCursorUserText(text: string): string {
@@ -200,7 +207,15 @@ async function readNormalizedTranscript(filePath: string): Promise<NormalizedCur
 
 /**
  * Find all Cursor agent-transcript JSONL files.
- * Structure: ~/.cursor/projects/<project-slug>/agent-transcripts/<uuid>/<uuid>.jsonl
+ *
+ * Cursor writes transcripts under `~/.cursor/projects/<project-slug>/agent-transcripts/`
+ * in two observed layouts:
+ *   - nested: `<uuid>/transcript.jsonl` (or `<uuid>/<uuid>.jsonl`)
+ *   - flat:   `<uuid>.jsonl`
+ *
+ * The recursive scan accepts both. Discovery does not assume a particular
+ * filename — `getSessionId()` derives the UUID, and `parseCursorSessions()`
+ * deduplicates by id when both layouts coexist for the same session.
  */
 async function findTranscriptFiles(): Promise<string[]> {
   if (!fs.existsSync(CURSOR_PROJECTS_DIR)) return [];
@@ -254,26 +269,45 @@ function getSessionId(filePath: string): string {
   return stem;
 }
 
-async function resolveProjectCwd(projectDir: string, slug: string): Promise<string> {
+async function resolveProjectCwd(
+  projectDir: string,
+  slug: string,
+  cache: Map<string, string>,
+): Promise<string> {
   const fallback = cwdFromSlug(slug);
   if (!projectDir) return fallback;
 
-  const repoJsonPath = path.join(projectDir, 'repo.json');
-  if (!fs.existsSync(repoJsonPath)) return fallback;
+  // Cache the resolved cwd per project directory: a single `repo.json` is
+  // shared by every transcript in a project, and discovery typically iterates
+  // many sibling sessions in the same project.
+  const cached = cache.get(projectDir);
+  if (cached !== undefined) return cached || fallback;
 
+  const repoJsonPath = path.join(projectDir, 'repo.json');
+  if (!fs.existsSync(repoJsonPath)) {
+    cache.set(projectDir, '');
+    return fallback;
+  }
+
+  let resolved = '';
   try {
     const content = await fs.promises.readFile(repoJsonPath, 'utf8');
     const parsed = JSON.parse(content) as unknown;
-    if (!isRecord(parsed)) return fallback;
-    for (const key of ['workspace', 'rootPath', 'path']) {
-      const value = getStringField(parsed, key);
-      if (value) return value;
+    if (isRecord(parsed)) {
+      for (const key of ['workspace', 'rootPath', 'path']) {
+        const value = getStringField(parsed, key);
+        if (value) {
+          resolved = value;
+          break;
+        }
+      }
     }
   } catch (err) {
     logger.debug('cursor: failed to read project metadata', repoJsonPath, err);
   }
 
-  return fallback;
+  cache.set(projectDir, resolved);
+  return resolved || fallback;
 }
 
 /**
@@ -284,13 +318,11 @@ async function parseSessionInfo(filePath: string): Promise<{
   firstTimestamp?: Date;
   lineCount: number;
   bytes: number;
-  messageCount: number;
   model?: string;
 }> {
   let firstUserMessage = '';
   let firstTimestamp: Date | undefined;
   let model: string | undefined;
-  let messageCount = 0;
 
   // Stream-count lines without full JSON parse (fast)
   const stats = await getFileStats(filePath);
@@ -299,8 +331,6 @@ async function parseSessionInfo(filePath: string): Promise<{
   await scanJsonlHead(filePath, 100, (parsed) => {
     const line = normalizeCursorLine(parsed);
     if (!line) return 'continue';
-
-    messageCount++;
 
     const timestamp = extractLineTimestamp(line);
     if (timestamp) {
@@ -328,7 +358,6 @@ async function parseSessionInfo(filePath: string): Promise<{
     firstTimestamp,
     lineCount: stats.lines,
     bytes: stats.bytes,
-    messageCount,
     model,
   };
 }
@@ -338,21 +367,25 @@ async function parseSessionInfo(filePath: string): Promise<{
  */
 export async function parseCursorSessions(): Promise<UnifiedSession[]> {
   const files = await findTranscriptFiles();
-  const sessions: UnifiedSession[] = [];
+  const sessionsById = new Map<string, UnifiedSession>();
+  const projectCwdCache = new Map<string, string>();
 
   for (const filePath of files) {
     try {
-      const { firstUserMessage, firstTimestamp, lineCount, bytes, messageCount, model } =
-        await parseSessionInfo(filePath);
-      if (messageCount === 0) continue;
+      const { firstUserMessage, firstTimestamp, lineCount, bytes, model } = await parseSessionInfo(filePath);
+      // Do not gate on head-scan `messageCount`: a long session whose first
+      // valid record sits past the 100-line head would be dropped here even
+      // though `extractCursorContext()` reads the full file. The downstream
+      // `lines > 0 && bytes > 0` filter still excludes truly empty files.
       const fileStats = fs.statSync(filePath);
       const slug = getProjectSlug(filePath);
-      const cwd = await resolveProjectCwd(getProjectDir(filePath), slug);
+      const cwd = await resolveProjectCwd(getProjectDir(filePath), slug, projectCwdCache);
 
       const summary = cleanSummary(firstUserMessage);
 
-      sessions.push({
-        id: getSessionId(filePath),
+      const id = getSessionId(filePath);
+      const next: UnifiedSession = {
+        id,
         source: 'cursor',
         cwd,
         repo: extractRepoFromCwd(cwd),
@@ -363,14 +396,23 @@ export async function parseCursorSessions(): Promise<UnifiedSession[]> {
         originalPath: filePath,
         summary: summary || undefined,
         model,
-      });
+      };
+
+      // Discovery may surface the same logical session twice when a session
+      // dir contains both `<uuid>/transcript.jsonl` and `<uuid>.jsonl` (or a
+      // legacy `<uuid>/<uuid>.jsonl` left behind). Keep the most recently
+      // updated copy so the picker shows the canonical entry.
+      const existing = sessionsById.get(id);
+      if (!existing || existing.updatedAt.getTime() < next.updatedAt.getTime()) {
+        sessionsById.set(id, next);
+      }
     } catch (err) {
       logger.debug('cursor: skipping unparseable session', filePath, err);
       // Skip files we can't parse
     }
   }
 
-  return sessions
+  return Array.from(sessionsById.values())
     .filter((s) => s.bytes > 0 && s.lines > 0)
     .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 }

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -22,6 +22,15 @@ const CURSOR_FIDELITY_WARNING =
   'Cursor transcript completeness warning: local agent-transcripts are partial exports and may omit tool outputs, images, reasoning, compaction markers, or other hidden SQLite/session state.';
 const CURSOR_TIMESTAMP_TAG_RE = /<timestamp>([\s\S]*?)<\/timestamp>/i;
 const CURSOR_TIMESTAMP_TAG_GLOBAL_RE = /<timestamp>[\s\S]*?<\/timestamp>/gi;
+// Supported `<timestamp>` body shapes (English locale only, per Cursor's
+// hard-coded format observed in the wild and corroborated by VibeLens'
+// `_TIMESTAMP_BODY_RE`):
+//   `Sunday, Apr 26, 2026, 9:53 PM`
+//   `Sunday, Apr 26, 2026, 9:53 PM (UTC-4)`
+//   `Apr 26, 2026, 9:53 PM (UTC+05:30)`
+// The optional weekday prefix and (UTC±H[:MM]) suffix are both tolerated.
+// Locale-specific or named-tz timestamps fall back to file mtime via
+// `fs.statSync(filePath)` in `parseCursorSessions`.
 const CURSOR_TIMESTAMP_BODY_RE =
   /(?:[A-Za-z]+,\s*)?([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4}),\s+(\d{1,2}):(\d{2})\s+([AP]M)\s*(?:\(UTC([+-])(\d{1,2})(?::?(\d{2}))?\))?/i;
 
@@ -269,11 +278,21 @@ function getSessionId(filePath: string): string {
   return stem;
 }
 
-async function resolveProjectCwd(
-  projectDir: string,
-  slug: string,
-  cache: Map<string, string>,
-): Promise<string> {
+/**
+ * Resolve the project working directory from `repo.json`, with cached results.
+ *
+ * Cursor does not officially document the `repo.json` schema (see
+ * docs/parser-documentation/access-recipes/07-cursor.md), so the key
+ * precedence below is observed/inferred:
+ *
+ *   workspace > rootPath > path
+ *
+ * Independently corroborated by VibeLens (CHATS-lab/VibeLens
+ * `src/vibelens/ingest/parsers/cursor.py`), which uses the same order.
+ *
+ * Falls back to slug-derived cwd when `repo.json` is absent or unreadable.
+ */
+async function resolveProjectCwd(projectDir: string, slug: string, cache: Map<string, string>): Promise<string> {
   const fallback = cwdFromSlug(slug);
   if (!projectDir) return fallback;
 
@@ -327,7 +346,15 @@ async function parseSessionInfo(filePath: string): Promise<{
   // Stream-count lines without full JSON parse (fast)
   const stats = await getFileStats(filePath);
 
-  // Scan head for first user message
+  // Scan head for first user message. The 100-record cap is a discovery
+  // optimization (avoids streaming megabyte transcripts twice — once here,
+  // once in `extractCursorContext`). The discovery path treats a missing
+  // first-user-message as cosmetic-only: `parseCursorSessions` no longer
+  // gates on `messageCount`, so a session whose first user record lives
+  // past the head window still surfaces — it just lists without a summary
+  // until the user opens it (covered by the
+  // 'keeps long transcripts whose first parseable record sits past the head
+  //  scan window' regression test).
   await scanJsonlHead(filePath, 100, (parsed) => {
     const line = normalizeCursorLine(parsed);
     if (!line) return 'continue';


### PR DESCRIPTION
# fix(cursor): harden transcript parsing

## Summary
Hardened Cursor transcript discovery and extraction so the parser accepts both nested `transcript.jsonl` layouts and flat Cursor CLI JSONL files, recovers project cwd from Cursor repo metadata, and normalizes looser transcript records before handoff generation. The Cursor partial-export caveat now lives in `sessionNotes.fidelityWarnings` instead of being presented as reasoning or visible handoff markdown.

## Context / Why now
Cursor local `agent-transcripts` are partial exports and do not behave like a single stable schema. The parser was too strict about file names, content shape, and user-message extraction, which could miss sessions, lose repo metadata, or leak Cursor wrapper/noise tags into continuation context.

## The 4 items

### Item 1: Nested and flat transcript layouts
- Files: `src/parsers/cursor.ts`, `src/__tests__/cursor-parser.test.ts`
- What: Preserves UUID session IDs for nested `agent-transcripts/<uuid>/transcript.jsonl` files while still discovering flat `agent-transcripts/<uuid>.jsonl` files.
- Why this shape: Keeps compatibility with the existing recursive JSONL scan and narrows the behavior change to session ID derivation.
- Verified by: Added parser coverage for nested `transcript.jsonl` and flat Cursor CLI transcript fixtures.

### Item 2: Repo metadata cwd
- Files: `src/parsers/cursor.ts`, `src/__tests__/cursor-parser.test.ts`
- What: Reads project `repo.json` and prefers `workspace`, `rootPath`, then `path` before falling back to cwd-from-slug.
- Why this shape: Cursor project slugs are lossy; repo metadata is a better source when present, but slug fallback preserves current behavior.
- Verified by: Added fixture coverage that expects `cwd` to come from `repo.json`.

### Item 3: Transcript normalization
- Files: `src/parsers/cursor.ts`, `src/__tests__/cursor-parser.test.ts`
- What: Adds a normalized line layer that accepts schema-valid records plus tolerant fallback records, string `message.content`, `<user_query>` wrappers, timestamp tags, tool-use blocks, model/usage/cache metadata, and malformed trailing JSONL records without throwing.
- Why this shape: Normalizing once lets discovery, context extraction, tool summaries, and session notes consume the same shape without weakening the exported session contract.
- Verified by: Added fixture coverage for string content, timestamp parsing, system-reminder filtering, tool extraction, file-modified extraction, usage aggregation, cache-token aggregation, and malformed record skipping.

### Item 4: Fidelity warning semantics
- Files: `src/parsers/cursor.ts`, `src/__tests__/cursor-parser.test.ts`
- What: Moves the Cursor completeness warning into `sessionNotes.fidelityWarnings`, leaves `reasoning` unset when no thinking exists, and avoids fabricating tool result fields for tool calls that lack outputs.
- Why this shape: A completeness warning is provenance metadata, not model reasoning, and rendering it into markdown made handoffs noisier than the underlying transcript justified.
- Verified by: Updated tests to assert the warning exists in `fidelityWarnings`, is absent from generated markdown, and does not invent shell exit/stdout/error data.

## Files touched

| File | +/- | Purpose |
|---|---:|---|
| `src/parsers/cursor.ts` | +279 / -38 | Normalize Cursor transcript records, resolve project metadata cwd, preserve nested session IDs, and emit fidelity warnings. |
| `src/__tests__/cursor-parser.test.ts` | +188 / -4 | Cover nested/flat layouts, repo metadata cwd, normalization, malformed records, and fidelity-warning behavior. |

## Verification
- Tests run: `pnpm test` failed before running tests because this worktree has no `node_modules`; `vitest` was not found.
- Tests run: `/Users/yigitkonur/dev-test/cli-continues/node_modules/.bin/vitest run --root /Users/yigitkonur/dev-test/cli-continues-wt-cursor-transcript-hardening --config /Users/yigitkonur/dev-test/cli-continues/vitest.config.ts` started Vitest from the dependency-bearing worktree, but failed because imports from this worktree still could not resolve packages such as `yaml`, `chalk`, `zod`, and `@clack/prompts`.
- Full-check baseline blocker: `/Users/yigitkonur/dev-test/cli-continues/node_modules/.bin/biome check src/ --diagnostic-level=error --max-diagnostics=50` failed with 3 existing formatter errors in `src/parsers/antigravity.ts`, `src/parsers/copilot.ts`, and `src/parsers/droid.ts`, all outside this PR's diff. Since `pnpm run check` is `pnpm lint && pnpm build`, the check chain is blocked before build by that baseline lint/format state.
- Not run directly: `pnpm run check`, because this worktree has no installed dependencies and the build phase writes `dist`.

## Weaknesses and open questions
1. Important: Discovery still scans only the first 100 JSONL records for list metadata. Context extraction reads the normalized transcript later, but a session whose first real user message appears after that head scan may still list without a summary.
2. Important: The `repo.json` cwd key order is inferred as `workspace`, `rootPath`, then `path`. That matches the fixtures and keeps a fallback, but it is not backed by an explicit Cursor metadata contract in this PR.
3. Minor: Timestamp parsing handles observed English Cursor timestamp tags with optional UTC offsets. Locale-specific timestamp text or named time zones fall back to file timestamps.

## Request to the reviewer
1. Please review the normalization boundary in depth: should fallback records without typed content blocks be preserved in any form, or is dropping them the right failure mode?
2. Please verify the `repo.json` cwd precedence. If Cursor writes multiple path-like keys, should `workspace` always win over `rootPath` and `path`?
3. Please review the fidelity-warning placement. Should the warning stay in structured `sessionNotes.fidelityWarnings`, or should generated handoff markdown surface it despite the added noise?

## Follow-ups
- Fix the existing formatter baseline in `src/parsers/antigravity.ts`, `src/parsers/copilot.ts`, and `src/parsers/droid.ts` so `pnpm run check` can reach build.
- Install dependencies in this worktree or run verification from a dependency-complete checkout.
- Investigate Cursor SQLite/session stores separately; this PR only hardens local `agent-transcripts` parsing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Cursor transcript parsing to support nested, flat, and sub‑agent layouts, normalize looser records, and produce cleaner context, tool data, and metadata. Sessions dedupe by id, resolve `cwd` from repo metadata, sort by filesystem recency, and record completeness warnings in `sessionNotes.fidelityWarnings`.

- **New Features**
  - Discover `agent-transcripts/<uuid>/transcript.jsonl`, `<uuid>.jsonl`, and sub-agent `.../<uuid>/subagents/<child>.jsonl`; dedupe by id and keep the most recent file.
  - Resolve `cwd` from `repo.json` with precedence: `workspace` > `rootPath` > `path`; cache per project.
  - Parse `<timestamp>` tags (incl. UTC offsets) to set message timestamps and session `createdAt`; order sessions by filesystem `mtime`.

- **Bug Fixes**
  - Remove the head-scan gate so long sessions are still discovered; skip malformed records safely and drop non-string `text` values after spreading.
  - Strip all `<timestamp>` tags from text; filter system/reminder noise; avoid fabricating tool results; store completeness warnings in `sessionNotes.fidelityWarnings` (not reasoning/markdown).

<sup>Written for commit 53c1c1337fd035aee3e454f642e29e3a408349fd. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/62?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

