### PR TITLE
feat: add --in flag to quick-resume commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,6 +95,8 @@ Quick start:
   $ continues
   $ npx continues --preset full
   $ continues claude 1
+  $ continues claude --in codex
+  $ continues codex --in claude
 
 Core workflows:
   $ continues list
@@ -268,8 +270,15 @@ for (const tool of ALL_TOOLS) {
   program
     .command(`${tool} [n]`)
     .description(`Resume Nth newest ${adapter.label} session (default: 1)`)
-    .action(async (n = '1') => {
-      await resumeBySource(tool, parseInt(n, 10));
+    .option('-i, --in <cli-tool>', `Hand off to a different CLI tool (${ALL_TOOLS.join(', ')})`)
+    .action(async (n = '1', options) => {
+      const globalOptions = program.opts();
+      await resumeBySource(tool, parseInt(n, 10), {
+        in: options.in as string | undefined,
+        preset: globalOptions.preset as string | undefined,
+        configPath: globalOptions.config as string | undefined,
+        chain: globalOptions.chain as boolean | undefined,
+      });
     });
 }
 

--- a/src/commands/quick-resume.ts
+++ b/src/commands/quick-resume.ts
@@ -1,13 +1,22 @@
 import chalk from 'chalk';
 import { formatSessionColored } from '../display/format.js';
-import type { SessionSource } from '../types/index.js';
+import { isSessionSource, type SessionSource, TOOL_NAMES } from '../types/index.js';
 import { getSessionsBySource } from '../utils/index.js';
-import { nativeResume } from '../utils/resume.js';
+import { nativeResume, resume } from '../utils/resume.js';
+
+export interface QuickResumeOptions {
+  /** Hand off to a different tool instead of native-resuming */
+  in?: string;
+  preset?: string;
+  configPath?: string;
+  chain?: boolean;
+}
 
 /**
- * Resume Nth session from a specific source tool
+ * Resume Nth session from a specific source tool.
+ * Pass `options.in` to hand off to a different tool (e.g. `continues claude --in codex`).
  */
-export async function resumeBySource(source: SessionSource, n: number): Promise<void> {
+export async function resumeBySource(source: SessionSource, n: number, options?: QuickResumeOptions): Promise<void> {
   try {
     const sessions = await getSessionsBySource(source);
 
@@ -24,7 +33,25 @@ export async function resumeBySource(source: SessionSource, n: number): Promise<
     console.log();
 
     if (session.cwd) process.chdir(session.cwd);
-    await nativeResume(session);
+
+    const targetTool = options?.in;
+    if (targetTool) {
+      if (!isSessionSource(targetTool)) {
+        console.error(
+          chalk.red('Error:'),
+          `Unknown target tool: ${targetTool}. Expected one of: ${TOOL_NAMES.join(', ')}.`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      await resume(session, targetTool, 'inline', undefined, {
+        preset: options?.preset,
+        configPath: options?.configPath,
+        chain: options?.chain,
+      });
+    } else {
+      await nativeResume(session);
+    }
   } catch (error) {
     console.error(chalk.red('Error:'), (error as Error).message);
     process.exitCode = 1;


### PR DESCRIPTION
## Summary

Adds `--in <tool>` to all quick-resume shorthands so cross-tool handoff is a one-liner.

**Before:**
```bash
continues resume $(continues list --source claude -n 1 --jsonl | jq -r '.id') --in codex
```

**After:**
```bash
continues claude --in codex
continues codex --in claude
continues claude 2 --in gemini   # nth session still works
```

## Changes

- **`src/commands/quick-resume.ts`** — `resumeBySource()` accepts an optional `QuickResumeOptions` object; when `options.in` is set, calls `resume()` with the cross-tool handoff path instead of `nativeResume()`. Validates the target tool name and surfaces a clear error for unknown tools.
- **`src/cli.ts`** — Adds `.option('-i, --in <cli-tool>', ...)` to each generated quick-resume command and threads `globalOptions` (preset, config, chain) through to `resumeBySource`.

All 28 test files / 917 tests pass. Build is clean.

## Test plan
- [ ] `continues claude --in codex` hands off latest Claude session to Codex
- [ ] `continues codex --in claude` hands off latest Codex session to Claude
- [ ] `continues claude 2 --in gemini` hands off 2nd-newest Claude session to Gemini
- [ ] `continues claude --in bogus` prints a clear error listing valid tool names
- [ ] `continues claude` (no `--in`) still does native resume as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--in <tool>` to all quick-resume commands so you can hand off a session to another tool in one step. Native resume remains the default, and selecting the Nth session still works.

- New Features
  - Add `-i, --in <cli-tool>` to `continues <tool> [n]` for cross-tool handoff.
  - Validate target tool and show a clear error with valid names.
  - Use cross-tool `resume()` when `--in` is set; otherwise use native resume.
  - Thread global options through handoff: `--preset`, `--config`, `--chain`.

<sup>Written for commit 3977c1de3786b6891a807fd0aafeb3f14708a030. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

