### PR TITLE
🧹 chore(cleanup): ignore local sweep artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,43 @@ skills-lock.json
 .claude/CLAUDE.md
 .claude/settings.local.json
 .emdash.json
+
+# Added by run-repo-cleanup init-to-delete.py
+# to-delete/ sweep folder - never tracked, used for quarantine before real deletion
+to-delete/
+
+# Secrets (never tracked)
+.env
+.env.local
+.env.*.local
+*.pem
+*.p12
+id_rsa
+id_rsa.pub
+*.key
+credentials.json
+service-account.json
+
+# AI agent session artifacts
+.continues-handoff.md
+.claude-session*
+.cursor-session*
+.aider*
+.design-soul/
+derailment-notes/
+derail-notes/
+derail-results/
+
+# Editor scratch
+.vscode/settings.local.json
+.idea/workspace.xml
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# Local-only test / debug output
+scratch/
+tmp/
+*.log
+# end run-repo-cleanup


### PR DESCRIPTION
# 🧹 chore(cleanup): ignore local sweep artifacts

## Summary
This PR adds the repo-cleanup quarantine and ignore patterns used during agent cleanup passes. It keeps `to-delete/`, local secrets, session artifacts, editor scratch, and local debug output out of git so future cleanup runs do not leave noisy untracked files.

## Context / Why now
Running the repo cleanup audit found the repository tidy after stale branch/worktree retirement, but the `run-repo-cleanup` initializer reported missing ignore hygiene. Earlier cleanup also surfaced empty `.claude/` session scaffolding as untracked noise, so adding these patterns makes the cleanup workflow repeatable without committing session artifacts.

## The 1 item

### Item 1: Ignore cleanup quarantine and local artifacts
- Files: `.gitignore`
- What: Adds `to-delete/`, secret-file patterns, AI session artifact patterns, editor scratch, and local test/debug output patterns.
- Why this shape: `to-delete/` is the cleanup skill's reversible quarantine folder for uncertain untracked files. The other patterns prevent common local-only files from entering review or publish paths.
- Verified by: `git diff --check HEAD^..HEAD`, targeted `git check-ignore`, and `init-to-delete.py --dry-run`.

## Files touched

| File | +/- | Purpose |
|---|---:|---|
| `.gitignore` | +40 / -0 | Ignore cleanup quarantine, local secrets, session artifacts, scratch files, and local debug output. |

## Verification
- Automated: `git diff --check HEAD^..HEAD` passed.
- Automated: `git check-ignore -v to-delete/scratch.txt .env.local .claude-session-test derailment-notes/foo tmp/output.log` confirmed each sample path is ignored by the new block.
- Automated: `python3 /Users/yigitkonur/dev-test/dotfiles/agents/.agents/skills/run-repo-cleanup/scripts/init-to-delete.py --dry-run` reported the patterns are already in place.
- Not run: `pnpm test` and `pnpm build`; this PR changes only `.gitignore`.

## Risks / Open items
1. The `*.log` pattern is intentionally broad. Reviewer should confirm this repo does not expect committed log fixtures.
2. `tmp/` and `scratch/` are now reserved for local-only output. Reviewer should confirm no planned tracked docs or fixtures use those root directory names.

## Follow-ups
- This PR does not delete any files.
- This PR does not change runtime code, parser behavior, package metadata, or release configuration.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.gitignore` rules to keep cleanup quarantine and local-only artifacts out of version control. Ignores `to-delete/`, common secret files, session traces (e.g., `.claude-session*`), editor scratch, `tmp/` and `scratch/`, and `*.log` outputs.

<sup>Written for commit 67e1be3c684960bb3be7118cc5b2b749d2d4ecdc. Summary will update on new commits. <a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/66?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
