### PR TITLE
add vscode copilot and mistral vibe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ npx continues
 
 https://github.com/user-attachments/assets/6945f3a5-bd19-45ab-9702-6df8e165a734
 
-
 [![npm version](https://img.shields.io/npm/v/continues.svg)](https://www.npmjs.com/package/continues)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -16,7 +15,7 @@ https://github.com/user-attachments/assets/6945f3a5-bd19-45ab-9702-6df8e165a734
 
 16 AI coding agents, any-to-any handoff:
 
-**Claude Code** · **Codex** · **GitHub Copilot CLI** · **Gemini CLI** · **Cursor** · **Amp** · **Cline** · **Roo Code** · **Kilo Code** · **Kiro** · **Crush** · **OpenCode** · **Factory Droid** · **Antigravity** · **Kimi CLI** · **Qwen Code**
+**Claude Code** · **Codex** · **GitHub Copilot CLI** · **Gemini CLI** · **Cursor** · **Amp** · **Cline** · **Roo Code** · **Kilo Code** · **Kiro** · **Crush** · **OpenCode** · **Factory Droid** · **Antigravity** · **Kimi CLI** · **Qwen Code** **VSCode Copilot** **Mistral Vibe**
 
 That's 240 cross-tool handoff paths. Pick any source, pick any destination — it works.
 
@@ -147,12 +146,12 @@ File naming: `{source}_{id}.md` or `{source}_{id}.json`
 
 Not every handoff needs to be a novel. Four presets control how much detail goes in:
 
-| Preset | Messages | Tool samples | Subagent detail | When to use |
-|:-------|:---------|:-------------|:----------------|:------------|
-| `minimal` | 3 | 0 | None | Quick context, token-constrained targets |
-| `standard` | 10 | 5 | 500 chars | Default — good balance |
-| `verbose` | 20 | 10 | 2000 chars | Debugging, complex multi-file tasks |
-| `full` | 50 | All | Everything | Complete session capture |
+| Preset     | Messages | Tool samples | Subagent detail | When to use                              |
+| :--------- | :------- | :----------- | :-------------- | :--------------------------------------- |
+| `minimal`  | 3        | 0            | None            | Quick context, token-constrained targets |
+| `standard` | 10       | 5            | 500 chars       | Default — good balance                   |
+| `verbose`  | 20       | 10           | 2000 chars      | Debugging, complex multi-file tasks      |
+| `full`     | 50       | All          | Everything      | Complete session capture                 |
 
 ```bash
 continues resume abc123 --preset full
@@ -176,38 +175,42 @@ Resolution order: `--config <path>` → `.continues.yml` in cwd → `~/.continue
 
 Every tool stores sessions differently — different formats, different schemas, different paths. Here's what `continues` reads:
 
-| Tool | Format | Where it lives |
-|:-----|:-------|:---------------|
-| Claude Code | JSONL | `~/.claude/projects/` |
-| Codex | JSONL | `~/.codex/sessions/` |
-| Copilot | YAML + JSONL | `~/.copilot/session-state/` |
-| Gemini CLI | JSON | `~/.gemini/tmp/*/chats/` |
-| OpenCode | SQLite | `~/.local/share/opencode/storage/` |
-| Factory Droid | JSONL + JSON | `~/.factory/sessions/` |
-| Cursor | JSONL | `~/.cursor/projects/*/agent-transcripts/` |
-| Amp | JSON | `~/.local/share/amp/threads/` |
-| Kiro | JSON | `~/Library/Application Support/Kiro/workspace-sessions/` |
-| Crush | SQLite | `~/.crush/crush.db` |
-| Cline | JSON | VS Code `globalStorage/saoudrizwan.claude-dev/tasks/` |
-| Roo Code | JSON | VS Code `globalStorage/rooveterinaryinc.roo-cline/tasks/` |
-| Kilo Code | JSON | VS Code `globalStorage/kilocode.kilo-code/tasks/` |
-| Antigravity | PB + brain artifacts + optional live RPC | `~/.gemini/antigravity/` |
-| Kimi CLI | JSONL + JSON | `~/.kimi/sessions/` |
-| Qwen Code | JSONL | `~/.qwen/projects/*/chats/` |
+| Tool           | Format                                   | Where it lives                                              |
+| :------------- | :--------------------------------------- | :---------------------------------------------------------- |
+| Claude Code    | JSONL                                    | `~/.claude/projects/`                                       |
+| Codex          | JSONL                                    | `~/.codex/sessions/`                                        |
+| Copilot        | YAML + JSONL                             | `~/.copilot/session-state/`                                 |
+| Gemini CLI     | JSON                                     | `~/.gemini/tmp/*/chats/`                                    |
+| OpenCode       | SQLite                                   | `~/.local/share/opencode/storage/`                          |
+| Factory Droid  | JSONL + JSON                             | `~/.factory/sessions/`                                      |
+| Cursor         | JSONL                                    | `~/.cursor/projects/*/agent-transcripts/`                   |
+| Amp            | JSON                                     | `~/.local/share/amp/threads/`                               |
+| Kiro           | JSON                                     | `~/Library/Application Support/Kiro/workspace-sessions/`    |
+| Crush          | SQLite                                   | `~/.crush/crush.db`                                         |
+| Cline          | JSON                                     | VS Code `globalStorage/saoudrizwan.claude-dev/tasks/`       |
+| Roo Code       | JSON                                     | VS Code `globalStorage/rooveterinaryinc.roo-cline/tasks/`   |
+| Kilo Code      | JSON                                     | VS Code `globalStorage/kilocode.kilo-code/tasks/`           |
+| Antigravity    | PB + brain artifacts + optional live RPC | `~/.gemini/antigravity/`                                    |
+| Kimi CLI       | JSONL + JSON                             | `~/.kimi/sessions/`                                         |
+| Qwen Code      | JSONL                                    | `~/.qwen/projects/*/chats/`                                 |
+| Vscode Copilot | JSONL                                    | `~/Library/Application Support/Code/User/workspaceStorage/` |
+| Mistral Vibe   | JSONL + JSON                             | `~/.vibe/logs/session/`                                     |
 
 All reads are **read-only** — `continues` never modifies your session files. Index cached at `~/.continues/sessions.jsonl` (5-min TTL, auto-refresh).
 
 ### Tool activity in handoffs
 
-The handoff document includes a **Tool Activity** section so the target agent knows what was *done*, not just what was *said*:
+The handoff document includes a **Tool Activity** section so the target agent knows what was _done_, not just what was _said_:
 
 ```markdown
 ## Tool Activity
+
 - **Bash** (×47): `$ npm test → exit 0` · `$ git status → exit 0` · `$ npm run build → exit 1`
 - **Edit** (×12): `edit src/auth.ts` · `edit src/api/routes.ts` · `edit tests/auth.test.ts`
 - **Grep** (×8): `grep "handleLogin" src/` · `grep "JWT_SECRET"` · `grep "middleware"`
 
 ## Session Notes
+
 - **Model**: claude-sonnet-4
 - **Tokens**: 45,230 in / 12,847 out
 - 💭 Need to handle the edge case where token refresh races with logout
@@ -219,16 +222,16 @@ Every handoff also includes the **full file path** of the original session, so t
 
 ## Commands reference
 
-| Command | What it does |
-|:--------|:-------------|
-| `continues` | Interactive TUI picker |
-| `continues list` | List sessions (`--source`, `--json`, `--jsonl`, `-n`) |
-| `continues resume <id>` | Resume by ID (`--in <tool>`, `--preset`) |
-| `continues inspect <id>` | Diagnostic view (`--truncate`, `--write-md`, `--preset`) |
-| `continues dump <source\|all> <dir>` | Bulk export sessions (`--json`, `--preset`, `--limit`) |
-| `continues scan` | Discovery stats (`--rebuild`) |
-| `continues rebuild` | Force-rebuild session index |
-| `continues <tool> [n]` | Quick-resume Nth session from any of the 16 tools |
+| Command                              | What it does                                             |
+| :----------------------------------- | :------------------------------------------------------- |
+| `continues`                          | Interactive TUI picker                                   |
+| `continues list`                     | List sessions (`--source`, `--json`, `--jsonl`, `-n`)    |
+| `continues resume <id>`              | Resume by ID (`--in <tool>`, `--preset`)                 |
+| `continues inspect <id>`             | Diagnostic view (`--truncate`, `--write-md`, `--preset`) |
+| `continues dump <source\|all> <dir>` | Bulk export sessions (`--json`, `--preset`, `--limit`)   |
+| `continues scan`                     | Discovery stats (`--rebuild`)                            |
+| `continues rebuild`                  | Force-rebuild session index                              |
+| `continues <tool> [n]`               | Quick-resume Nth session from any of the 16 tools        |
 
 Global flags: `--config <path>`, `--preset <name>`, `--verbose`, `--debug`
 
@@ -244,6 +247,7 @@ This started as a 7-tool project and grew fast thanks to contributors:
 The latest batch — **Amp, Kiro, Crush, Cline, Roo Code, Kilo Code, Antigravity, Kimi CLI, and Qwen Code** — was added by reverse-engineering [mnemo](https://github.com/Pilan-AI/mnemo)'s Go adapters and adapting the schemas for TypeScript. Along the way we also improved token/cache/model extraction for the existing Claude, Codex, Cursor, and Gemini parsers.
 
 **Bugs fixed in this round:**
+
 - Symlink traversal — `fs.Dirent.isDirectory()` returns `false` for symlinks; fixed with `isSymbolicLink() && statSync()` fallback
 - Zero-token display — no longer shows "0 in / 0 out" when a session has no token data
 - Key Decisions count — now respects the verbosity config instead of being hardcoded to 5

--- a/src/__tests__/e2e-conversions.test.ts
+++ b/src/__tests__/e2e-conversions.test.ts
@@ -32,6 +32,8 @@ import {
   extractOpenCodeContext,
   extractQwenCodeContext,
   extractRooCodeContext,
+  extractMistralVibeContext,
+  extractVscodeCopilotContext,
   parseAmpSessions,
   parseAntigravitySessions,
   parseClaudeSessions,
@@ -48,6 +50,8 @@ import {
   parseOpenCodeSessions,
   parseQwenCodeSessions,
   parseRooCodeSessions,
+  parseMistralVibeSessions,
+  parseVscodeCopilotSessions,
 } from '../parsers/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 import { WHICH_CMD } from '../utils/platform.js';
@@ -68,7 +72,9 @@ const ALL_SOURCES: SessionSource[] = [
   'kilo-code',
   'antigravity',
   'kimi',
+  'mistral-vibe',
   'qwen-code',
+  'vscode-copilot',
 ];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
@@ -87,7 +93,9 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   'kilo-code': parseKiloCodeSessions,
   antigravity: parseAntigravitySessions,
   kimi: parseKimiSessions,
+  'mistral-vibe': parseMistralVibeSessions,
   'qwen-code': parseQwenCodeSessions,
+  'vscode-copilot': parseVscodeCopilotSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -106,7 +114,9 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   'kilo-code': extractKiloCodeContext,
   antigravity: extractAntigravityContext,
   kimi: extractKimiContext,
+  'mistral-vibe': extractMistralVibeContext,
   'qwen-code': extractQwenCodeContext,
+  'vscode-copilot': extractVscodeCopilotContext,
 };
 
 // Results directory
@@ -297,7 +307,9 @@ describe('E2E: 20 Cross-Tool Conversion Paths', () => {
           'kilo-code': 'Kilo Code',
           antigravity: 'Antigravity',
           kimi: 'Kimi CLI',
+          'mistral-vibe': 'Mistral Vibe',
           'qwen-code': 'Qwen Code',
+          'vscode-copilot': 'VS Code Copilot',
         };
         const sourceLabel = sourceLabels[source];
 

--- a/src/__tests__/extract-handoffs.ts
+++ b/src/__tests__/extract-handoffs.ts
@@ -22,6 +22,8 @@ import {
   extractOpenCodeContext,
   extractQwenCodeContext,
   extractRooCodeContext,
+  extractMistralVibeContext,
+  extractVscodeCopilotContext,
   parseAmpSessions,
   parseAntigravitySessions,
   parseClaudeSessions,
@@ -38,6 +40,8 @@ import {
   parseOpenCodeSessions,
   parseQwenCodeSessions,
   parseRooCodeSessions,
+  parseMistralVibeSessions,
+  parseVscodeCopilotSessions,
 } from '../parsers/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 
@@ -60,7 +64,9 @@ const ALL_SOURCES: SessionSource[] = [
   'kilo-code',
   'antigravity',
   'kimi',
+  'mistral-vibe',
   'qwen-code',
+  'vscode-copilot',
 ];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
@@ -79,7 +85,9 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   'kilo-code': parseKiloCodeSessions,
   antigravity: parseAntigravitySessions,
   kimi: parseKimiSessions,
+  'mistral-vibe': parseMistralVibeSessions,
   'qwen-code': parseQwenCodeSessions,
+  'vscode-copilot': parseVscodeCopilotSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -98,7 +106,9 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   'kilo-code': extractKiloCodeContext,
   antigravity: extractAntigravityContext,
   kimi: extractKimiContext,
+  'mistral-vibe': extractMistralVibeContext,
   'qwen-code': extractQwenCodeContext,
+  'vscode-copilot': extractVscodeCopilotContext,
 };
 
 async function main() {

--- a/src/__tests__/fixtures/index.ts
+++ b/src/__tests__/fixtures/index.ts
@@ -1202,6 +1202,95 @@ export function createQwenCodeFixture(): FixtureDir {
 }
 
 /**
+ * Create VS Code Copilot Chat fixture
+ */
+export function createVscodeCopilotFixture(): FixtureDir {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'test-vscode-copilot-'));
+  const hashDir = path.join(root, 'abc123def456abc1');
+  const chatSessionsDir = path.join(hashDir, 'chatSessions');
+  fs.mkdirSync(chatSessionsDir, { recursive: true });
+
+  const sessionId = 'test-vscode-copilot-session-1';
+  const sessionData = {
+    version: 3,
+    requesterUsername: 'testuser',
+    responderUsername: '',
+    initialLocation: 'panel',
+    sessionId,
+    creationDate: 1758735000000,
+    lastMessageDate: 1758735149883,
+    customTitle: 'Fix the authentication bug in login.ts',
+    isImported: false,
+    requests: [
+      {
+        requestId: 'request_00000001',
+        message: { text: 'Fix the authentication bug in login.ts' },
+        response: [
+          { value: 'I found the issue in login.ts. The token validation was missing.' },
+          { value: ' I have added the missing validateToken call.' },
+        ],
+        result: { details: 'GPT-4.1 • 1x' },
+        timestamp: 1758735100000,
+      },
+      {
+        requestId: 'request_00000002',
+        message: { text: 'Great, please also add error handling' },
+        response: [
+          { value: 'Done. I added try-catch blocks and proper error messages to the validation function.' },
+        ],
+        result: { details: 'GPT-4.1 • 1x' },
+        timestamp: 1758735149883,
+      },
+    ],
+  };
+
+  fs.writeFileSync(path.join(chatSessionsDir, `${sessionId}.json`), JSON.stringify(sessionData, null, 2));
+  fs.writeFileSync(
+    path.join(hashDir, 'workspace.json'),
+    JSON.stringify({ folder: 'file:///home/user/project' }),
+  );
+
+  return {
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+export function createMistralVibeFixture(): FixtureDir {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'test-mistral-vibe-'));
+  const sessionDir = path.join(root, 'session_20260508_120000_abcd1234');
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  const meta = {
+    session_id: 'abcd1234-0000-0000-0000-000000000001',
+    parent_session_id: null,
+    start_time: '2026-05-08T12:00:00.000000+00:00',
+    end_time: '2026-05-08T12:05:00.000000+00:00',
+    git_branch: 'main',
+    environment: { working_directory: '/home/user/project' },
+    title: 'Fix auth bug',
+    title_source: 'auto',
+    config: { active_model: 'mistral-medium-3.5' },
+    total_messages: 4,
+  };
+  fs.writeFileSync(path.join(sessionDir, 'meta.json'), JSON.stringify(meta, null, 2));
+
+  const messages = [
+    JSON.stringify({ role: 'system', content: 'You are Mistral Vibe.', injected: false, message_id: '00000001' }),
+    JSON.stringify({ role: 'user', content: 'Fix the authentication bug in login.ts', injected: false, message_id: '00000002' }),
+    JSON.stringify({ role: 'assistant', content: 'I found the issue in login.ts. The token validation was missing.', injected: false, tool_calls: null, message_id: '00000003' }),
+    JSON.stringify({ role: 'user', content: 'Great, please also add error handling', injected: false, message_id: '00000004' }),
+    JSON.stringify({ role: 'assistant', content: 'Done. I added try-catch blocks and proper error messages.', injected: false, tool_calls: null, message_id: '00000005' }),
+  ];
+  fs.writeFileSync(path.join(sessionDir, 'messages.jsonl'), messages.join('\n') + '\n');
+
+  return {
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+/**
  * Create OpenCode JSON-only fixture (legacy format)
  */
 export function createOpenCodeJsonFixture(): FixtureDir {

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -42,8 +42,8 @@ import { EDIT_TOOLS, READ_TOOLS, SHELL_TOOLS, TOOL_NAMES, WRITE_TOOLS } from '..
 // ── tool-names.ts ────────────────────────────────────────────────────────────
 
 describe('TOOL_NAMES', () => {
-  it('contains exactly 16 tools', () => {
-    expect(TOOL_NAMES).toHaveLength(16);
+  it('contains exactly 18 tools', () => {
+    expect(TOOL_NAMES).toHaveLength(18);
   });
 
   it('includes all known tools', () => {
@@ -64,6 +64,8 @@ describe('TOOL_NAMES', () => {
       'antigravity',
       'kimi',
       'qwen-code',
+      'mistral-vibe',
+      'vscode-copilot',
     ];
     expect([...TOOL_NAMES]).toEqual(expected);
   });

--- a/src/__tests__/unit-conversions.test.ts
+++ b/src/__tests__/unit-conversions.test.ts
@@ -26,6 +26,8 @@ import {
   createOpenCodeSqliteFixture,
   createQwenCodeFixture,
   createRooCodeFixture,
+  createMistralVibeFixture,
+  createVscodeCopilotFixture,
   type FixtureDir,
 } from './fixtures/index.js';
 
@@ -459,6 +461,8 @@ beforeAll(() => {
   fixtures['kilo-code'] = createKiloCodeFixture();
   fixtures.antigravity = createAntigravityFixture();
   fixtures['qwen-code'] = createQwenCodeFixture();
+  fixtures['mistral-vibe'] = createMistralVibeFixture();
+  fixtures['vscode-copilot'] = createVscodeCopilotFixture();
   fixtures.crush = createCrushFixture();
 
   // Build contexts from fixtures
@@ -905,6 +909,78 @@ beforeAll(() => {
     pendingTasks: [],
     toolSummaries: [],
     markdown: generateHandoffMarkdown(qwenCodeSession, qwenCodeMsgs, [], [], []),
+  };
+
+  // VS Code Copilot
+  const vscodeCopilotFile = fs
+    .readdirSync(fixtures['vscode-copilot'].root, { recursive: true })
+    .map((f) => path.join(fixtures['vscode-copilot'].root, f as string))
+    .find((f) => f.endsWith('.json') && f.includes('chatSessions'))!;
+  const vscodeCopilotData = JSON.parse(fs.readFileSync(vscodeCopilotFile, 'utf-8'));
+  const vscodeCopilotSession: UnifiedSession = {
+    id: 'test-vscode-copilot-session-1',
+    source: 'vscode-copilot',
+    cwd: '/home/user/project',
+    lines: 4,
+    bytes: fs.statSync(vscodeCopilotFile).size,
+    createdAt: new Date(vscodeCopilotData.creationDate),
+    updatedAt: new Date(vscodeCopilotData.lastMessageDate),
+    originalPath: vscodeCopilotFile,
+    summary: 'Fix auth bug',
+    model: 'GPT-4.1',
+  };
+  const vscodeCopilotMsgs: ConversationMessage[] = vscodeCopilotData.requests.flatMap(
+    (req: { message?: { text?: string }; response?: Array<{ value?: string; kind?: string }>; timestamp?: number }) => {
+      const msgs: ConversationMessage[] = [];
+      const userText = req.message?.text?.trim() ?? '';
+      if (userText) msgs.push({ role: 'user', content: userText, timestamp: req.timestamp ? new Date(req.timestamp) : undefined });
+      const assistantText = (req.response ?? []).filter((p) => p.kind !== 'inlineReference' && typeof p.value === 'string').map((p) => p.value as string).join('').trim();
+      if (assistantText) msgs.push({ role: 'assistant', content: assistantText, timestamp: req.timestamp ? new Date(req.timestamp) : undefined });
+      return msgs;
+    },
+  );
+  contexts['vscode-copilot'] = {
+    session: vscodeCopilotSession,
+    recentMessages: vscodeCopilotMsgs,
+    filesModified: [],
+    pendingTasks: [],
+    toolSummaries: [],
+    markdown: generateHandoffMarkdown(vscodeCopilotSession, vscodeCopilotMsgs, [], [], []),
+  };
+
+  // Mistral Vibe
+  const mistralVibeSessionDir = fs
+    .readdirSync(fixtures['mistral-vibe'].root, { withFileTypes: true })
+    .find((d) => d.isDirectory())!;
+  const mistralVibeDir = path.join(fixtures['mistral-vibe'].root, mistralVibeSessionDir.name);
+  const mistralVibeMeta = JSON.parse(fs.readFileSync(path.join(mistralVibeDir, 'meta.json'), 'utf-8'));
+  const mistralVibeLines = fs
+    .readFileSync(path.join(mistralVibeDir, 'messages.jsonl'), 'utf-8')
+    .trim()
+    .split('\n')
+    .map((l) => JSON.parse(l));
+  const mistralVibeSession: UnifiedSession = {
+    id: mistralVibeMeta.session_id,
+    source: 'mistral-vibe',
+    cwd: mistralVibeMeta.environment.working_directory,
+    lines: 4,
+    bytes: fs.statSync(path.join(mistralVibeDir, 'messages.jsonl')).size,
+    createdAt: new Date(mistralVibeMeta.start_time),
+    updatedAt: new Date(mistralVibeMeta.end_time),
+    originalPath: mistralVibeDir,
+    summary: 'Fix auth bug',
+    model: mistralVibeMeta.config.active_model,
+  };
+  const mistralVibeMsgs: ConversationMessage[] = mistralVibeLines
+    .filter((m: any) => (m.role === 'user' || m.role === 'assistant') && !m.injected && m.content?.trim())
+    .map((m: any) => ({ role: m.role as 'user' | 'assistant', content: m.content.trim() }));
+  contexts['mistral-vibe'] = {
+    session: mistralVibeSession,
+    recentMessages: mistralVibeMsgs,
+    filesModified: [],
+    pendingTasks: [],
+    toolSummaries: [],
+    markdown: generateHandoffMarkdown(mistralVibeSession, mistralVibeMsgs, [], [], []),
   };
 });
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -19,5 +19,7 @@ export { extractKimiContext, parseKimiSessions } from './kimi.js';
 export { extractKiroContext, parseKiroSessions } from './kiro.js';
 export { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
 export { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
+export { extractMistralVibeContext, parseMistralVibeSessions } from './mistral-vibe.js';
+export { extractVscodeCopilotContext, parseVscodeCopilotSessions } from './vscode-copilot.js';
 export type { ToolAdapter } from './registry.js';
 export { ALL_TOOLS, adapters, SOURCE_HELP } from './registry.js';

--- a/src/parsers/mistral-vibe.ts
+++ b/src/parsers/mistral-vibe.ts
@@ -1,0 +1,227 @@
+import * as fs from 'node:fs';
+import * as readline from 'node:readline';
+import * as path from 'node:path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
+import { logger } from '../logger.js';
+import type { ConversationMessage, SessionContext, SessionParseOptions, UnifiedSession } from '../types/index.js';
+import { findFiles } from '../utils/fs-helpers.js';
+import { generateHandoffMarkdown } from '../utils/markdown.js';
+import { extractRepoFromCwd, homeDir, trimMessages } from '../utils/parser-helpers.js';
+import { fileSummary, fetchSummary, grepSummary, mcpSummary, searchSummary, shellSummary, subagentSummary, SummaryCollector } from '../utils/tool-summarizer.js';
+
+function getVibeSessionsDir(): string {
+  const configured = process.env.VIBE_HOME?.trim();
+  const base = configured ? path.resolve(configured) : path.join(homeDir(), '.vibe');
+  return path.join(base, 'logs', 'session');
+}
+
+const VIBE_SESSIONS_DIR = getVibeSessionsDir();
+
+interface VibeMeta {
+  session_id?: string;
+  start_time?: string;
+  end_time?: string;
+  title?: string;
+  environment?: { working_directory?: string };
+  git_branch?: string;
+  config?: { active_model?: string };
+}
+
+interface VibeToolCall {
+  function?: { name?: string; arguments?: string };
+}
+
+interface VibeMessage {
+  role?: string;
+  content?: string;
+  injected?: boolean;
+  tool_calls?: VibeToolCall[];
+  name?: string;
+  tool_call_id?: string;
+}
+
+async function parseMessages(messagesPath: string): Promise<VibeMessage[]> {
+  const messages: VibeMessage[] = [];
+  const rl = readline.createInterface({ input: fs.createReadStream(messagesPath), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    try {
+      messages.push(JSON.parse(line) as VibeMessage);
+    } catch {
+      continue;
+    }
+  }
+  return messages;
+}
+
+function extractConversationMessages(messages: VibeMessage[]): ConversationMessage[] {
+  const result: ConversationMessage[] = [];
+  for (const msg of messages) {
+    if (msg.role !== 'user' && msg.role !== 'assistant') continue;
+    if (msg.injected) continue;
+    const text = msg.content?.trim() ?? '';
+    if (!text) continue;
+    result.push({ role: msg.role as 'user' | 'assistant', content: text });
+  }
+  return result;
+}
+
+export async function parseMistralVibeSessions(_options?: SessionParseOptions): Promise<UnifiedSession[]> {
+  if (!fs.existsSync(VIBE_SESSIONS_DIR)) return [];
+
+  const sessionDirs = findFiles(VIBE_SESSIONS_DIR, {
+    match: (entry) => entry.name === 'meta.json',
+    maxDepth: 2,
+  }).map((f) => path.dirname(f));
+
+  const sessions: UnifiedSession[] = [];
+
+  for (const dir of sessionDirs) {
+    try {
+      const metaPath = path.join(dir, 'meta.json');
+      const messagesPath = path.join(dir, 'messages.jsonl');
+      if (!fs.existsSync(messagesPath)) continue;
+
+      const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8')) as VibeMeta;
+      const stats = fs.statSync(messagesPath);
+
+      const cwd = meta.environment?.working_directory ?? '';
+      const createdAt = new Date(meta.start_time ?? stats.birthtimeMs);
+      const updatedAt = new Date(meta.end_time ?? stats.mtimeMs);
+
+      const messages = await parseMessages(messagesPath);
+      const conversationMessages = extractConversationMessages(messages);
+      if (conversationMessages.length === 0) continue;
+
+      const firstUserText = conversationMessages.find((m) => m.role === 'user')?.content ?? '';
+      const summary =
+        (meta.title && meta.title.length > 0 ? meta.title : firstUserText).slice(0, 80).replace(/\s+/g, ' ').trim() ||
+        undefined;
+
+      sessions.push({
+        id: meta.session_id ?? path.basename(dir),
+        source: 'mistral-vibe',
+        cwd,
+        repo: extractRepoFromCwd(cwd),
+        branch: meta.git_branch,
+        summary,
+        lines: conversationMessages.length,
+        bytes: stats.size,
+        createdAt,
+        updatedAt,
+        originalPath: dir,
+        model: meta.config?.active_model,
+      });
+    } catch (err) {
+      logger.debug('mistral-vibe: skipping unparseable session', dir, err);
+    }
+  }
+
+  return sessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}
+
+export async function extractMistralVibeContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
+  const resolvedConfig = config ?? getPreset('standard');
+  const collector = new SummaryCollector(resolvedConfig);
+
+  const metaPath = path.join(session.originalPath, 'meta.json');
+  const messagesPath = path.join(session.originalPath, 'messages.jsonl');
+  const messages = await parseMessages(messagesPath);
+
+  const recentMessages: ConversationMessage[] = [];
+
+  for (const msg of messages) {
+    if (msg.injected) continue;
+
+    if ((msg.role === 'user' || msg.role === 'assistant') && msg.content?.trim()) {
+      recentMessages.push({ role: msg.role as 'user' | 'assistant', content: msg.content.trim() });
+    }
+
+    if (msg.role === 'assistant' && msg.tool_calls) {
+      for (const tc of msg.tool_calls) {
+        const name = tc.function?.name ?? '';
+        if (!name) continue;
+        let args: Record<string, unknown> = {};
+        try {
+          args = JSON.parse(tc.function?.arguments ?? '{}') as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+
+        switch (name) {
+          case 'bash': {
+            const cmd = String(args.command ?? '').trim();
+            if (cmd) collector.add('shell', shellSummary(cmd));
+            break;
+          }
+          case 'read_file': {
+            const filePath = String(args.path ?? '').trim();
+            if (filePath) collector.add('read', fileSummary('read', filePath), { filePath });
+            break;
+          }
+          case 'write_file': {
+            const filePath = String(args.path ?? '').trim();
+            if (filePath) collector.add('write', fileSummary('write', filePath), { filePath, isWrite: true });
+            break;
+          }
+          case 'search_replace': {
+            const filePath = String(args.file_path ?? '').trim();
+            if (filePath) collector.add('edit', fileSummary('edit', filePath), { filePath, isWrite: true });
+            break;
+          }
+          case 'grep': {
+            const pattern = String(args.pattern ?? '').trim();
+            const searchPath = String(args.path ?? '').trim();
+            if (pattern) collector.add('grep', grepSummary(pattern, searchPath || undefined));
+            break;
+          }
+          case 'web_search': {
+            const query = String(args.query ?? '').trim();
+            if (query) collector.add('search', searchSummary(query));
+            break;
+          }
+          case 'web_fetch': {
+            const url = String(args.url ?? '').trim();
+            if (url) collector.add('fetch', fetchSummary(url));
+            break;
+          }
+          case 'task': {
+            const taskDesc = String(args.task ?? '').trim();
+            const agent = String(args.agent ?? 'explore').trim();
+            if (taskDesc) collector.add('task', subagentSummary(taskDesc.slice(0, 80), agent));
+            break;
+          }
+          default: {
+            collector.add('mcp', mcpSummary(name, JSON.stringify(args).slice(0, 80)));
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  const trimmed = trimMessages(recentMessages, resolvedConfig.recentMessages);
+  const toolSummaries = collector.getSummaries();
+  const filesModified = collector.getFilesModified();
+
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    [],
+    toolSummaries,
+    undefined,
+    resolvedConfig,
+    'inline',
+  );
+
+  return {
+    session,
+    recentMessages: trimmed,
+    filesModified,
+    pendingTasks: [],
+    toolSummaries,
+    markdown,
+  };
+}

--- a/src/parsers/mistral-vibe.ts
+++ b/src/parsers/mistral-vibe.ts
@@ -1,14 +1,14 @@
 import * as fs from 'node:fs';
-import * as readline from 'node:readline';
 import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type { ConversationMessage, SessionContext, SessionParseOptions, UnifiedSession } from '../types/index.js';
 import { findFiles } from '../utils/fs-helpers.js';
+import { readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { extractRepoFromCwd, homeDir, trimMessages } from '../utils/parser-helpers.js';
-import { fileSummary, fetchSummary, grepSummary, mcpSummary, searchSummary, shellSummary, subagentSummary, SummaryCollector } from '../utils/tool-summarizer.js';
+import { fetchSummary, fileSummary, grepSummary, mcpSummary, searchSummary, shellSummary, subagentSummary, SummaryCollector } from '../utils/tool-summarizer.js';
 
 function getVibeSessionsDir(): string {
   const configured = process.env.VIBE_HOME?.trim();
@@ -39,20 +39,6 @@ interface VibeMessage {
   tool_calls?: VibeToolCall[];
   name?: string;
   tool_call_id?: string;
-}
-
-async function parseMessages(messagesPath: string): Promise<VibeMessage[]> {
-  const messages: VibeMessage[] = [];
-  const rl = readline.createInterface({ input: fs.createReadStream(messagesPath), crlfDelay: Infinity });
-  for await (const line of rl) {
-    if (!line.trim()) continue;
-    try {
-      messages.push(JSON.parse(line) as VibeMessage);
-    } catch {
-      continue;
-    }
-  }
-  return messages;
 }
 
 function extractConversationMessages(messages: VibeMessage[]): ConversationMessage[] {
@@ -90,11 +76,21 @@ export async function parseMistralVibeSessions(_options?: SessionParseOptions): 
       const createdAt = new Date(meta.start_time ?? stats.birthtimeMs);
       const updatedAt = new Date(meta.end_time ?? stats.mtimeMs);
 
-      const messages = await parseMessages(messagesPath);
-      const conversationMessages = extractConversationMessages(messages);
-      if (conversationMessages.length === 0) continue;
+      // Scan only the first ~30 lines to get summary without reading the full file.
+      // meta.title is preferred; fall back to the first non-injected user message.
+      let firstUserText = '';
+      let hasConversation = false;
+      await scanJsonlHead(messagesPath, 30, (parsed) => {
+        const msg = parsed as VibeMessage;
+        if (msg.injected || (msg.role !== 'user' && msg.role !== 'assistant')) return 'continue';
+        const text = msg.content?.trim() ?? '';
+        if (!text) return 'continue';
+        hasConversation = true;
+        if (msg.role === 'user' && !firstUserText) firstUserText = text;
+        return firstUserText ? 'stop' : 'continue';
+      });
+      if (!hasConversation) continue;
 
-      const firstUserText = conversationMessages.find((m) => m.role === 'user')?.content ?? '';
       const summary =
         (meta.title && meta.title.length > 0 ? meta.title : firstUserText).slice(0, 80).replace(/\s+/g, ' ').trim() ||
         undefined;
@@ -106,7 +102,7 @@ export async function parseMistralVibeSessions(_options?: SessionParseOptions): 
         repo: extractRepoFromCwd(cwd),
         branch: meta.git_branch,
         summary,
-        lines: conversationMessages.length,
+        lines: 0,
         bytes: stats.size,
         createdAt,
         updatedAt,
@@ -125,9 +121,8 @@ export async function extractMistralVibeContext(session: UnifiedSession, config?
   const resolvedConfig = config ?? getPreset('standard');
   const collector = new SummaryCollector(resolvedConfig);
 
-  const metaPath = path.join(session.originalPath, 'meta.json');
   const messagesPath = path.join(session.originalPath, 'messages.jsonl');
-  const messages = await parseMessages(messagesPath);
+  const messages = await readJsonlFile<VibeMessage>(messagesPath);
 
   const recentMessages: ConversationMessage[] = [];
 

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -30,6 +30,8 @@ import { extractKimiContext, parseKimiSessions } from './kimi.js';
 import { extractKiroContext, parseKiroSessions } from './kiro.js';
 import { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
 import { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
+import { extractMistralVibeContext, parseMistralVibeSessions } from './mistral-vibe.js';
+import { extractVscodeCopilotContext, parseVscodeCopilotSessions } from './vscode-copilot.js';
 
 /**
  * Adapter interface — single contract for all supported CLI tools.
@@ -937,6 +939,36 @@ register({
   crossToolArgs: (prompt) => [prompt],
   resumeCommandDisplay: (s) => `qwen --resume ${s.id}`,
   mapHandoffFlags: mapGeminiFlags,
+});
+
+// ── Mistral Vibe ─────────────────────────────────────────────────────
+register({
+  name: 'mistral-vibe',
+  label: 'Mistral Vibe',
+  color: chalk.hex('#FF7000'),
+  storagePath: '~/.vibe/logs/session/',
+  envVar: 'VIBE_HOME',
+  binaryName: 'vibe',
+  parseSessions: parseMistralVibeSessions,
+  extractContext: extractMistralVibeContext,
+  nativeResumeArgs: () => [],
+  crossToolArgs: (prompt) => [prompt],
+  resumeCommandDisplay: () => 'vibe',
+});
+
+// ── VS Code Copilot Chat ─────────────────────────────────────────────
+register({
+  name: 'vscode-copilot',
+  label: 'VS Code Copilot',
+  color: chalk.hex('#24A0ED'),
+  storagePath: '~/Library/Application Support/Code/User/workspaceStorage/ (Linux: ~/.config/Code/User/workspaceStorage/, Windows: %APPDATA%/Code/User/workspaceStorage/)',
+  envVar: 'VSCODE_COPILOT_HOME',
+  binaryName: 'code',
+  parseSessions: parseVscodeCopilotSessions,
+  extractContext: extractVscodeCopilotContext,
+  nativeResumeArgs: () => [],
+  crossToolArgs: (prompt) => [prompt],
+  resumeCommandDisplay: () => 'code',
 });
 
 // ── Completeness assertion ──────────────────────────────────────────

--- a/src/parsers/vscode-copilot.ts
+++ b/src/parsers/vscode-copilot.ts
@@ -1,0 +1,285 @@
+import * as fs from 'node:fs';
+import * as readline from 'node:readline';
+import * as path from 'node:path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
+import { logger } from '../logger.js';
+import type { ConversationMessage, SessionContext, SessionParseOptions, UnifiedSession } from '../types/index.js';
+import { findFiles } from '../utils/fs-helpers.js';
+import { generateHandoffMarkdown } from '../utils/markdown.js';
+import { homeDir, trimMessages } from '../utils/parser-helpers.js';
+
+function getWorkspaceStorageDir(): string {
+  if (process.env.VSCODE_COPILOT_HOME) return process.env.VSCODE_COPILOT_HOME;
+  const home = homeDir();
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming'), 'Code', 'User', 'workspaceStorage');
+  }
+  if (process.platform === 'linux') {
+    return path.join(process.env.XDG_CONFIG_HOME ?? path.join(home, '.config'), 'Code', 'User', 'workspaceStorage');
+  }
+  return path.join(home, 'Library', 'Application Support', 'Code', 'User', 'workspaceStorage');
+}
+
+const WORKSPACE_STORAGE_DIR = getWorkspaceStorageDir();
+
+interface VscodeChatResponsePart {
+  value?: string;
+  kind?: string;
+}
+
+interface VscodeChatRequest {
+  requestId?: string;
+  message?: { text?: string };
+  response?: VscodeChatResponsePart[];
+  result?: { details?: string };
+  timestamp?: number;
+}
+
+// ── JSON format (legacy) ──────────────────────────────────────────────────────
+
+interface VscodeChatSessionJson {
+  sessionId?: string;
+  creationDate?: number;
+  lastMessageDate?: number;
+  customTitle?: string;
+  requests?: VscodeChatRequest[];
+}
+
+// ── JSONL format (current) ────────────────────────────────────────────────────
+// Append log: each line is {kind, v}
+// kind=0 → session metadata
+// kind=1 → state patch: string=title update, otherwise ignored
+// kind=2 → list of request-response turns (items with requestId) or response chunks
+
+interface VscodeChatSessionMeta {
+  sessionId?: string;
+  creationDate?: number;
+  lastMessageDate?: number;
+}
+
+interface VscodeChatTurn {
+  requestId: string;
+  timestamp?: number;
+  message?: { text?: string };
+  response?: VscodeChatResponsePart[];
+  result?: { details?: string };
+}
+
+interface ParsedJsonlSession {
+  meta: VscodeChatSessionMeta;
+  title: string;
+  turns: VscodeChatTurn[];
+  lastTimestamp: number;
+}
+
+async function parseJsonlSession(filePath: string): Promise<ParsedJsonlSession | null> {
+  const meta: VscodeChatSessionMeta = {};
+  let title = '';
+  const turns: VscodeChatTurn[] = [];
+  let lastTimestamp = 0;
+
+  const rl = readline.createInterface({ input: fs.createReadStream(filePath), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    let entry: { kind: number; v: unknown };
+    try {
+      entry = JSON.parse(line) as { kind: number; v: unknown };
+    } catch {
+      continue;
+    }
+
+    if (entry.kind === 0 && entry.v && typeof entry.v === 'object' && !Array.isArray(entry.v)) {
+      const v = entry.v as VscodeChatSessionMeta;
+      if (v.sessionId) meta.sessionId = v.sessionId;
+      if (v.creationDate) meta.creationDate = v.creationDate;
+      if (v.lastMessageDate) meta.lastMessageDate = v.lastMessageDate;
+    } else if (entry.kind === 1 && typeof entry.v === 'string' && entry.v.trim()) {
+      const k = (entry as unknown as { k?: unknown }).k;
+      if (Array.isArray(k) && k.length === 1 && k[0] === 'customTitle') {
+        title = entry.v.trim();
+      }
+    } else if (entry.kind === 2 && Array.isArray(entry.v)) {
+      for (const item of entry.v as unknown[]) {
+        if (!item || typeof item !== 'object' || !('requestId' in item)) continue;
+        const turn = item as VscodeChatTurn;
+        turns.push(turn);
+        if (turn.timestamp && turn.timestamp > lastTimestamp) lastTimestamp = turn.timestamp;
+      }
+    }
+  }
+
+  if (!meta.sessionId && turns.length === 0) return null;
+  return { meta, title, turns, lastTimestamp };
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+function extractResponseText(parts: VscodeChatResponsePart[]): string {
+  return parts
+    .filter((p) => p.kind !== 'inlineReference' && typeof p.value === 'string')
+    .map((p) => p.value as string)
+    .join('');
+}
+
+function extractModelFromRequests(requests: VscodeChatRequest[]): string | undefined {
+  for (const req of requests) {
+    const details = req.result?.details;
+    if (details) {
+      const model = details.split('•')[0].trim();
+      if (model) return model;
+    }
+  }
+  return undefined;
+}
+
+function extractModelFromTurns(turns: VscodeChatTurn[]): string | undefined {
+  for (const turn of turns) {
+    const details = turn.result?.details;
+    if (details) {
+      const model = details.split('•')[0].trim();
+      if (model) return model;
+    }
+  }
+  return undefined;
+}
+
+function extractCwd(workspaceJson: string): string {
+  try {
+    const data = JSON.parse(fs.readFileSync(workspaceJson, 'utf-8')) as { folder?: string; workspace?: string };
+    const raw = data.folder ?? data.workspace ?? '';
+    return raw.replace(/^file:\/\//, '');
+  } catch {
+    return '';
+  }
+}
+
+function messagesFromRequests(requests: VscodeChatRequest[]): ConversationMessage[] {
+  const msgs: ConversationMessage[] = [];
+  for (const req of requests) {
+    const userText = req.message?.text?.trim() ?? '';
+    if (userText) msgs.push({ role: 'user', content: userText, timestamp: req.timestamp ? new Date(req.timestamp) : undefined });
+    const assistantText = extractResponseText(req.response ?? []).trim();
+    if (assistantText) msgs.push({ role: 'assistant', content: assistantText, timestamp: req.timestamp ? new Date(req.timestamp) : undefined });
+  }
+  return msgs;
+}
+
+function messagesFromTurns(turns: VscodeChatTurn[]): ConversationMessage[] {
+  const msgs: ConversationMessage[] = [];
+  for (const turn of turns) {
+    const userText = turn.message?.text?.trim() ?? '';
+    if (userText) msgs.push({ role: 'user', content: userText, timestamp: turn.timestamp ? new Date(turn.timestamp) : undefined });
+    const assistantText = extractResponseText(turn.response ?? []).trim();
+    if (assistantText) msgs.push({ role: 'assistant', content: assistantText, timestamp: turn.timestamp ? new Date(turn.timestamp) : undefined });
+  }
+  return msgs;
+}
+
+// ── Discovery ─────────────────────────────────────────────────────────────────
+
+async function findChatSessionFiles(): Promise<Array<{ filePath: string; hashDir: string }>> {
+  if (!fs.existsSync(WORKSPACE_STORAGE_DIR)) return [];
+  const results: Array<{ filePath: string; hashDir: string }> = [];
+  const files = findFiles(WORKSPACE_STORAGE_DIR, {
+    match: (entry) => entry.name.endsWith('.json') || entry.name.endsWith('.jsonl'),
+    maxDepth: 2,
+  });
+  for (const filePath of files) {
+    if (filePath.includes(`${path.sep}chatSessions${path.sep}`)) {
+      const hashDir = path.dirname(path.dirname(filePath));
+      results.push({ filePath, hashDir });
+    }
+  }
+  return results;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export async function parseVscodeCopilotSessions(_options?: SessionParseOptions): Promise<UnifiedSession[]> {
+  const files = await findChatSessionFiles();
+  const sessions: UnifiedSession[] = [];
+
+  for (const { filePath, hashDir } of files) {
+    try {
+      const stats = fs.statSync(filePath);
+      const cwd = extractCwd(path.join(hashDir, 'workspace.json'));
+
+      if (filePath.endsWith('.jsonl')) {
+        const parsed = await parseJsonlSession(filePath);
+        if (!parsed || parsed.turns.length === 0) continue;
+
+        const { meta, title, turns, lastTimestamp } = parsed;
+        const firstUserText = turns[0]?.message?.text?.trim() ?? '';
+        const summary = (title || firstUserText).slice(0, 80).replace(/\s+/g, ' ').trim() || undefined;
+
+        sessions.push({
+          id: meta.sessionId ?? path.basename(filePath, '.jsonl'),
+          source: 'vscode-copilot',
+          cwd,
+          summary,
+          lines: turns.length * 2,
+          bytes: stats.size,
+          createdAt: new Date(meta.creationDate ?? stats.birthtimeMs),
+          updatedAt: new Date(lastTimestamp || meta.lastMessageDate || stats.mtimeMs),
+          originalPath: filePath,
+          model: extractModelFromTurns(turns),
+        });
+      } else {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as VscodeChatSessionJson;
+        const requests = data.requests ?? [];
+        if (requests.length === 0) continue;
+
+        const firstUserText = requests[0]?.message?.text?.trim() ?? '';
+        const summary = (data.customTitle ?? firstUserText).slice(0, 80).replace(/\s+/g, ' ').trim() || undefined;
+
+        sessions.push({
+          id: data.sessionId ?? path.basename(filePath, '.json'),
+          source: 'vscode-copilot',
+          cwd,
+          summary,
+          lines: requests.length * 2,
+          bytes: stats.size,
+          createdAt: new Date(data.creationDate ?? stats.birthtimeMs),
+          updatedAt: new Date(data.lastMessageDate ?? stats.mtimeMs),
+          originalPath: filePath,
+          model: extractModelFromRequests(requests),
+        });
+      }
+    } catch (err) {
+      logger.debug('vscode-copilot: skipping unparseable session', filePath, err);
+    }
+  }
+
+  return sessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}
+
+export async function extractVscodeCopilotContext(
+  session: UnifiedSession,
+  config?: VerbosityConfig,
+): Promise<SessionContext> {
+  const resolvedConfig = config ?? getPreset('standard');
+
+  let recentMessages: ConversationMessage[];
+
+  if (session.originalPath.endsWith('.jsonl')) {
+    const parsed = await parseJsonlSession(session.originalPath);
+    recentMessages = parsed ? messagesFromTurns(parsed.turns) : [];
+  } else {
+    const data = JSON.parse(fs.readFileSync(session.originalPath, 'utf-8')) as VscodeChatSessionJson;
+    recentMessages = messagesFromRequests(data.requests ?? []);
+  }
+
+  const trimmed = trimMessages(recentMessages, resolvedConfig.recentMessages);
+
+  const markdown = generateHandoffMarkdown(session, trimmed, [], [], [], undefined, resolvedConfig, 'inline');
+
+  return {
+    session,
+    recentMessages: trimmed,
+    filesModified: [],
+    pendingTasks: [],
+    toolSummaries: [],
+    markdown,
+  };
+}

--- a/src/parsers/vscode-copilot.ts
+++ b/src/parsers/vscode-copilot.ts
@@ -1,11 +1,11 @@
 import * as fs from 'node:fs';
-import * as readline from 'node:readline';
 import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type { ConversationMessage, SessionContext, SessionParseOptions, UnifiedSession } from '../types/index.js';
 import { findFiles } from '../utils/fs-helpers.js';
+import { scanJsonlFile } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
 import { homeDir, trimMessages } from '../utils/parser-helpers.js';
 
@@ -79,16 +79,8 @@ async function parseJsonlSession(filePath: string): Promise<ParsedJsonlSession |
   const turns: VscodeChatTurn[] = [];
   let lastTimestamp = 0;
 
-  const rl = readline.createInterface({ input: fs.createReadStream(filePath), crlfDelay: Infinity });
-  for await (const line of rl) {
-    if (!line.trim()) continue;
-    let entry: { kind: number; v: unknown };
-    try {
-      entry = JSON.parse(line) as { kind: number; v: unknown };
-    } catch {
-      continue;
-    }
-
+  await scanJsonlFile(filePath, (parsed) => {
+    const entry = parsed as { kind: number; v: unknown };
     if (entry.kind === 0 && entry.v && typeof entry.v === 'object' && !Array.isArray(entry.v)) {
       const v = entry.v as VscodeChatSessionMeta;
       if (v.sessionId) meta.sessionId = v.sessionId;
@@ -107,7 +99,8 @@ async function parseJsonlSession(filePath: string): Promise<ParsedJsonlSession |
         if (turn.timestamp && turn.timestamp > lastTimestamp) lastTimestamp = turn.timestamp;
       }
     }
-  }
+    return 'continue';
+  });
 
   if (!meta.sessionId && turns.length === 0) return null;
   return { meta, title, turns, lastTimestamp };

--- a/src/types/tool-names.ts
+++ b/src/types/tool-names.ts
@@ -21,6 +21,8 @@ export const TOOL_NAMES = Object.freeze([
   'antigravity',
   'kimi',
   'qwen-code',
+  'mistral-vibe',
+  'vscode-copilot',
 ] as const);
 
 /** Source CLI tool — derived from TOOL_NAMES, never defined manually */
@@ -70,6 +72,7 @@ export const EDIT_TOOLS: ReadonlySet<string> = new Set([
   'apply_patch',
   'ApplyPatch',
   'replace',
+  'search_replace',
   'mcp__morph__edit_file',
   'morph___edit_file',
 ]);


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for VS Code Copilot Chat and Mistral Vibe, enabling resume and any-to-any handoffs. Supported tools increase from 16 to 18 with updated docs and tests.

- **New Features**
  - New parsers: `vscode-copilot` (JSON + JSONL) and `mistral-vibe` (JSONL + JSON) with registry entries.
  - Discovery paths: VS Code `workspaceStorage` (override with `VSCODE_COPILOT_HOME`); Vibe at `~/.vibe/logs/session/` (override with `VIBE_HOME`).
  - Copilot: parses legacy `.json` and new `.jsonl`; builds messages from requests; extracts model from `result.details`; uses custom title or first user message.
  - Vibe: reads `meta.json` + `messages.jsonl`; extracts recent messages, model, cwd; summarizes `tool_calls` (bash, read/write, grep, web_search/fetch, task, fallback MCP) via tool summarizer.
  - Tests/fixtures: e2e and unit coverage for both tools; `TOOL_NAMES` includes `mistral-vibe` and `vscode-copilot` (count 18); added `search_replace` to edit tools.
  - README: lists both tools, their storage locations, and updates supported tools and command tables.

- **Refactors**
  - Faster session scans by reading JSONL heads for summaries; reduced I/O in Vibe/Copilot parsers.

<sup>Written for commit e3dcd4d31cc131e606ad0061e82c4952e1ba266a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

