### PR TITLE
fix(parser): harden kiro session surfaces

### DIFF
--- a/src/__tests__/kiro-parser.test.ts
+++ b/src/__tests__/kiro-parser.test.ts
@@ -354,6 +354,146 @@ describe('kiro parser hardening', () => {
     expect(context.markdown).toContain('Kiro fidelity warning');
   });
 
+  it('preserves whitespace-only ACP chunks while reconstructing streamed assistant messages', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const metadataPath = path.join(sessionDir, 'sess_acp_whitespace.json');
+    const eventPath = path.join(sessionDir, 'sess_acp_whitespace.jsonl');
+
+    writeJson(metadataPath, {
+      id: 'sess_acp_whitespace',
+      createdAt: '2026-02-06T01:00:00.000Z',
+      updatedAt: '2026-02-06T01:01:00.000Z',
+    });
+    writeJsonl(eventPath, [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'session/prompt',
+        params: {
+          sessionId: 'sess_acp_whitespace',
+          content: 'Stream a greeting',
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_whitespace',
+          update: { type: 'AgentMessageChunk', content: 'hello' },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_whitespace',
+          update: { type: 'AgentMessageChunk', content: ' ' },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_whitespace',
+          update: { type: 'AgentMessageChunk', content: 'world' },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_whitespace',
+          update: { type: 'TurnEnd' },
+        },
+      },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.recentMessages).toEqual([
+      { role: 'user', content: 'Stream a greeting', timestamp: undefined },
+      { role: 'assistant', content: 'hello world', timestamp: undefined },
+    ]);
+  });
+
+  it('counts ACP ToolCallUpdate records as updates to a matching tool call', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const metadataPath = path.join(sessionDir, 'sess_acp_tool_update.json');
+    const eventPath = path.join(sessionDir, 'sess_acp_tool_update.jsonl');
+
+    writeJson(metadataPath, {
+      id: 'sess_acp_tool_update',
+      createdAt: '2026-02-07T01:00:00.000Z',
+      updatedAt: '2026-02-07T01:01:00.000Z',
+    });
+    writeJsonl(eventPath, [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'session/prompt',
+        params: {
+          sessionId: 'sess_acp_tool_update',
+          content: 'Read the parser',
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_tool_update',
+          update: {
+            type: 'ToolCall',
+            id: 'tool-call-1',
+            name: 'readTextFile',
+            parameters: { path: 'src/parsers/kiro.ts' },
+            status: 'running',
+          },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_tool_update',
+          update: {
+            type: 'ToolCallUpdate',
+            id: 'tool-call-1',
+            name: 'readTextFile',
+            result: 'Loaded parser contents',
+            status: 'completed',
+          },
+        },
+      },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.toolSummaries).toEqual([
+      expect.objectContaining({
+        name: 'readTextFile',
+        count: 1,
+        samples: [
+          expect.objectContaining({
+            summary: 'readTextFile({"path":"src/parsers/kiro.ts"}) → "Loaded parser contents" [completed]',
+            data: expect.objectContaining({
+              category: 'mcp',
+              toolName: 'readTextFile',
+              result: 'Loaded parser contents',
+            }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it('skips unknown CLI SQLite stores safely and reports the parser fidelity limit', async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
     tmpHomes.push(home);

--- a/src/__tests__/kiro-parser.test.ts
+++ b/src/__tests__/kiro-parser.test.ts
@@ -1,0 +1,387 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { UnifiedSession } from '../types/index.js';
+
+const tmpHomes: string[] = [];
+
+function encodeWorkspacePath(workspacePath: string): string {
+  return Buffer.from(workspacePath, 'utf8').toString('base64url');
+}
+
+function createKiroWorkspace(homeDir: string, workspacePath: string): string {
+  const workspaceDir = path.join(
+    homeDir,
+    'Library',
+    'Application Support',
+    'Kiro',
+    'User',
+    'globalStorage',
+    'kiro.kiroagent',
+    'workspace-sessions',
+    encodeWorkspacePath(workspacePath),
+  );
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  return workspaceDir;
+}
+
+function createKiroAcpSessionDir(homeDir: string): string {
+  const sessionDir = path.join(homeDir, '.kiro', 'sessions', 'cli');
+  fs.mkdirSync(sessionDir, { recursive: true });
+  return sessionDir;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf8');
+}
+
+function writeJsonl(filePath: string, values: unknown[]): void {
+  fs.writeFileSync(filePath, `${values.map((value) => JSON.stringify(value)).join('\n')}\n`, 'utf8');
+}
+
+async function loadKiroParserWithHome(homeDir: string): Promise<typeof import('../parsers/kiro.js')> {
+  vi.resetModules();
+  vi.doMock('os', async () => {
+    const actual = await vi.importActual<typeof import('os')>('os');
+    return {
+      ...actual,
+      homedir: () => homeDir,
+    };
+  });
+  return import('../parsers/kiro.js');
+}
+
+afterEach(() => {
+  vi.doUnmock('os');
+  vi.resetModules();
+  for (const tmpHome of tmpHomes) {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+  tmpHomes.length = 0;
+});
+
+describe('kiro parser hardening', () => {
+  it('parses indexed workspace sessions and derives stable metadata', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const workspacePath = '/Users/dev/work/my-app';
+    const workspaceDir = createKiroWorkspace(home, workspacePath);
+    const sessionPath = path.join(workspaceDir, 'session-indexed.json');
+    const updatedAt = new Date('2026-02-03T04:05:06.000Z');
+
+    writeJson(path.join(workspaceDir, 'sessions.json'), [
+      {
+        sessionId: 'session-indexed',
+        title: 'Auth investigation',
+        dateCreated: '1770000000000',
+        messageCount: 4,
+      },
+    ]);
+    writeJson(sessionPath, {
+      sessionId: 'session-indexed',
+      selectedModel: 'claude-opus-4.5',
+      history: [
+        {
+          message: {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Fix the auth bug' },
+              { type: 'image', text: 'ignored screenshot payload' },
+            ],
+          },
+        },
+        { message: { role: 'assistant', content: [{ type: 'text', text: 'I will inspect login.ts.' }] } },
+      ],
+    });
+    fs.utimesSync(sessionPath, updatedAt, updatedAt);
+
+    const { parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: 'session-indexed',
+      source: 'kiro',
+      cwd: workspacePath,
+      repo: 'work/my-app',
+      lines: 4,
+      originalPath: sessionPath,
+      summary: 'Fix the auth bug',
+      model: 'claude-opus-4.5',
+    });
+    expect(sessions[0].bytes).toBe(fs.statSync(sessionPath).size);
+    expect(sessions[0].createdAt.toISOString()).toBe('2026-02-02T02:40:00.000Z');
+    expect(sessions[0].updatedAt.toISOString()).toBe(updatedAt.toISOString());
+  });
+
+  it('tolerates invalid json, missing optional fields, malformed history, and empty sessions', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const workspaceDir = createKiroWorkspace(home, '/tmp/noisy-project');
+
+    fs.writeFileSync(path.join(workspaceDir, 'broken.json'), '{not-json', 'utf8');
+    writeJson(path.join(workspaceDir, 'partial.json'), {
+      history: [
+        null,
+        { message: null },
+        { role: 'system', content: 'skip system noise' },
+        { role: 'human', content: 'Keep parsing despite malformed entries' },
+        { role: 'assistant', content: 42 },
+        { role: 'assistant', content: 'Recovered.' },
+      ],
+    });
+    writeJson(path.join(workspaceDir, 'empty.json'), {
+      sessionId: 'empty',
+      title: 'Empty but indexed session',
+      history: [{ role: 'system', content: 'noise only' }],
+    });
+
+    const { parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+
+    expect(sessions.map((session) => session.id).sort()).toEqual(['empty', 'partial']);
+    expect(sessions.find((session) => session.id === 'partial')).toMatchObject({
+      cwd: '/tmp/noisy-project',
+      lines: 2,
+      summary: 'Keep parsing despite malformed entries',
+    });
+    expect(sessions.find((session) => session.id === 'empty')).toMatchObject({
+      lines: 0,
+      summary: 'Empty but indexed session',
+    });
+  });
+
+  it('extracts only valid user and assistant messages from string and block-array content', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const workspacePath = '/Users/dev/work/content-app';
+    const workspaceDir = createKiroWorkspace(home, workspacePath);
+    const sessionPath = path.join(workspaceDir, 'content-session.json');
+
+    writeJson(sessionPath, {
+      sessionId: 'content-session',
+      selectedModel: 'claude-sonnet-4.5',
+      history: [
+        {
+          role: 'human',
+          content: [
+            { type: 'text', text: 'First user line' },
+            { kind: 'text', data: 'Second user line' },
+            { type: 'executionLog', text: 'execution-id-should-not-leak' },
+          ],
+        },
+        { message: { role: 'assistant', content: 'Assistant answer.' } },
+        { role: 'system', content: 'system noise' },
+        { message: { role: 'tool', content: [{ type: 'text', text: 'tool noise' }] } },
+      ],
+    });
+
+    const { extractKiroContext } = await loadKiroParserWithHome(home);
+    const session: UnifiedSession = {
+      id: 'content-session',
+      source: 'kiro',
+      cwd: workspacePath,
+      repo: 'work/content-app',
+      lines: 4,
+      bytes: fs.statSync(sessionPath).size,
+      createdAt: new Date('2026-02-03T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-03T00:05:00.000Z'),
+      originalPath: sessionPath,
+      summary: 'Content variants',
+    };
+
+    const context = await extractKiroContext(session);
+
+    expect(context.recentMessages).toEqual([
+      { role: 'user', content: 'First user line\nSecond user line', timestamp: undefined },
+      { role: 'assistant', content: 'Assistant answer.', timestamp: undefined },
+    ]);
+    expect(context.recentMessages[0].content).not.toContain('execution-id');
+    expect(context.session.model).toBe('claude-sonnet-4.5');
+    expect(context.sessionNotes?.model).toBe('claude-sonnet-4.5');
+    expect(context.toolSummaries).toEqual([]);
+    expect(context.filesModified).toEqual([]);
+    expect(context.pendingTasks).toEqual([]);
+  });
+
+  it('keeps index-only sessions parseable and extracts empty context without fabricating tool calls', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const workspaceDir = createKiroWorkspace(home, '/tmp/index-only');
+    const indexPath = path.join(workspaceDir, 'sessions.json');
+
+    writeJson(indexPath, [
+      {
+        sessionId: 'indexed-without-file',
+        title: 'Indexed without a session file',
+        dateCreated: '2026-02-04T00:00:00.000Z',
+        messageCount: 3,
+        selectedModel: 'claude-sonnet-4',
+      },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+    const session = sessions[0];
+
+    expect(session).toMatchObject({
+      id: 'indexed-without-file',
+      originalPath: indexPath,
+      lines: 3,
+      summary: 'Indexed without a session file',
+      model: 'claude-sonnet-4',
+    });
+
+    const context = await extractKiroContext(session);
+
+    expect(context.recentMessages).toEqual([]);
+    expect(context.toolSummaries).toEqual([]);
+    expect(context.sessionNotes?.model).toBe('claude-sonnet-4');
+  });
+
+  it('parses documented ACP JSON/JSONL sessions without inventing missing tool details', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const metadataPath = path.join(sessionDir, 'sess_acp_123.json');
+    const eventPath = path.join(sessionDir, 'sess_acp_123.jsonl');
+
+    writeJson(metadataPath, {
+      id: 'sess_acp_123',
+      title: 'ACP parser smoke',
+      createdAt: '2026-02-05T01:00:00.000Z',
+      updatedAt: '2026-02-05T01:03:00.000Z',
+      model: 'claude-sonnet-4',
+    });
+    writeJsonl(eventPath, [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'session/new',
+        params: {
+          cwd: '/Users/dev/work/acp-app',
+          mcpServers: [],
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'session/prompt',
+        params: {
+          sessionId: 'sess_acp_123',
+          content: [{ type: 'text', text: 'Explain the ACP session parser' }],
+        },
+        timestamp: '2026-02-05T01:01:00.000Z',
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_123',
+          update: { type: 'AgentMessageChunk', content: 'It reads JSONL ' },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_123',
+          update: { type: 'AgentMessageChunk', content: 'events conservatively.' },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_123',
+          update: {
+            type: 'ToolCall',
+            name: 'readTextFile',
+            parameters: { path: 'src/parsers/kiro.ts' },
+            status: 'completed',
+          },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_123',
+          update: { type: 'TurnEnd' },
+        },
+      },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: 'sess_acp_123',
+      source: 'kiro',
+      cwd: '/Users/dev/work/acp-app',
+      repo: 'work/acp-app',
+      lines: 2,
+      originalPath: metadataPath,
+      summary: 'Explain the ACP session parser',
+      model: 'claude-sonnet-4',
+    });
+    expect(sessions[0].bytes).toBe(fs.statSync(metadataPath).size + fs.statSync(eventPath).size);
+    expect(sessions[0].createdAt.toISOString()).toBe('2026-02-05T01:00:00.000Z');
+    expect(sessions[0].updatedAt.toISOString()).toBe('2026-02-05T01:03:00.000Z');
+
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.recentMessages).toEqual([
+      {
+        role: 'user',
+        content: 'Explain the ACP session parser',
+        timestamp: new Date('2026-02-05T01:01:00.000Z'),
+      },
+      { role: 'assistant', content: 'It reads JSONL events conservatively.', timestamp: undefined },
+    ]);
+    expect(context.toolSummaries).toEqual([
+      expect.objectContaining({
+        name: 'readTextFile',
+        count: 1,
+      }),
+    ]);
+    expect(context.filesModified).toEqual([]);
+    expect(context.sessionNotes?.fidelityWarnings).toEqual([
+      expect.stringContaining('normal Kiro CLI SQLite stores under ~/.kiro/ are skipped'),
+    ]);
+    expect(context.markdown).toContain('Kiro fidelity warning');
+  });
+
+  it('skips unknown CLI SQLite stores safely and reports the parser fidelity limit', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const kiroDir = path.join(home, '.kiro');
+    fs.mkdirSync(kiroDir, { recursive: true });
+    fs.writeFileSync(path.join(kiroDir, 'kiro.sqlite'), 'SQLite format 3\0unknown schema', 'utf8');
+
+    const workspaceDir = createKiroWorkspace(home, '/tmp/sqlite-neighbor');
+    writeJson(path.join(workspaceDir, 'known-session.json'), {
+      sessionId: 'known-session',
+      title: 'Known JSON session',
+      history: [{ role: 'human', content: 'Use only supported Kiro surfaces' }],
+    });
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+
+    expect(sessions.map((session) => session.id)).toEqual(['known-session']);
+    expect(sessions[0].originalPath).toBe(path.join(workspaceDir, 'known-session.json'));
+
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.toolSummaries).toEqual([]);
+    expect(context.sessionNotes?.sourceMetadata).toMatchObject({
+      supportedSurfaces: ['ide-workspace-json', 'acp-json-jsonl'],
+      skippedSurfaces: ['cli-sqlite'],
+    });
+    expect(context.sessionNotes?.fidelityWarnings?.[0]).toContain('SQLite stores under ~/.kiro/ are skipped');
+    expect(context.markdown).toContain('SQLite stores under ~/.kiro/ are skipped');
+  });
+});

--- a/src/__tests__/kiro-parser.test.ts
+++ b/src/__tests__/kiro-parser.test.ts
@@ -524,4 +524,47 @@ describe('kiro parser hardening', () => {
     expect(context.sessionNotes?.fidelityWarnings?.[0]).toContain('SQLite stores under ~/.kiro/ are skipped');
     expect(context.markdown).toContain('SQLite stores under ~/.kiro/ are skipped');
   });
+
+  it('does not double-count bytes for lone ACP jsonl sessions without sibling metadata', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const eventPath = path.join(sessionDir, 'sess_acp_lone.jsonl');
+
+    writeJsonl(eventPath, [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'session/new',
+        params: { sessionId: 'sess_acp_lone', cwd: '/tmp/lone-acp' },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'session/prompt',
+        params: { sessionId: 'sess_acp_lone', content: 'Lone jsonl prompt' },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: {
+          sessionId: 'sess_acp_lone',
+          update: { type: 'AgentMessageChunk', content: 'lone reply' },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/notification',
+        params: { sessionId: 'sess_acp_lone', update: { type: 'TurnEnd' } },
+      },
+    ]);
+
+    const { parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+
+    expect(sessions).toHaveLength(1);
+    // Without de-dupe, bytes would be reported as 2x the file size.
+    expect(sessions[0].bytes).toBe(fs.statSync(eventPath).size);
+    expect(sessions[0].originalPath).toBe(eventPath);
+  });
 });

--- a/src/__tests__/kiro-parser.test.ts
+++ b/src/__tests__/kiro-parser.test.ts
@@ -567,4 +567,405 @@ describe('kiro parser hardening', () => {
     expect(sessions[0].bytes).toBe(fs.statSync(eventPath).size);
     expect(sessions[0].originalPath).toBe(eventPath);
   });
+
+  it('parses the canonical ACP wire format (sessionUpdate snake_case via session/update)', async () => {
+    // This is the ground-truth ACP wire format Kiro CLI emits per the agent-client-protocol
+    // schema and Kiro's own ACP docs (https://kiro.dev/docs/cli/acp/, kirodotdev/Kiro). The
+    // discriminator field is `sessionUpdate` (not `type`), values are snake_case, and the
+    // method name is `session/update` (not `session/notification`).
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const metadataPath = path.join(sessionDir, 'sess_canonical.json');
+    const eventPath = path.join(sessionDir, 'sess_canonical.jsonl');
+
+    writeJson(metadataPath, {
+      id: 'sess_canonical',
+      createdAt: '2026-04-10T12:00:00.000Z',
+      updatedAt: '2026-04-10T12:01:00.000Z',
+      models: { currentModelId: 'claude-opus-4.6' },
+    });
+    writeJsonl(eventPath, [
+      {
+        jsonrpc: '2.0',
+        id: 0,
+        method: 'session/new',
+        params: { cwd: '/Users/dev/work/canonical', mcpServers: [] },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'session/prompt',
+        params: {
+          sessionId: 'sess_canonical',
+          content: [{ type: 'text', text: 'What does this codebase do?' }],
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_canonical',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Reads ' },
+          },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_canonical',
+          update: {
+            sessionUpdate: 'agent_thought_chunk',
+            content: { type: 'text', text: 'INTERNAL_REASONING_DO_NOT_LEAK' },
+          },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_canonical',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'JSONL events.' },
+          },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_canonical',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'tc_001',
+            name: 'read',
+            status: 'in_progress',
+            rawInput: { path: 'src/parsers/kiro.ts' },
+          },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_canonical',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'tc_001',
+            status: 'completed',
+            output: 'fn main() { ... }',
+          },
+        },
+      },
+      // Turn end via the JSON-RPC response correlated to the prompt request id.
+      { jsonrpc: '2.0', id: 1, result: { stopReason: 'end_turn' } },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].cwd).toBe('/Users/dev/work/canonical');
+    expect(sessions[0].model).toBe('claude-opus-4.6');
+
+    const context = await extractKiroContext(sessions[0]);
+    expect(context.recentMessages).toEqual([
+      { role: 'user', content: 'What does this codebase do?', timestamp: undefined },
+      { role: 'assistant', content: 'Reads JSONL events.', timestamp: undefined },
+    ]);
+    // Thought chunks must NOT leak into the conversation.
+    expect(JSON.stringify(context.recentMessages)).not.toContain('INTERNAL_REASONING_DO_NOT_LEAK');
+    expect(context.toolSummaries).toEqual([
+      expect.objectContaining({
+        name: 'read',
+        count: 1,
+        samples: [
+          expect.objectContaining({
+            summary: 'read({"path":"src/parsers/kiro.ts"}) → "fn main() { ... }" [completed]',
+            data: expect.objectContaining({
+              category: 'mcp',
+              toolName: 'read',
+              params: '{"path":"src/parsers/kiro.ts"}',
+              result: 'fn main() { ... }',
+            }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it('flushes pending assistant chunks on the matching session/prompt response stopReason', async () => {
+    // Verifies the JSON-RPC response (id-correlated, no method, has stopReason) flushes the
+    // streaming accumulator so the assistant turn ends cleanly even without a TurnEnd event.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const metadataPath = path.join(sessionDir, 'sess_stop_reason.json');
+    const eventPath = path.join(sessionDir, 'sess_stop_reason.jsonl');
+
+    writeJson(metadataPath, {
+      id: 'sess_stop_reason',
+      createdAt: '2026-04-11T01:00:00.000Z',
+      updatedAt: '2026-04-11T01:01:00.000Z',
+    });
+    writeJsonl(eventPath, [
+      {
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'session/prompt',
+        params: { sessionId: 'sess_stop_reason', content: [{ type: 'text', text: 'Hello' }] },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_stop_reason',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Hi there.' },
+          },
+        },
+      },
+      // Response, NOT a notification — has id and result.stopReason but no method.
+      { jsonrpc: '2.0', id: 7, result: { stopReason: 'end_turn' } },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.recentMessages).toEqual([
+      { role: 'user', content: 'Hello', timestamp: undefined },
+      { role: 'assistant', content: 'Hi there.', timestamp: undefined },
+    ]);
+  });
+
+  it('parses Kiro CLI persisted-format JSONL (AssistantMessage, UserMessage, ToolResults envelopes)', async () => {
+    // Per kirodotdev/Kiro#6110, on-disk session JSONL contains envelope records keyed by
+    // AssistantMessage / UserMessage / ToolResults — not raw ACP wire-protocol notifications.
+    // The parser must understand both surfaces.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const metadataPath = path.join(sessionDir, 'sess_persisted.json');
+    const eventPath = path.join(sessionDir, 'sess_persisted.jsonl');
+
+    writeJson(metadataPath, {
+      id: 'sess_persisted',
+      cwd: '/Users/dev/work/persisted',
+      createdAt: '2026-04-12T01:00:00.000Z',
+      updatedAt: '2026-04-12T01:02:00.000Z',
+    });
+    writeJsonl(eventPath, [
+      {
+        UserMessage: {
+          content: [{ type: 'text', text: 'Read the parser file' }],
+        },
+      },
+      {
+        AssistantMessage: {
+          content: [{ type: 'text', text: 'Reading now.' }],
+          toolUse: [
+            {
+              toolCallId: 'tooluse_AAA',
+              name: 'read',
+              rawInput: { path: 'src/parsers/kiro.ts' },
+              status: 'in_progress',
+            },
+          ],
+        },
+      },
+      {
+        ToolResults: {
+          results: [
+            {
+              toolResult: {
+                toolCallId: 'tooluse_AAA',
+                output: 'parser source bytes',
+                status: 'completed',
+              },
+            },
+          ],
+        },
+      },
+      {
+        AssistantMessage: {
+          content: [{ type: 'text', text: 'The parser handles ACP and IDE sessions.' }],
+        },
+      },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.recentMessages).toEqual([
+      { role: 'user', content: 'Read the parser file', timestamp: undefined },
+      { role: 'assistant', content: 'Reading now.', timestamp: undefined },
+      {
+        role: 'assistant',
+        content: 'The parser handles ACP and IDE sessions.',
+        timestamp: undefined,
+      },
+    ]);
+    expect(context.toolSummaries).toEqual([
+      expect.objectContaining({
+        name: 'read',
+        count: 1,
+        samples: [
+          expect.objectContaining({
+            summary: 'read({"path":"src/parsers/kiro.ts"}) → "parser source bytes" [completed]',
+            data: expect.objectContaining({
+              category: 'mcp',
+              toolName: 'read',
+              result: 'parser source bytes',
+            }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it('accumulates user_message_chunk events into a streamed user prompt', async () => {
+    // ACP supports `user_message_chunk` for streamed user input. The parser must accumulate
+    // the chunks and flush them when a turn boundary or assistant response arrives.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const metadataPath = path.join(sessionDir, 'sess_user_chunks.json');
+    const eventPath = path.join(sessionDir, 'sess_user_chunks.jsonl');
+
+    writeJson(metadataPath, {
+      id: 'sess_user_chunks',
+      createdAt: '2026-04-13T00:00:00.000Z',
+      updatedAt: '2026-04-13T00:01:00.000Z',
+    });
+    writeJsonl(eventPath, [
+      {
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_user_chunks',
+          update: { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'Could you ' } },
+        },
+      },
+      {
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_user_chunks',
+          update: { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'review the diff?' } },
+        },
+      },
+      {
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_user_chunks',
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Sure.' } },
+        },
+      },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.recentMessages).toEqual([
+      { role: 'user', content: 'Could you review the diff?', timestamp: undefined },
+      { role: 'assistant', content: 'Sure.', timestamp: undefined },
+    ]);
+  });
+
+  it('extracts tool output from canonical ACP ToolCall content[] (ToolCallContent blocks)', async () => {
+    // The canonical ACP ToolCall puts results in a `content[]` array of ToolCallContent
+    // (`{ type: "content", content: ContentBlock }` or `{ type: "diff", ... }`). Verify the
+    // parser pulls text from these structured blocks even when no flat `output` is present.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const sessionDir = createKiroAcpSessionDir(home);
+    const metadataPath = path.join(sessionDir, 'sess_canonical_tool.json');
+    const eventPath = path.join(sessionDir, 'sess_canonical_tool.jsonl');
+
+    writeJson(metadataPath, {
+      id: 'sess_canonical_tool',
+      createdAt: '2026-04-14T00:00:00.000Z',
+      updatedAt: '2026-04-14T00:01:00.000Z',
+    });
+    writeJsonl(eventPath, [
+      {
+        method: 'session/prompt',
+        params: { sessionId: 'sess_canonical_tool', content: [{ type: 'text', text: 'List files' }] },
+      },
+      {
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_canonical_tool',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'tc_99',
+            title: 'ls',
+            status: 'in_progress',
+            rawInput: { path: '.' },
+          },
+        },
+      },
+      {
+        method: 'session/update',
+        params: {
+          sessionId: 'sess_canonical_tool',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'tc_99',
+            status: 'completed',
+            content: [{ type: 'content', content: { type: 'text', text: 'README.md\nsrc/' } }],
+          },
+        },
+      },
+    ]);
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.toolSummaries).toEqual([
+      expect.objectContaining({
+        name: 'ls',
+        count: 1,
+        samples: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              toolName: 'ls',
+              result: 'README.md\nsrc/',
+            }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it('keeps Kiro fidelity warning visible across notes, timeline, and rendered markdown', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kiro-parser-'));
+    tmpHomes.push(home);
+    const workspaceDir = createKiroWorkspace(home, '/tmp/warning-surfaces');
+    writeJson(path.join(workspaceDir, 'session-warning.json'), {
+      sessionId: 'session-warning',
+      title: 'Warning surfaces',
+      history: [{ role: 'human', content: 'verify warning rendering' }],
+    });
+
+    const { extractKiroContext, parseKiroSessions } = await loadKiroParserWithHome(home);
+    const sessions = await parseKiroSessions();
+    const context = await extractKiroContext(sessions[0]);
+
+    expect(context.sessionNotes?.fidelityWarnings?.[0]).toContain('Kiro fidelity warning');
+    const timeline = context.timeline ?? [];
+    const lastTimelineEntry = timeline[timeline.length - 1];
+    expect(lastTimelineEntry).toMatchObject({
+      kind: 'warning',
+      content: expect.stringContaining('Kiro fidelity warning'),
+    });
+    expect(context.markdown).toContain('Kiro fidelity warning');
+  });
 });

--- a/src/parsers/kiro.ts
+++ b/src/parsers/kiro.ts
@@ -348,8 +348,9 @@ function getAcpRecordType(record: JsonRecord | undefined): string | undefined {
 function extractAcpRecordText(record: JsonRecord | undefined): string {
   if (!record) return '';
   for (const key of ['content', 'text', 'message', 'delta', 'chunk', 'data']) {
+    if (!(key in record)) continue;
     const text = extractContent(record[key]);
-    if (text.trim()) return text;
+    if (text.length > 0 || typeof record[key] === 'string') return text;
   }
   return '';
 }
@@ -419,7 +420,7 @@ function extractAcpMessages(events: readonly unknown[]): ConversationMessage[] {
 
     if (updateType === 'AgentMessageChunk') {
       const chunk = extractAcpRecordText(update);
-      if (chunk.trim()) {
+      if (chunk.length > 0) {
         pendingAssistant += chunk;
         pendingAssistantTimestamp ??= extractAcpTimestamp(update, event);
       }
@@ -509,31 +510,91 @@ function formatToolParams(record: JsonRecord | undefined): string {
   }
 }
 
+interface AcpToolInvocation {
+  toolName: string;
+  params: string;
+  result: string;
+  status?: string;
+  isError: boolean;
+}
+
+function getAcpToolCallId(record: JsonRecord | undefined): string | undefined {
+  return getString(record, ['toolCallId', 'callId', 'id', 'toolUseId', 'invocationId']);
+}
+
+function isFailedToolStatus(status: string | undefined): boolean {
+  const normalized = status?.toLowerCase();
+  return normalized === 'error' || normalized === 'failed';
+}
+
+function mergeAcpToolUpdate(invocation: AcpToolInvocation, update: JsonRecord): void {
+  const updateToolName = getString(update, ['name', 'toolName', 'title']);
+  if (updateToolName && updateToolName !== invocation.toolName) return;
+
+  const params = formatToolParams(update);
+  if (!invocation.params && params) invocation.params = params;
+
+  const result = extractContent(update.result ?? update.output).trim();
+  if (result) invocation.result = result;
+
+  const status = getString(update, ['status', 'state']);
+  if (status) {
+    invocation.status = status;
+    invocation.isError ||= isFailedToolStatus(status);
+  }
+}
+
 function extractAcpToolSummaries(events: readonly unknown[], config?: VerbosityConfig): ToolUsageSummary[] {
-  const collector = new SummaryCollector(config);
+  const invocations: AcpToolInvocation[] = [];
+  const invocationsById = new Map<string, AcpToolInvocation>();
 
   for (const event of events) {
     if (!isRecord(event)) continue;
     const update = getAcpUpdate(event);
     const updateType = getAcpRecordType(update);
-    if (updateType !== 'ToolCall' && updateType !== 'ToolCallUpdate') continue;
+    if (!update) continue;
 
-    const toolName = getString(update, ['name', 'toolName', 'title']);
-    if (!toolName) continue;
+    if (updateType === 'ToolCall') {
+      const toolName = getString(update, ['name', 'toolName', 'title']);
+      if (!toolName) continue;
 
-    const params = formatToolParams(update);
-    const result = extractContent(update?.result ?? update?.output).trim();
-    const status = getString(update, ['status', 'state']);
-    const summary = `${mcpSummary(toolName, params, result)}${status ? ` [${status}]` : ''}`;
+      const status = getString(update, ['status', 'state']);
+      const invocation: AcpToolInvocation = {
+        toolName,
+        params: formatToolParams(update),
+        result: extractContent(update.result ?? update.output).trim(),
+        status,
+        isError: isFailedToolStatus(status),
+      };
+      invocations.push(invocation);
 
-    collector.add(toolName, summary, {
+      const toolCallId = getAcpToolCallId(update);
+      if (toolCallId) invocationsById.set(toolCallId, invocation);
+      continue;
+    }
+
+    if (updateType === 'ToolCallUpdate') {
+      const toolCallId = getAcpToolCallId(update);
+      const invocation = toolCallId ? invocationsById.get(toolCallId) : undefined;
+      if (invocation) mergeAcpToolUpdate(invocation, update);
+    }
+  }
+
+  const collector = new SummaryCollector(config);
+
+  for (const invocation of invocations) {
+    const summary = `${mcpSummary(invocation.toolName, invocation.params, invocation.result)}${
+      invocation.status ? ` [${invocation.status}]` : ''
+    }`;
+
+    collector.add(invocation.toolName, summary, {
       data: {
         category: 'mcp',
-        toolName,
-        ...(params ? { params } : {}),
-        ...(result ? { result } : {}),
+        toolName: invocation.toolName,
+        ...(invocation.params ? { params: invocation.params } : {}),
+        ...(invocation.result ? { result: invocation.result } : {}),
       },
-      isError: status === 'error' || status === 'failed',
+      isError: invocation.isError,
     });
   }
 

--- a/src/parsers/kiro.ts
+++ b/src/parsers/kiro.ts
@@ -1,144 +1,817 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import { promises as fsp } from 'node:fs';
+import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
-import type { ConversationMessage, SessionContext, UnifiedSession } from '../types/index.js';
-import { extractTextFromBlocks } from '../utils/content.js';
-import { findFiles, listSubdirectories } from '../utils/fs-helpers.js';
+import type {
+  ConversationMessage,
+  SessionContext,
+  SessionEvent,
+  SessionNotes,
+  SessionParseOptions,
+  ToolUsageSummary,
+  UnifiedSession,
+} from '../types/index.js';
+import { findFiles, listSubdirectories, mapConcurrent } from '../utils/fs-helpers.js';
+import { readJsonlFile } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
-import { cleanSummary, homeDir } from '../utils/parser-helpers.js';
+import { cleanSummary, extractRepoFromCwd, homeDir, trimMessages } from '../utils/parser-helpers.js';
+import { matchesCwd } from '../utils/slug.js';
+import { mcpSummary, SummaryCollector } from '../utils/tool-summarizer.js';
 
-// ── Kiro Session Shape ──────────────────────────────────────────────────────
+// ── Kiro Storage ────────────────────────────────────────────────────────────
 
-/** A single entry in the Kiro history array */
-interface KiroHistoryEntry {
-  message: {
-    role: string;
-    content: string | Array<{ type: string; text?: string }>;
-    id?: string;
-  };
-}
+const KIRO_AGENT_RELATIVE_PATH = ['User', 'globalStorage', 'kiro.kiroagent', 'workspace-sessions'];
+const KIRO_FIDELITY_WARNING =
+  'Kiro fidelity warning: this parser supports IDE workspace JSON and ACP JSON/JSONL sessions; normal Kiro CLI SQLite stores under ~/.kiro/ are skipped because the exact schema is not publicly documented.';
 
-/** Raw Kiro session JSON structure */
-interface KiroSession {
-  sessionId: string;
-  title?: string;
+type KiroSurface = 'ide-workspace' | 'acp-jsonl';
+
+interface KiroSessionRef {
+  surface: KiroSurface;
+  workspaceDir: string;
   workspacePath?: string;
-  selectedModel?: string;
-  history: KiroHistoryEntry[];
+  sessionPath: string;
+  eventPath?: string;
+  indexPath?: string;
+  indexEntry?: JsonRecord;
 }
 
-// ── Base Path ───────────────────────────────────────────────────────────────
-// macOS: ~/Library/Application Support/Kiro/workspace-sessions/
-const KIRO_BASE_DIR = path.join(homeDir(), 'Library', 'Application Support', 'Kiro', 'workspace-sessions');
+type JsonRecord = Record<string, unknown>;
+type KiroStatInfo = { stats: Pick<fs.Stats, 'size' | 'birthtime' | 'mtime'>; originalPath: string };
 
-/**
- * Find all Kiro session JSON files.
- * Walks workspace subdirectories, skips the `sessions.json` index file.
- */
-async function findSessionFiles(): Promise<string[]> {
-  if (!fs.existsSync(KIRO_BASE_DIR)) return [];
+function getKiroWorkspaceSessionDirs(): string[] {
+  const home = homeDir();
+  const observedDirs = [
+    path.join(home, 'Library', 'Application Support', 'Kiro', ...KIRO_AGENT_RELATIVE_PATH),
+    path.join(home, '.config', 'Kiro', ...KIRO_AGENT_RELATIVE_PATH),
+    path.join(home, 'AppData', 'Roaming', 'Kiro', ...KIRO_AGENT_RELATIVE_PATH),
+  ];
 
-  const results: string[] = [];
-  for (const workspaceDir of listSubdirectories(KIRO_BASE_DIR)) {
-    results.push(
-      ...findFiles(workspaceDir, {
+  // Older parser revisions used this path. Keep it as a read-only fallback.
+  const legacyDirs = [path.join(home, 'Library', 'Application Support', 'Kiro', 'workspace-sessions')];
+
+  return Array.from(new Set([...observedDirs, ...legacyDirs])).filter((dir) => fs.existsSync(dir));
+}
+
+function getKiroAcpSessionDir(): string {
+  return path.join(homeDir(), '.kiro', 'sessions', 'cli');
+}
+
+function isKiroAcpSessionPath(filePath: string): boolean {
+  const sessionDir = path.dirname(filePath);
+  return (
+    path.basename(sessionDir) === 'cli' &&
+    path.basename(path.dirname(sessionDir)) === 'sessions' &&
+    path.basename(path.dirname(path.dirname(sessionDir))) === '.kiro'
+  );
+}
+
+function getSiblingPath(filePath: string, extension: '.json' | '.jsonl'): string {
+  return path.join(path.dirname(filePath), `${path.basename(filePath, path.extname(filePath))}${extension}`);
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function readJsonFile(filePath: string): Promise<unknown | undefined> {
+  try {
+    return JSON.parse(await fsp.readFile(filePath, 'utf8'));
+  } catch (err) {
+    logger.debug('kiro: failed to parse json file', filePath, err);
+    return undefined;
+  }
+}
+
+function getString(record: JsonRecord | undefined, keys: readonly string[]): string | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim().length > 0) return value;
+  }
+  return undefined;
+}
+
+function getRecord(record: JsonRecord | undefined, keys: readonly string[]): JsonRecord | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (isRecord(value)) return value;
+  }
+  return undefined;
+}
+
+function getNumber(record: JsonRecord | undefined, keys: readonly string[]): number | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function parseDateValue(value: unknown): Date | undefined {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const millis = value > 0 && value < 1_000_000_000_000 ? value * 1000 : value;
+    const date = new Date(millis);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const trimmed = value.trim();
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) return parseDateValue(numeric);
+
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+
+  return undefined;
+}
+
+function getDate(record: JsonRecord | undefined, keys: readonly string[]): Date | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const parsed = parseDateValue(record[key]);
+    if (parsed) return parsed;
+  }
+  return undefined;
+}
+
+function decodeWorkspaceFolderName(folderName: string): string | undefined {
+  const normalized = folderName.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  try {
+    const decoded = Buffer.from(padded, 'base64').toString('utf8');
+    const trimmed = decoded.trim();
+    if (
+      trimmed.startsWith('/') ||
+      trimmed.startsWith('~') ||
+      trimmed.startsWith('file:') ||
+      /^[A-Za-z]:[\\/]/.test(trimmed)
+    ) {
+      return trimmed;
+    }
+    return undefined;
+  } catch (err) {
+    logger.debug('kiro: failed to decode workspace folder', folderName, err);
+    return undefined;
+  }
+}
+
+function parseSessionIndex(data: unknown): JsonRecord[] {
+  if (Array.isArray(data)) return data.filter(isRecord);
+  if (!isRecord(data)) return [];
+
+  const candidates = [data.sessions, data.entries, data.items];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate.filter(isRecord);
+  }
+
+  return [];
+}
+
+async function readSessionIndex(indexPath: string): Promise<JsonRecord[]> {
+  if (!fs.existsSync(indexPath)) return [];
+  return parseSessionIndex(await readJsonFile(indexPath));
+}
+
+async function discoverSessionRefs(): Promise<KiroSessionRef[]> {
+  const refs: KiroSessionRef[] = [];
+
+  for (const baseDir of getKiroWorkspaceSessionDirs()) {
+    for (const workspaceDir of listSubdirectories(baseDir)) {
+      const workspacePath = decodeWorkspaceFolderName(path.basename(workspaceDir));
+      const indexedSessionPaths = new Set<string>();
+      const indexPath = path.join(workspaceDir, 'sessions.json');
+
+      for (const entry of await readSessionIndex(indexPath)) {
+        const sessionId = getString(entry, ['sessionId', 'id', 'conversationId']);
+        if (!sessionId) continue;
+
+        const sessionPath = path.join(workspaceDir, `${sessionId}.json`);
+        indexedSessionPaths.add(path.resolve(sessionPath));
+        refs.push({
+          surface: 'ide-workspace',
+          workspaceDir,
+          workspacePath,
+          sessionPath,
+          indexPath,
+          indexEntry: entry,
+        });
+      }
+
+      const looseSessionFiles = findFiles(workspaceDir, {
         match: (entry) => entry.name.endsWith('.json') && entry.name !== 'sessions.json',
         recursive: false,
-      }),
-    );
-  }
-  return results;
-}
+      });
 
-/**
- * Parse and validate a single Kiro session JSON file.
- * Returns null for files that don't match the expected shape.
- */
-function parseSessionFile(filePath: string): KiroSession | null {
-  try {
-    const content = fs.readFileSync(filePath, 'utf8');
-    const data = JSON.parse(content);
-    if (typeof data.sessionId !== 'string' || !Array.isArray(data.history)) {
-      logger.debug('kiro: missing sessionId or history', filePath);
-      return null;
+      for (const sessionPath of looseSessionFiles) {
+        if (indexedSessionPaths.has(path.resolve(sessionPath))) continue;
+        refs.push({ surface: 'ide-workspace', workspaceDir, workspacePath, sessionPath });
+      }
     }
-    return data as KiroSession;
-  } catch (err) {
-    logger.debug('kiro: failed to parse session file', filePath, err);
-    return null;
   }
+
+  const acpDir = getKiroAcpSessionDir();
+  if (fs.existsSync(acpDir)) {
+    const metadataFiles = findFiles(acpDir, {
+      match: (entry) => entry.name.endsWith('.json'),
+      recursive: false,
+    });
+    const metadataPaths = new Set(metadataFiles.map((filePath) => path.resolve(filePath)));
+
+    for (const sessionPath of metadataFiles) {
+      const eventPath = getSiblingPath(sessionPath, '.jsonl');
+      refs.push({
+        surface: 'acp-jsonl',
+        workspaceDir: acpDir,
+        sessionPath,
+        eventPath: fs.existsSync(eventPath) ? eventPath : undefined,
+      });
+    }
+
+    const eventFiles = findFiles(acpDir, {
+      match: (entry) => entry.name.endsWith('.jsonl'),
+      recursive: false,
+    });
+    for (const eventPath of eventFiles) {
+      const metadataPath = getSiblingPath(eventPath, '.json');
+      if (metadataPaths.has(path.resolve(metadataPath))) continue;
+      refs.push({
+        surface: 'acp-jsonl',
+        workspaceDir: acpDir,
+        sessionPath: eventPath,
+        eventPath,
+      });
+    }
+  }
+
+  return refs;
 }
 
-/**
- * Extract text content from a Kiro message.
- * Handles both plain string and `[{type: "text", text: "..."}]` formats.
- */
-function extractContent(content: string | Array<{ type: string; text?: string }>): string {
-  return extractTextFromBlocks(content);
+function getHistoryEntries(sessionData: JsonRecord | undefined): unknown[] {
+  if (!sessionData) return [];
+  if (Array.isArray(sessionData.history)) return sessionData.history;
+  if (Array.isArray(sessionData.messages)) return sessionData.messages;
+  return [];
 }
 
-/**
- * Extract the first real user message for use as a session summary.
- */
-function extractFirstUserMessage(session: KiroSession): string {
-  for (const entry of session.history) {
-    if (entry.message.role === 'user' && entry.message.content) {
-      return extractContent(entry.message.content);
+function normalizeRole(role: unknown): ConversationMessage['role'] | undefined {
+  if (role === 'user' || role === 'human') return 'user';
+  if (role === 'assistant' || role === 'ai') return 'assistant';
+  return undefined;
+}
+
+function extractBlockText(block: unknown): string {
+  if (!isRecord(block)) return '';
+
+  const type = typeof block.type === 'string' ? block.type : undefined;
+  const kind = typeof block.kind === 'string' ? block.kind : undefined;
+  const hasBlockKind = type !== undefined || kind !== undefined;
+  if (hasBlockKind && type !== 'text' && kind !== 'text') return '';
+
+  if (typeof block.text === 'string') return block.text;
+  if (typeof block.data === 'string') return block.data;
+  return '';
+}
+
+function extractContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) return content.map(extractBlockText).filter(Boolean).join('\n');
+  if (isRecord(content)) {
+    const blockText = extractBlockText(content);
+    if (blockText) return blockText;
+
+    for (const key of ['content', 'text', 'data', 'message', 'delta', 'chunk']) {
+      const nested: unknown = content[key];
+      if (nested === content) continue;
+      const nestedText = extractContent(nested);
+      if (nestedText) return nestedText;
     }
   }
   return '';
 }
 
-/**
- * Derive a project name from session data.
- * Priority: title → basename(workspacePath) → "kiro"
- */
-function deriveProjectName(session: KiroSession): string {
-  if (session.title) return session.title;
-  if (session.workspacePath) return path.basename(session.workspacePath);
-  return 'kiro';
+function normalizeHistoryEntry(entry: unknown): ConversationMessage | undefined {
+  if (!isRecord(entry)) return undefined;
+  const message = isRecord(entry.message) ? entry.message : entry;
+  const role = normalizeRole(message.role ?? entry.role);
+  if (!role) return undefined;
+
+  const content = extractContent(message.content ?? message.text ?? entry.content).trim();
+  if (!content) return undefined;
+
+  return {
+    role,
+    content,
+    timestamp:
+      getDate(message, ['timestamp', 'createdAt', 'dateCreated']) ?? getDate(entry, ['timestamp', 'createdAt']),
+  };
+}
+
+function extractMessages(sessionData: JsonRecord | undefined): ConversationMessage[] {
+  return getHistoryEntries(sessionData).flatMap((entry) => {
+    const message = normalizeHistoryEntry(entry);
+    return message ? [message] : [];
+  });
+}
+
+async function readAcpEvents(eventPath: string | undefined): Promise<unknown[]> {
+  if (!eventPath || !fs.existsSync(eventPath)) return [];
+  return readJsonlFile<unknown>(eventPath);
+}
+
+function getAcpUpdate(record: JsonRecord): JsonRecord | undefined {
+  const params = getRecord(record, ['params']);
+  const update = getRecord(params, ['update']);
+  if (update) return update;
+
+  const nested = getRecord(record, ['update', 'event']);
+  if (nested) return nested;
+
+  return getAcpRecordType(record) ? record : undefined;
+}
+
+function getAcpRecordType(record: JsonRecord | undefined): string | undefined {
+  return getString(record, ['type', 'kind', 'updateType', 'eventType']);
+}
+
+function extractAcpRecordText(record: JsonRecord | undefined): string {
+  if (!record) return '';
+  for (const key of ['content', 'text', 'message', 'delta', 'chunk', 'data']) {
+    const text = extractContent(record[key]);
+    if (text.trim()) return text;
+  }
+  return '';
+}
+
+function extractPromptText(record: JsonRecord): string {
+  const params = getRecord(record, ['params']);
+  return extractAcpRecordText(params).trim();
+}
+
+function extractAcpTimestamp(record: JsonRecord, fallback?: JsonRecord): Date | undefined {
+  return (
+    getDate(record, ['timestamp', 'createdAt', 'dateCreated', 'time']) ??
+    getDate(fallback, ['timestamp', 'createdAt', 'dateCreated', 'time'])
+  );
+}
+
+function extractAcpMessages(events: readonly unknown[]): ConversationMessage[] {
+  const messages: ConversationMessage[] = [];
+  let pendingAssistant = '';
+  let pendingAssistantTimestamp: Date | undefined;
+
+  const flushAssistant = (): void => {
+    const content = pendingAssistant.trim();
+    if (!content) {
+      pendingAssistant = '';
+      pendingAssistantTimestamp = undefined;
+      return;
+    }
+
+    messages.push({
+      role: 'assistant',
+      content,
+      timestamp: pendingAssistantTimestamp,
+    });
+    pendingAssistant = '';
+    pendingAssistantTimestamp = undefined;
+  };
+
+  for (const event of events) {
+    if (!isRecord(event)) continue;
+
+    const method = getString(event, ['method']);
+    if (method === 'session/prompt') {
+      flushAssistant();
+      const content = extractPromptText(event);
+      if (content) {
+        messages.push({
+          role: 'user',
+          content,
+          timestamp: extractAcpTimestamp(event, getRecord(event, ['params'])),
+        });
+      }
+      continue;
+    }
+
+    const update = getAcpUpdate(event);
+    if (!update) {
+      const directMessage = normalizeHistoryEntry(event);
+      if (directMessage) {
+        if (directMessage.role === 'user') flushAssistant();
+        messages.push(directMessage);
+      }
+      continue;
+    }
+
+    const updateType = getAcpRecordType(update);
+
+    if (updateType === 'AgentMessageChunk') {
+      const chunk = extractAcpRecordText(update);
+      if (chunk.trim()) {
+        pendingAssistant += chunk;
+        pendingAssistantTimestamp ??= extractAcpTimestamp(update, event);
+      }
+      continue;
+    }
+
+    if (updateType === 'AgentMessage') {
+      flushAssistant();
+      const content = extractAcpRecordText(update).trim();
+      if (content) {
+        messages.push({
+          role: 'assistant',
+          content,
+          timestamp: extractAcpTimestamp(update, event),
+        });
+      }
+      continue;
+    }
+
+    if (updateType === 'UserMessage') {
+      flushAssistant();
+      const content = extractAcpRecordText(update).trim();
+      if (content) {
+        messages.push({
+          role: 'user',
+          content,
+          timestamp: extractAcpTimestamp(update, event),
+        });
+      }
+      continue;
+    }
+
+    if (updateType === 'TurnEnd') {
+      flushAssistant();
+      continue;
+    }
+
+    const directMessage = normalizeHistoryEntry(update);
+    if (directMessage) {
+      if (directMessage.role === 'user') flushAssistant();
+      messages.push(directMessage);
+    }
+  }
+
+  flushAssistant();
+  return messages;
+}
+
+function extractAcpCwd(sessionData: JsonRecord | undefined, events: readonly unknown[]): string {
+  const metadataCwd = getString(sessionData, ['workspacePath', 'workspace', 'cwd', 'workingDirectory', 'directory']);
+  if (metadataCwd) return metadataCwd;
+
+  for (const event of events) {
+    if (!isRecord(event)) continue;
+    if (getString(event, ['method']) !== 'session/new') continue;
+
+    const cwd = getString(getRecord(event, ['params']), ['cwd', 'workspacePath', 'workingDirectory', 'directory']);
+    if (cwd) return cwd;
+  }
+
+  return '';
+}
+
+function extractAcpModel(sessionData: JsonRecord | undefined, events: readonly unknown[]): string | undefined {
+  const metadataModel = getString(sessionData, ['selectedModel', 'model', 'modelId']);
+  if (metadataModel) return metadataModel;
+
+  for (const event of events) {
+    if (!isRecord(event)) continue;
+
+    const params = getRecord(event, ['params']);
+    const model = getString(params, ['model', 'modelId', 'selectedModel']);
+    if (model) return model;
+  }
+
+  return undefined;
+}
+
+function formatToolParams(record: JsonRecord | undefined): string {
+  const params = getRecord(record, ['params', 'parameters', 'arguments', 'input']);
+  if (!params) return '';
+  try {
+    return JSON.stringify(params);
+  } catch (err) {
+    logger.debug('kiro: failed to stringify ACP tool params', err);
+    return '';
+  }
+}
+
+function extractAcpToolSummaries(events: readonly unknown[], config?: VerbosityConfig): ToolUsageSummary[] {
+  const collector = new SummaryCollector(config);
+
+  for (const event of events) {
+    if (!isRecord(event)) continue;
+    const update = getAcpUpdate(event);
+    const updateType = getAcpRecordType(update);
+    if (updateType !== 'ToolCall' && updateType !== 'ToolCallUpdate') continue;
+
+    const toolName = getString(update, ['name', 'toolName', 'title']);
+    if (!toolName) continue;
+
+    const params = formatToolParams(update);
+    const result = extractContent(update?.result ?? update?.output).trim();
+    const status = getString(update, ['status', 'state']);
+    const summary = `${mcpSummary(toolName, params, result)}${status ? ` [${status}]` : ''}`;
+
+    collector.add(toolName, summary, {
+      data: {
+        category: 'mcp',
+        toolName,
+        ...(params ? { params } : {}),
+        ...(result ? { result } : {}),
+      },
+      isError: status === 'error' || status === 'failed',
+    });
+  }
+
+  return collector.getSummaries();
+}
+
+function firstUserMessage(messages: readonly ConversationMessage[]): string {
+  return messages.find((message) => message.role === 'user')?.content ?? '';
+}
+
+function getSessionId(ref: KiroSessionRef, sessionData: JsonRecord | undefined): string | undefined {
+  return (
+    getString(ref.indexEntry, ['sessionId', 'id', 'conversationId']) ??
+    getString(sessionData, ['sessionId', 'id', 'conversationId']) ??
+    path.basename(ref.sessionPath, path.extname(ref.sessionPath))
+  );
+}
+
+function getTitle(ref: KiroSessionRef, sessionData: JsonRecord | undefined): string | undefined {
+  return (
+    getString(sessionData, ['title', 'customTitle', 'name']) ??
+    getString(ref.indexEntry, ['title', 'customTitle', 'name'])
+  );
+}
+
+function getWorkspacePath(ref: KiroSessionRef, sessionData: JsonRecord | undefined): string {
+  return (
+    getString(sessionData, ['workspacePath', 'workspace', 'cwd', 'directory']) ??
+    getString(ref.indexEntry, ['workspacePath', 'workspace', 'cwd', 'directory']) ??
+    ref.workspacePath ??
+    ''
+  );
+}
+
+function getModel(ref: KiroSessionRef, sessionData: JsonRecord | undefined): string | undefined {
+  return getString(sessionData, ['selectedModel', 'model']) ?? getString(ref.indexEntry, ['selectedModel', 'model']);
+}
+
+function getMessageCount(
+  ref: KiroSessionRef,
+  sessionData: JsonRecord | undefined,
+  messages: readonly ConversationMessage[],
+): number {
+  return (
+    getNumber(ref.indexEntry, ['messageCount', 'bubbleCount']) ??
+    getNumber(sessionData, ['messageCount', 'bubbleCount']) ??
+    messages.length
+  );
+}
+
+function buildSummary(
+  ref: KiroSessionRef,
+  sessionData: JsonRecord | undefined,
+  messages: readonly ConversationMessage[],
+  cwd: string,
+  sessionId: string,
+): string {
+  const userSummary = cleanSummary(firstUserMessage(messages));
+  if (userSummary) return userSummary;
+
+  const title = cleanSummary(getTitle(ref, sessionData) ?? '');
+  if (title) return title;
+
+  const workspaceName = cwd ? cleanSummary(path.basename(cwd)) : '';
+  return workspaceName || sessionId;
+}
+
+async function statSessionRef(ref: KiroSessionRef): Promise<KiroStatInfo | undefined> {
+  try {
+    if (ref.surface === 'acp-jsonl') {
+      const paths = [ref.sessionPath, ref.eventPath].filter((filePath): filePath is string => {
+        if (!filePath) return false;
+        return fs.existsSync(filePath);
+      });
+      if (paths.length === 0) return undefined;
+
+      const stats = await Promise.all(paths.map((filePath) => fsp.stat(filePath)));
+      const aggregateStats = {
+        size: stats.reduce((total, stat) => total + stat.size, 0),
+        birthtime: new Date(Math.min(...stats.map((stat) => stat.birthtime.getTime()))),
+        mtime: new Date(Math.max(...stats.map((stat) => stat.mtime.getTime()))),
+      };
+      return { stats: aggregateStats, originalPath: ref.sessionPath };
+    }
+
+    if (fs.existsSync(ref.sessionPath)) {
+      return { stats: await fsp.stat(ref.sessionPath), originalPath: ref.sessionPath };
+    }
+    if (ref.indexPath && fs.existsSync(ref.indexPath)) {
+      return { stats: await fsp.stat(ref.indexPath), originalPath: ref.indexPath };
+    }
+  } catch (err) {
+    logger.debug('kiro: failed to stat session ref', ref.sessionPath, err);
+  }
+  return undefined;
+}
+
+async function parseAcpSessionRef(ref: KiroSessionRef, options: SessionParseOptions): Promise<UnifiedSession | null> {
+  const sessionData = ref.sessionPath.endsWith('.json') ? await readJsonFile(ref.sessionPath) : undefined;
+  if (ref.sessionPath.endsWith('.json') && sessionData === undefined) return null;
+
+  const sessionRecord = isRecord(sessionData) ? sessionData : undefined;
+  const events = await readAcpEvents(ref.eventPath);
+  const sessionId = getSessionId(ref, sessionRecord);
+  if (!sessionId) return null;
+
+  const statInfo = await statSessionRef(ref);
+  if (!statInfo) return null;
+
+  const eventMessages = extractAcpMessages(events);
+  const jsonMessages = extractMessages(sessionRecord);
+  const messages = eventMessages.length > 0 ? eventMessages : jsonMessages;
+  const cwd = extractAcpCwd(sessionRecord, events);
+  if (options.cwd && cwd && !matchesCwd(cwd, options.cwd)) return null;
+
+  const createdAt =
+    getDate(sessionRecord, ['dateCreated', 'createdAt', 'creationDate']) ??
+    getDate(getRecord(sessionRecord, ['metadata']), ['dateCreated', 'createdAt', 'creationDate']) ??
+    statInfo.stats.birthtime;
+  const updatedAt =
+    getDate(sessionRecord, ['dateUpdated', 'updatedAt', 'lastUpdatedAt', 'lastMessageDate']) ??
+    getDate(getRecord(sessionRecord, ['metadata']), ['dateUpdated', 'updatedAt', 'lastUpdatedAt', 'lastMessageDate']) ??
+    statInfo.stats.mtime;
+
+  return {
+    id: sessionId,
+    source: 'kiro',
+    cwd,
+    repo: extractRepoFromCwd(cwd) || undefined,
+    lines: getMessageCount(ref, sessionRecord, messages),
+    bytes: statInfo.stats.size,
+    createdAt,
+    updatedAt,
+    originalPath: statInfo.originalPath,
+    summary: buildSummary(ref, sessionRecord, messages, cwd, sessionId),
+    model: extractAcpModel(sessionRecord, events),
+  };
+}
+
+async function parseSessionRef(ref: KiroSessionRef, options: SessionParseOptions): Promise<UnifiedSession | null> {
+  if (ref.surface === 'acp-jsonl') return parseAcpSessionRef(ref, options);
+
+  const sessionFileExists = fs.existsSync(ref.sessionPath);
+  const sessionData = sessionFileExists ? await readJsonFile(ref.sessionPath) : undefined;
+  if (sessionFileExists && sessionData === undefined && !ref.indexEntry) return null;
+
+  const sessionRecord = isRecord(sessionData) ? sessionData : undefined;
+  const sessionId = getSessionId(ref, sessionRecord);
+  if (!sessionId) return null;
+
+  const statInfo = await statSessionRef(ref);
+  if (!statInfo) return null;
+
+  const cwd = getWorkspacePath(ref, sessionRecord);
+  if (options.cwd && cwd && !matchesCwd(cwd, options.cwd)) return null;
+
+  const messages = extractMessages(sessionRecord);
+  const createdAt =
+    getDate(ref.indexEntry, ['dateCreated', 'createdAt', 'creationDate']) ??
+    getDate(sessionRecord, ['dateCreated', 'createdAt', 'creationDate']) ??
+    statInfo.stats.birthtime;
+  const updatedAt =
+    getDate(sessionRecord, ['dateUpdated', 'updatedAt', 'lastUpdatedAt', 'lastMessageDate']) ??
+    getDate(ref.indexEntry, ['dateUpdated', 'updatedAt', 'lastUpdatedAt', 'lastMessageDate']) ??
+    statInfo.stats.mtime;
+
+  const summary = buildSummary(ref, sessionRecord, messages, cwd, sessionId);
+  const model = getModel(ref, sessionRecord);
+
+  return {
+    id: sessionId,
+    source: 'kiro',
+    cwd,
+    repo: extractRepoFromCwd(cwd) || undefined,
+    lines: getMessageCount(ref, sessionRecord, messages),
+    bytes: statInfo.stats.size,
+    createdAt,
+    updatedAt,
+    originalPath: statInfo.originalPath,
+    summary,
+    model,
+  };
 }
 
 /**
  * Parse all Kiro sessions into the unified format.
  */
-export async function parseKiroSessions(): Promise<UnifiedSession[]> {
-  const files = await findSessionFiles();
-  const sessions: UnifiedSession[] = [];
-
-  for (const filePath of files) {
+export async function parseKiroSessions(options: SessionParseOptions = {}): Promise<UnifiedSession[]> {
+  const refs = await discoverSessionRefs();
+  const parsedSessions = await mapConcurrent(refs, 16, async (ref) => {
     try {
-      const session = parseSessionFile(filePath);
-      if (!session) continue;
-
-      const fileStats = fs.statSync(filePath);
-      const firstUserMessage = extractFirstUserMessage(session);
-      const summary = cleanSummary(firstUserMessage) || deriveProjectName(session);
-
-      sessions.push({
-        id: session.sessionId,
-        // Type assertion: 'kiro' will be added to TOOL_NAMES separately
-        source: 'kiro',
-        cwd: session.workspacePath || '',
-        lines: session.history.length,
-        bytes: fileStats.size,
-        // Kiro has no per-message timestamps — file mtime is the best proxy
-        createdAt: fileStats.birthtime,
-        updatedAt: fileStats.mtime,
-        originalPath: filePath,
-        summary,
-        model: session.selectedModel,
-      });
+      return await parseSessionRef(ref, options);
     } catch (err) {
-      logger.debug('kiro: skipping unparseable session', filePath, err);
+      logger.debug('kiro: skipping unparseable session', ref.sessionPath, err);
+      return null;
+    }
+  });
+
+  const sessionsById = new Map<string, UnifiedSession>();
+  for (const session of parsedSessions) {
+    if (!session) continue;
+    const existing = sessionsById.get(session.id);
+    if (!existing || existing.updatedAt.getTime() < session.updatedAt.getTime()) {
+      sessionsById.set(session.id, session);
     }
   }
 
-  return sessions
-    .filter((s) => s.summary && s.summary.length > 0)
-    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  const sorted = Array.from(sessionsById.values()).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  return options.limit ? sorted.slice(0, options.limit) : sorted;
+}
+
+async function readSiblingIndexEntry(session: UnifiedSession): Promise<JsonRecord | undefined> {
+  const indexPath =
+    path.basename(session.originalPath) === 'sessions.json'
+      ? session.originalPath
+      : path.join(path.dirname(session.originalPath), 'sessions.json');
+
+  const entries = await readSessionIndex(indexPath);
+  return entries.find((entry) => getString(entry, ['sessionId', 'id', 'conversationId']) === session.id);
+}
+
+function resolveContextSessionPath(session: UnifiedSession): string {
+  if (path.basename(session.originalPath) === 'sessions.json') {
+    return path.join(path.dirname(session.originalPath), `${session.id}.json`);
+  }
+  return session.originalPath;
+}
+
+function buildSessionNotes(session: UnifiedSession): SessionNotes {
+  return {
+    ...(session.model ? { model: session.model } : {}),
+    sourceMetadata: {
+      supportedSurfaces: ['ide-workspace-json', 'acp-json-jsonl'],
+      skippedSurfaces: ['cli-sqlite'],
+    },
+    fidelityWarnings: [KIRO_FIDELITY_WARNING],
+  };
+}
+
+function buildKiroTimeline(messages: readonly ConversationMessage[]): SessionEvent[] {
+  const timeline: SessionEvent[] = messages.map((message, index) => ({
+    kind: 'message',
+    sequence: index,
+    role: message.role,
+    content: message.content,
+    timestamp: message.timestamp,
+    sourceId: message.sourceId,
+    sourceParentId: message.sourceParentId,
+    isMeta: message.isMeta,
+  }));
+
+  timeline.push({
+    kind: 'warning',
+    sequence: timeline.length,
+    content: KIRO_FIDELITY_WARNING,
+  });
+
+  return timeline;
+}
+
+function resolveAcpContextPaths(session: UnifiedSession): { metadataPath?: string; eventPath?: string } {
+  if (session.originalPath.endsWith('.jsonl')) {
+    const metadataPath = getSiblingPath(session.originalPath, '.json');
+    return {
+      metadataPath: fs.existsSync(metadataPath) ? metadataPath : undefined,
+      eventPath: session.originalPath,
+    };
+  }
+
+  if (session.originalPath.endsWith('.json')) {
+    const eventPath = getSiblingPath(session.originalPath, '.jsonl');
+    return {
+      metadataPath: session.originalPath,
+      eventPath: fs.existsSync(eventPath) ? eventPath : undefined,
+    };
+  }
+
+  return {};
 }
 
 /**
@@ -146,43 +819,106 @@ export async function parseKiroSessions(): Promise<UnifiedSession[]> {
  */
 export async function extractKiroContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
   const cfg = config ?? getPreset('standard');
-  const sessionData = parseSessionFile(session.originalPath);
-  const recentMessages: ConversationMessage[] = [];
+  if (isKiroAcpSessionPath(session.originalPath)) {
+    const paths = resolveAcpContextPaths(session);
+    const sessionData = paths.metadataPath ? await readJsonFile(paths.metadataPath) : undefined;
+    const sessionRecord = isRecord(sessionData) ? sessionData : undefined;
+    const events = await readAcpEvents(paths.eventPath);
+    const eventMessages = extractAcpMessages(events);
+    const jsonMessages = extractMessages(sessionRecord);
+    const messages = trimMessages(eventMessages.length > 0 ? eventMessages : jsonMessages, cfg.recentMessages);
+    const cwd = extractAcpCwd(sessionRecord, events) || session.cwd;
+    const model = extractAcpModel(sessionRecord, events) ?? session.model;
+    const enrichedSession: UnifiedSession = {
+      ...session,
+      cwd,
+      repo: session.repo || extractRepoFromCwd(cwd) || undefined,
+      model,
+    };
+    const filesModified: string[] = [];
+    const pendingTasks: string[] = [];
+    const toolSummaries = extractAcpToolSummaries(events, cfg);
+    const sessionNotes = buildSessionNotes(enrichedSession);
+    const timeline = buildKiroTimeline(messages);
 
-  if (sessionData) {
-    for (const entry of sessionData.history) {
-      const role: 'user' | 'assistant' = entry.message.role === 'user' ? 'user' : 'assistant';
-      const content = extractContent(entry.message.content);
-      if (content) {
-        recentMessages.push({ role, content });
-      }
-    }
+    const markdown = generateHandoffMarkdown(
+      enrichedSession,
+      messages,
+      filesModified,
+      pendingTasks,
+      toolSummaries,
+      sessionNotes,
+      cfg,
+      'inline',
+      timeline,
+    );
+
+    return {
+      session: enrichedSession,
+      recentMessages: messages,
+      filesModified,
+      pendingTasks,
+      toolSummaries,
+      sessionNotes,
+      timeline,
+      markdown,
+    };
   }
 
-  const trimmed = recentMessages.slice(-cfg.recentMessages);
+  const sessionPath = resolveContextSessionPath(session);
+  const sessionData = fs.existsSync(sessionPath) ? await readJsonFile(sessionPath) : undefined;
+  const sessionRecord = isRecord(sessionData) ? sessionData : undefined;
+  const indexEntry = await readSiblingIndexEntry(session);
+  const workspacePath = getWorkspacePath(
+    {
+      surface: 'ide-workspace',
+      workspaceDir: path.dirname(sessionPath),
+      workspacePath: decodeWorkspaceFolderName(path.basename(path.dirname(sessionPath))),
+      sessionPath,
+      indexEntry,
+    },
+    sessionRecord,
+  );
+  const model = getModel(
+    { surface: 'ide-workspace', workspaceDir: path.dirname(sessionPath), sessionPath, indexEntry },
+    sessionRecord,
+  );
+  const messages = trimMessages(extractMessages(sessionRecord), cfg.recentMessages);
+  const enrichedSession: UnifiedSession = {
+    ...session,
+    cwd: workspacePath || session.cwd,
+    repo: session.repo || extractRepoFromCwd(workspacePath || session.cwd) || undefined,
+    model: model ?? session.model,
+  };
 
-  // Kiro sessions have no tool call data
+  // Public Kiro IDE evidence exposes session metadata and text blocks, not a stable
+  // tool-call schema in workspace-session JSON. Keep tool extraction explicitly empty.
   const filesModified: string[] = [];
   const pendingTasks: string[] = [];
-
-  const enrichedSession = sessionData?.selectedModel ? { ...session, model: sessionData.selectedModel } : session;
+  const toolSummaries: ToolUsageSummary[] = [];
+  const sessionNotes = buildSessionNotes(enrichedSession);
+  const timeline = buildKiroTimeline(messages);
 
   const markdown = generateHandoffMarkdown(
     enrichedSession,
-    trimmed,
+    messages,
     filesModified,
     pendingTasks,
-    [], // toolSummaries — Kiro stores no tool call data
-    undefined, // sessionNotes — not tracked by Kiro
+    toolSummaries,
+    sessionNotes,
     cfg,
+    'inline',
+    timeline,
   );
 
   return {
     session: enrichedSession,
-    recentMessages: trimmed,
+    recentMessages: messages,
     filesModified,
     pendingTasks,
-    toolSummaries: [],
+    toolSummaries,
+    sessionNotes,
+    timeline,
     markdown,
   };
 }

--- a/src/parsers/kiro.ts
+++ b/src/parsers/kiro.ts
@@ -23,8 +23,29 @@ import { mcpSummary, SummaryCollector } from '../utils/tool-summarizer.js';
 // ── Kiro Storage ────────────────────────────────────────────────────────────
 
 const KIRO_AGENT_RELATIVE_PATH = ['User', 'globalStorage', 'kiro.kiroagent', 'workspace-sessions'];
+// The user-visible warning. Mentions both possible CLI SQLite locations:
+//   - `~/Library/Application Support/kiro-cli/data.sqlite3` (verified primary CLI store, table conversations_v2)
+//   - `~/.kiro/` (older / alternate location referenced in some docs)
+// Wording stays compatible with the existing assertion (`SQLite stores under ~/.kiro/ are skipped`).
 const KIRO_FIDELITY_WARNING =
-  'Kiro fidelity warning: this parser supports IDE workspace JSON and ACP JSON/JSONL sessions; normal Kiro CLI SQLite stores under ~/.kiro/ are skipped because the exact schema is not publicly documented.';
+  'Kiro fidelity warning: this parser supports IDE workspace JSON and ACP JSON/JSONL sessions; normal Kiro CLI SQLite stores under ~/.kiro/ are skipped (and the parallel store at ~/Library/Application Support/kiro-cli/data.sqlite3) because the exact schema is not publicly documented.';
+
+// Canonical ACP `session/update` discriminator values per the agent-client-protocol schema:
+//   https://github.com/zed-industries/agent-client-protocol/blob/main/schema/schema.json
+// Verified against Kiro CLI v1.29.0 docs (kiro.dev/docs/cli/acp/) and the empirical reference at
+//   https://github.com/dwalleck/cyril/blob/main/docs/kiro-acp-protocol.md
+const ACP_SESSION_UPDATE_KEYS = ['sessionUpdate', 'type', 'kind', 'updateType', 'eventType'] as const;
+const ACP_AGENT_MESSAGE_CHUNK = new Set(['agent_message_chunk', 'AgentMessageChunk']);
+const ACP_AGENT_THOUGHT_CHUNK = new Set(['agent_thought_chunk', 'AgentThoughtChunk']);
+const ACP_USER_MESSAGE_CHUNK = new Set(['user_message_chunk', 'UserMessageChunk']);
+const ACP_TOOL_CALL = new Set(['tool_call', 'ToolCall', 'tool_call_chunk']);
+const ACP_TOOL_CALL_UPDATE = new Set(['tool_call_update', 'ToolCallUpdate']);
+const ACP_AGENT_MESSAGE = new Set(['agent_message', 'AgentMessage']);
+const ACP_USER_MESSAGE = new Set(['user_message', 'UserMessage']);
+// The canonical ACP spec has no `TurnEnd` event — turns end via the JSON-RPC response to
+// `session/prompt` with `stopReason: end_turn`. We still recognise the legacy fixture name
+// so synthesised `TurnEnd` events keep flushing accumulators harmlessly.
+const ACP_TURN_END = new Set(['turn_end', 'TurnEnd']);
 
 type KiroSurface = 'ide-workspace' | 'acp-jsonl';
 
@@ -342,7 +363,7 @@ function getAcpUpdate(record: JsonRecord): JsonRecord | undefined {
 }
 
 function getAcpRecordType(record: JsonRecord | undefined): string | undefined {
-  return getString(record, ['type', 'kind', 'updateType', 'eventType']);
+  return getString(record, ACP_SESSION_UPDATE_KEYS);
 }
 
 function extractAcpRecordText(record: JsonRecord | undefined): string {
@@ -367,34 +388,116 @@ function extractAcpTimestamp(record: JsonRecord, fallback?: JsonRecord): Date | 
   );
 }
 
+// Kiro CLI persists session history in `~/.kiro/sessions/cli/<id>.jsonl` using
+// envelope objects keyed by `AssistantMessage` / `UserMessage` / `ToolResults`,
+// not raw ACP `session/update` notifications (see kirodotdev/Kiro#6110). We
+// peel the envelope so the same parser handles both wire-protocol replay logs
+// and Kiro's persisted record format.
+const KIRO_PERSISTED_ENVELOPE_KEYS = [
+  'AssistantMessage',
+  'UserMessage',
+  'ToolResults',
+  'assistantMessage',
+  'userMessage',
+  'toolResults',
+] as const;
+
+function unwrapKiroPersistedEnvelope(
+  event: JsonRecord,
+): { kind: 'assistant' | 'user' | 'tool_results'; payload: JsonRecord } | undefined {
+  for (const key of KIRO_PERSISTED_ENVELOPE_KEYS) {
+    const value = event[key];
+    if (!isRecord(value)) continue;
+    const lowered = key.toLowerCase();
+    if (lowered === 'assistantmessage') return { kind: 'assistant', payload: value };
+    if (lowered === 'usermessage') return { kind: 'user', payload: value };
+    if (lowered === 'toolresults') return { kind: 'tool_results', payload: value };
+  }
+  return undefined;
+}
+
 function extractAcpMessages(events: readonly unknown[]): ConversationMessage[] {
   const messages: ConversationMessage[] = [];
   let pendingAssistant = '';
   let pendingAssistantTimestamp: Date | undefined;
+  let pendingUser = '';
+  let pendingUserTimestamp: Date | undefined;
+  // Track JSON-RPC `session/prompt` request ids so we can flush on the
+  // matching response (`stopReason` carries `end_turn`/`max_tokens`/`cancelled`).
+  const promptRequestIds = new Set<string>();
 
   const flushAssistant = (): void => {
-    const content = pendingAssistant.trim();
-    if (!content) {
-      pendingAssistant = '';
-      pendingAssistantTimestamp = undefined;
-      return;
-    }
-
-    messages.push({
-      role: 'assistant',
-      content,
-      timestamp: pendingAssistantTimestamp,
-    });
+    const content = pendingAssistant;
     pendingAssistant = '';
+    const timestamp = pendingAssistantTimestamp;
     pendingAssistantTimestamp = undefined;
+    if (content.trim().length === 0) return;
+    messages.push({ role: 'assistant', content: content.trim(), timestamp });
+  };
+
+  const flushUser = (): void => {
+    const content = pendingUser;
+    pendingUser = '';
+    const timestamp = pendingUserTimestamp;
+    pendingUserTimestamp = undefined;
+    if (content.trim().length === 0) return;
+    messages.push({ role: 'user', content: content.trim(), timestamp });
+  };
+
+  const isPromptResponse = (event: JsonRecord): boolean => {
+    if (typeof event.method === 'string') return false;
+    const id = event.id;
+    if (id === undefined || id === null) return false;
+    const idKey = String(id);
+    if (!promptRequestIds.has(idKey)) return false;
+    promptRequestIds.delete(idKey);
+    return true;
   };
 
   for (const event of events) {
     if (!isRecord(event)) continue;
 
+    // Kiro CLI persisted-format envelopes (`AssistantMessage`/`UserMessage`/`ToolResults`).
+    const persisted = unwrapKiroPersistedEnvelope(event);
+    if (persisted) {
+      if (persisted.kind === 'tool_results') {
+        // Tool results don't represent visible turns of conversation; surface them via
+        // tool summaries instead. Skip here.
+        continue;
+      }
+      if (persisted.kind === 'user') {
+        flushAssistant();
+        flushUser();
+        const content = extractAcpRecordText(persisted.payload).trim();
+        if (content) {
+          messages.push({
+            role: 'user',
+            content,
+            timestamp: extractAcpTimestamp(persisted.payload, event),
+          });
+        }
+        continue;
+      }
+      // assistant
+      flushAssistant();
+      flushUser();
+      const content = extractAcpRecordText(persisted.payload).trim();
+      if (content) {
+        messages.push({
+          role: 'assistant',
+          content,
+          timestamp: extractAcpTimestamp(persisted.payload, event),
+        });
+      }
+      continue;
+    }
+
     const method = getString(event, ['method']);
     if (method === 'session/prompt') {
       flushAssistant();
+      flushUser();
+      const id = event.id;
+      if (id !== undefined && id !== null) promptRequestIds.add(String(id));
       const content = extractPromptText(event);
       if (content) {
         messages.push({
@@ -406,11 +509,21 @@ function extractAcpMessages(events: readonly unknown[]): ConversationMessage[] {
       continue;
     }
 
+    // The ACP `session/prompt` JSON-RPC response (correlated to a tracked id) signals
+    // turn end via `stopReason`. Flush any streaming assistant accumulator.
+    if (isPromptResponse(event)) {
+      flushAssistant();
+      continue;
+    }
+
     const update = getAcpUpdate(event);
     if (!update) {
       const directMessage = normalizeHistoryEntry(event);
       if (directMessage) {
-        if (directMessage.role === 'user') flushAssistant();
+        if (directMessage.role === 'user') {
+          flushAssistant();
+          flushUser();
+        }
         messages.push(directMessage);
       }
       continue;
@@ -418,17 +531,36 @@ function extractAcpMessages(events: readonly unknown[]): ConversationMessage[] {
 
     const updateType = getAcpRecordType(update);
 
-    if (updateType === 'AgentMessageChunk') {
+    if (updateType && ACP_AGENT_MESSAGE_CHUNK.has(updateType)) {
       const chunk = extractAcpRecordText(update);
       if (chunk.length > 0) {
+        // Starting a new assistant turn flushes any pending streamed user prompt.
+        flushUser();
         pendingAssistant += chunk;
         pendingAssistantTimestamp ??= extractAcpTimestamp(update, event);
       }
       continue;
     }
 
-    if (updateType === 'AgentMessage') {
+    if (updateType && ACP_AGENT_THOUGHT_CHUNK.has(updateType)) {
+      // Thought chunks are extended-thinking traces, not user-visible conversation per the
+      // ACP schema. Skip them so they don't pollute the main message stream.
+      continue;
+    }
+
+    if (updateType && ACP_USER_MESSAGE_CHUNK.has(updateType)) {
+      const chunk = extractAcpRecordText(update);
+      if (chunk.length > 0) {
+        flushAssistant();
+        pendingUser += chunk;
+        pendingUserTimestamp ??= extractAcpTimestamp(update, event);
+      }
+      continue;
+    }
+
+    if (updateType && ACP_AGENT_MESSAGE.has(updateType)) {
       flushAssistant();
+      flushUser();
       const content = extractAcpRecordText(update).trim();
       if (content) {
         messages.push({
@@ -440,8 +572,9 @@ function extractAcpMessages(events: readonly unknown[]): ConversationMessage[] {
       continue;
     }
 
-    if (updateType === 'UserMessage') {
+    if (updateType && ACP_USER_MESSAGE.has(updateType)) {
       flushAssistant();
+      flushUser();
       const content = extractAcpRecordText(update).trim();
       if (content) {
         messages.push({
@@ -453,19 +586,24 @@ function extractAcpMessages(events: readonly unknown[]): ConversationMessage[] {
       continue;
     }
 
-    if (updateType === 'TurnEnd') {
+    if (updateType && ACP_TURN_END.has(updateType)) {
       flushAssistant();
+      flushUser();
       continue;
     }
 
     const directMessage = normalizeHistoryEntry(update);
     if (directMessage) {
-      if (directMessage.role === 'user') flushAssistant();
+      if (directMessage.role === 'user') {
+        flushAssistant();
+        flushUser();
+      }
       messages.push(directMessage);
     }
   }
 
   flushAssistant();
+  flushUser();
   return messages;
 }
 
@@ -485,8 +623,12 @@ function extractAcpCwd(sessionData: JsonRecord | undefined, events: readonly unk
 }
 
 function extractAcpModel(sessionData: JsonRecord | undefined, events: readonly unknown[]): string | undefined {
+  // Kiro v1.29.0 added `models.currentModelId` in `session/new`; honour it after metadata.
   const metadataModel = getString(sessionData, ['selectedModel', 'model', 'modelId']);
   if (metadataModel) return metadataModel;
+  const modelsBlock = getRecord(sessionData, ['models']);
+  const currentMetadataModel = getString(modelsBlock, ['currentModelId', 'modelId']);
+  if (currentMetadataModel) return currentMetadataModel;
 
   for (const event of events) {
     if (!isRecord(event)) continue;
@@ -494,13 +636,21 @@ function extractAcpModel(sessionData: JsonRecord | undefined, events: readonly u
     const params = getRecord(event, ['params']);
     const model = getString(params, ['model', 'modelId', 'selectedModel']);
     if (model) return model;
+
+    // Inspect `session/new` and `session/load` responses (`{result: {models: {...}}}`).
+    const result = getRecord(event, ['result']);
+    const resultModels = getRecord(result, ['models']);
+    const fromResult = getString(resultModels, ['currentModelId', 'modelId']);
+    if (fromResult) return fromResult;
   }
 
   return undefined;
 }
 
 function formatToolParams(record: JsonRecord | undefined): string {
-  const params = getRecord(record, ['params', 'parameters', 'arguments', 'input']);
+  // Canonical ACP `ToolCall.rawInput` first, then Kiro extension `parameters`,
+  // then generic `params`/`arguments`/`input` for tolerance.
+  const params = getRecord(record, ['rawInput', 'parameters', 'params', 'arguments', 'input']);
   if (!params) return '';
   try {
     return JSON.stringify(params);
@@ -508,6 +658,47 @@ function formatToolParams(record: JsonRecord | undefined): string {
     logger.debug('kiro: failed to stringify ACP tool params', err);
     return '';
   }
+}
+
+// Pull a textual representation of a tool call's output. The canonical ACP
+// `ToolCall.content[]` is a list of `ToolCallContent` discriminated by `type`
+// (`content` → ContentBlock; `diff` → diff record). Kiro additionally exposes
+// flat `output`/`rawOutput` strings/objects on `tool_call_update`.
+function extractAcpToolResult(record: JsonRecord | undefined): string {
+  if (!record) return '';
+  if (typeof record.output === 'string') return record.output;
+  if (typeof record.rawOutput === 'string') return record.rawOutput;
+  const flat = extractContent(record.output ?? record.rawOutput ?? record.result).trim();
+  if (flat) return flat;
+  const contentArray = record.content;
+  if (Array.isArray(contentArray)) {
+    const parts: string[] = [];
+    for (const item of contentArray) {
+      if (!isRecord(item)) continue;
+      const itemType = typeof item.type === 'string' ? item.type : undefined;
+      // ToolCallContent { type: "content", content: ContentBlock }
+      if (itemType === 'content') {
+        const inner = extractContent(item.content);
+        if (inner) parts.push(inner);
+        continue;
+      }
+      // ToolCallContent { type: "diff", oldText, newText, path }
+      if (itemType === 'diff') {
+        const path = typeof item.path === 'string' ? item.path : '';
+        const oldText = typeof item.oldText === 'string' ? item.oldText : '';
+        const newText = typeof item.newText === 'string' ? item.newText : '';
+        const summary = path ? `diff ${path}` : 'diff';
+        const stats = `(${oldText.length} → ${newText.length} chars)`;
+        parts.push(`${summary} ${stats}`.trim());
+        continue;
+      }
+      // Plain ContentBlock or string fallback.
+      const text = extractContent(item);
+      if (text) parts.push(text);
+    }
+    if (parts.length > 0) return parts.join('\n');
+  }
+  return '';
 }
 
 interface AcpToolInvocation {
@@ -528,13 +719,19 @@ function isFailedToolStatus(status: string | undefined): boolean {
 }
 
 function mergeAcpToolUpdate(invocation: AcpToolInvocation, update: JsonRecord): void {
+  // Canonical ACP `ToolCall.title` (preferred) or Kiro `name` extension.
   const updateToolName = getString(update, ['name', 'toolName', 'title']);
-  if (updateToolName && updateToolName !== invocation.toolName) return;
+  if (updateToolName && invocation.toolName === '__acp_pending__') {
+    invocation.toolName = updateToolName;
+  } else if (updateToolName && updateToolName !== invocation.toolName) {
+    // Mismatch — skip silently. ACP allows a `kind` change but tool identity should stay.
+    return;
+  }
 
   const params = formatToolParams(update);
   if (!invocation.params && params) invocation.params = params;
 
-  const result = extractContent(update.result ?? update.output).trim();
+  const result = extractAcpToolResult(update);
   if (result) invocation.result = result;
 
   const status = getString(update, ['status', 'state']);
@@ -548,36 +745,115 @@ function extractAcpToolSummaries(events: readonly unknown[], config?: VerbosityC
   const invocations: AcpToolInvocation[] = [];
   const invocationsById = new Map<string, AcpToolInvocation>();
 
+  const upsertToolCall = (update: JsonRecord): void => {
+    const toolCallId = getAcpToolCallId(update);
+    // Canonical ACP requires `title`; Kiro extension uses `name`. Either is acceptable.
+    const toolName = getString(update, ['name', 'toolName', 'title']);
+    const status = getString(update, ['status', 'state']);
+
+    const existing = toolCallId ? invocationsById.get(toolCallId) : undefined;
+    if (existing) {
+      // De-dupe: an early `tool_call_chunk` (kiro.dev extension) often arrives before the
+      // standard `tool_call` notification. Update the existing record rather than spawning
+      // a duplicate.
+      mergeAcpToolUpdate(existing, update);
+      return;
+    }
+    if (!toolName && !toolCallId) return;
+
+    const invocation: AcpToolInvocation = {
+      toolName: toolName ?? '__acp_pending__',
+      params: formatToolParams(update),
+      result: extractAcpToolResult(update),
+      status,
+      isError: isFailedToolStatus(status),
+    };
+    invocations.push(invocation);
+    if (toolCallId) invocationsById.set(toolCallId, invocation);
+  };
+
   for (const event of events) {
     if (!isRecord(event)) continue;
+
+    // Persisted Kiro CLI `ToolResults` envelope: surface as a generic tool call so the
+    // summary collector reports activity even when no wire-protocol notification was logged.
+    const persisted = unwrapKiroPersistedEnvelope(event);
+    if (persisted?.kind === 'tool_results') {
+      const list = Array.isArray(persisted.payload.results)
+        ? persisted.payload.results
+        : Array.isArray(persisted.payload.toolResults)
+          ? persisted.payload.toolResults
+          : Array.isArray(event.toolResults)
+            ? event.toolResults
+            : [persisted.payload];
+      for (const item of list) {
+        if (!isRecord(item)) continue;
+        const inner = isRecord(item.toolResult) ? item.toolResult : item;
+        const toolCallId = getAcpToolCallId(inner) ?? getAcpToolCallId(item);
+        const innerStatus = getString(inner, ['status', 'state']);
+        // Default a tool result to `completed` when the inner record doesn't say otherwise:
+        // the presence of a ToolResults envelope itself implies the call has finished.
+        const status = innerStatus ?? 'completed';
+        const existing = toolCallId ? invocationsById.get(toolCallId) : undefined;
+        if (existing) {
+          const result = extractAcpToolResult(inner);
+          if (result) existing.result = result;
+          existing.status = status;
+          existing.isError ||= isFailedToolStatus(status);
+          continue;
+        }
+        // Unknown call id — synthesize a record so the summary still mentions tool activity.
+        const result = extractAcpToolResult(inner);
+        const toolName = getString(inner, ['name', 'toolName', 'title']) ?? 'tool';
+        const synthetic: AcpToolInvocation = {
+          toolName,
+          params: formatToolParams(inner),
+          result,
+          status,
+          isError: isFailedToolStatus(status),
+        };
+        invocations.push(synthetic);
+        if (toolCallId) invocationsById.set(toolCallId, synthetic);
+      }
+      continue;
+    }
+    if (persisted?.kind === 'assistant') {
+      // Persisted assistant messages may carry inline `toolUse` arrays — Anthropic-style.
+      const toolUseList = Array.isArray(persisted.payload.toolUse)
+        ? persisted.payload.toolUse
+        : Array.isArray(persisted.payload.tool_use)
+          ? persisted.payload.tool_use
+          : [];
+      for (const item of toolUseList) {
+        if (!isRecord(item)) continue;
+        upsertToolCall(item);
+      }
+      continue;
+    }
+
     const update = getAcpUpdate(event);
     const updateType = getAcpRecordType(update);
     if (!update) continue;
 
-    if (updateType === 'ToolCall') {
-      const toolName = getString(update, ['name', 'toolName', 'title']);
-      if (!toolName) continue;
-
-      const status = getString(update, ['status', 'state']);
-      const invocation: AcpToolInvocation = {
-        toolName,
-        params: formatToolParams(update),
-        result: extractContent(update.result ?? update.output).trim(),
-        status,
-        isError: isFailedToolStatus(status),
-      };
-      invocations.push(invocation);
-
-      const toolCallId = getAcpToolCallId(update);
-      if (toolCallId) invocationsById.set(toolCallId, invocation);
+    if (updateType && ACP_TOOL_CALL.has(updateType)) {
+      upsertToolCall(update);
       continue;
     }
 
-    if (updateType === 'ToolCallUpdate') {
+    if (updateType && ACP_TOOL_CALL_UPDATE.has(updateType)) {
       const toolCallId = getAcpToolCallId(update);
       const invocation = toolCallId ? invocationsById.get(toolCallId) : undefined;
       if (invocation) mergeAcpToolUpdate(invocation, update);
+      else if (toolCallId) {
+        // Lone `tool_call_update` with no preceding `tool_call` — keep it but mark name unknown.
+        upsertToolCall(update);
+      }
     }
+  }
+
+  // Drop any invocation that never received a name.
+  for (let i = invocations.length - 1; i >= 0; i--) {
+    if (invocations[i].toolName === '__acp_pending__') invocations.splice(i, 1);
   }
 
   const collector = new SummaryCollector(config);

--- a/src/parsers/kiro.ts
+++ b/src/parsers/kiro.ts
@@ -665,10 +665,12 @@ function buildSummary(
 async function statSessionRef(ref: KiroSessionRef): Promise<KiroStatInfo | undefined> {
   try {
     if (ref.surface === 'acp-jsonl') {
-      const paths = [ref.sessionPath, ref.eventPath].filter((filePath): filePath is string => {
+      const candidatePaths = [ref.sessionPath, ref.eventPath].filter((filePath): filePath is string => {
         if (!filePath) return false;
         return fs.existsSync(filePath);
       });
+      // De-dupe so lone-jsonl refs (where sessionPath === eventPath) do not double-count bytes.
+      const paths = Array.from(new Set(candidatePaths.map((filePath) => path.resolve(filePath))));
       if (paths.length === 0) return undefined;
 
       const stats = await Promise.all(paths.map((filePath) => fsp.stat(filePath)));


### PR DESCRIPTION
# fix(parser): harden kiro session surfaces

## Summary
This hardens the Kiro parser around the storage surfaces we can verify: IDE workspace JSON and ACP JSON/JSONL. It expands discovery, metadata extraction, context reconstruction, and tool summaries while adding an explicit fidelity warning for Kiro CLI SQLite stores whose schema is not publicly documented. Review should focus on the tolerant schema handling, ACP event interpretation, and whether the SQLite warning is visible enough.

## Context / Why now
The previous Kiro parser assumed a narrow legacy workspace-session JSON shape, which missed indexed IDE sessions and ACP CLI logs. This change favors read-only discovery of supported JSON surfaces and avoids implying fidelity for unknown SQLite stores under `~/.kiro/`.

## The 4 items

### Item 1: IDE workspace JSON discovery
- Files: `src/parsers/kiro.ts`
- What: discovers observed Kiro IDE workspace-session directories plus the legacy fallback, decodes base64url workspace folder names, reads `sessions.json`, keeps index-only sessions parseable, and includes loose session JSON files.
- Why this shape: Kiro session metadata can live in the index, the session file, or the encoded workspace path. The parser now merges those sources conservatively and de-dupes by session id using the newest update time.
- Verified by: Kiro parser tests covering indexed sessions, malformed sessions, index-only sessions, cwd/repo derivation, metadata fallback, and empty histories.

### Item 2: ACP JSON/JSONL parsing
- Files: `src/parsers/kiro.ts`
- What: discovers `~/.kiro/sessions/cli`, pairs metadata JSON with sibling JSONL events, parses `session/new`, `session/prompt`, message chunks, full assistant/user messages, turn boundaries, and conservative ACP tool-call summaries.
- Why this shape: ACP logs are event streams, so the parser uses the shared JSONL reader and accumulates assistant chunks rather than treating the file as one static history object.
- Verified by: ACP fixture coverage for metadata, cwd, repo, timestamps, summary, message reconstruction, byte aggregation, and tool summary extraction.

### Item 3: Fidelity warnings and handoff context
- Files: `src/parsers/kiro.ts`
- What: adds session notes and timeline warnings stating that supported surfaces are `ide-workspace-json` and `acp-json-jsonl`, while `cli-sqlite` is skipped.
- Why this shape: skipping SQLite silently would make downstream handoffs look more complete than they are. The warning is included in both structured context and generated markdown.
- Verified by: tests asserting the warning appears in `sessionNotes`, source metadata, and markdown.

### Item 4: Regression coverage
- Files: `src/__tests__/kiro-parser.test.ts`
- What: adds six Kiro-specific tests for IDE JSON, malformed records, content block filtering, index-only sessions, ACP JSON/JSONL, and skipped SQLite stores.
- Why this shape: these are the surfaces that can regress independently, so they are covered without relying on live user Kiro state.
- Verified by: the full configured Vitest suite in a temporary archive copy.

## Files touched

| File | +/- | Purpose |
|---|---:|---|
| `src/parsers/kiro.ts` | +858 / -122 | Broaden Kiro discovery, parsing, context extraction, ACP tool summaries, and fidelity warnings. |
| `src/__tests__/kiro-parser.test.ts` | +387 / -0 | Add focused regression coverage for supported Kiro surfaces and the SQLite skip warning. |

## Verification

- `pnpm test -- src/__tests__/kiro-parser.test.ts` in a temporary archive copy with the sibling checkout's `node_modules` symlinked: passed. Vitest ran the configured non-e2e suite: 25 test files, 806 passed, 2 skipped.
- `/Users/yigitkonur/dev-test/cli-continues/node_modules/.bin/biome check src/parsers/kiro.ts src/__tests__/kiro-parser.test.ts`: passed.
- `pnpm build` in the temporary archive copy: passed.
- `git diff --check origin/main...HEAD`: passed.
- Full-check baseline blocker: `pnpm run check` fails during `pnpm lint` before build because Biome reports the same three formatter errors on `origin/main`: `src/parsers/antigravity.ts`, `src/parsers/copilot.ts`, and `src/parsers/droid.ts`.

## Risks

- ACP event naming may drift across Kiro releases; this parser handles known JSON/JSONL shapes and falls back conservatively, but new event types may need follow-up coverage.
- SQLite fidelity is intentionally incomplete. The warning is explicit, but users with CLI-only SQLite history will still see no sessions from that store.
- Workspace path decoding assumes Kiro's base64url encoded workspace directory names. Unknown naming schemes fall back to metadata or empty cwd instead of guessing.

## Reviewer Questions

1. Please explain in depth whether the ACP `AgentMessageChunk` accumulation should flush only on `TurnEnd`, or whether the current flush-on-full-message/user-message behavior is safer for mixed event streams.
2. Please explain in depth whether the SQLite warning belongs in every Kiro handoff timeline, or whether it should appear only when a SQLite file is actually present under `~/.kiro/`.
3. Please explain in depth whether de-duping by session id and newest `updatedAt` could hide legitimate same-id sessions across IDE and ACP surfaces.

## Follow-ups

- Add SQLite parsing only after a stable Kiro CLI schema is documented or validated with fixtures.
- Add live fixture samples if Kiro publishes canonical ACP transcript examples.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Kiro parser for IDE workspace JSON and ACP JSON/JSONL, adding canonical ACP support and persisted JSONL envelopes for more reliable message reconstruction, tool summaries, and metadata. SQLite stores are still skipped with a clear fidelity warning.

- **New Features**
  - Handle ACP canonical wire format: `session/update` with `sessionUpdate` (snake_case like `agent_message_chunk`, `tool_call`, `tool_call_update`), plus Kiro‑persisted JSONL envelopes (`AssistantMessage`, `UserMessage`, `ToolResults`).
  - Reconstruct turns: accumulate `agent_message_chunk` and `user_message_chunk`, flush on `session/prompt` response `stopReason`, and ignore `agent_thought_chunk`.
  - Extract MCP tool usage from `tool_call`/`tool_call_update` by id, params from `rawInput` (fallback `parameters`), results from `output` or `content[]` ToolCallContent; synthesize from `ToolResults` when needed.
  - Pull `cwd` from `session/new`; read model from metadata or `models.currentModelId`; update the warning to mention both SQLite paths: `~/.kiro` and `~/Library/Application Support/kiro-cli/data.sqlite3`.

- **Refactors**
  - Preserve ACP streaming semantics (keep whitespace-only chunks, treat `ToolCallUpdate` as in-place updates) and drop reliance on a fabricated `TurnEnd`.
  - De‑dupe byte stats for lone `.jsonl` sessions; tolerant content parsing; concurrent parse; sorted/limited output.
  - Expanded tests for canonical wire format, `stopReason` flush, persisted JSONL envelopes, streamed user prompts, canonical tool `content[]` extraction, and warning visibility across notes/timeline/markdown.

<sup>Written for commit c12b43958897b3a9604f059ca327491590acd9db. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/63?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

