### PR TITLE
Support Antigravity CLI sessions

### DIFF
--- a/docs/parser-documentation/access-recipes/14-antigravity.md
+++ b/docs/parser-documentation/access-recipes/14-antigravity.md
@@ -3,8 +3,10 @@
 ## Raw Sources
 
 - Primary root: `~/.gemini/antigravity/`
-- Session discovery: `conversations/*.pb`, `brain/<id>/`, and `state.vscdb` trajectory summaries.
+- CLI root: `~/.gemini/antigravity-cli/`
+- Session discovery: CLI `conversations/*.db`, IDE `conversations/*.pb`, `brain/<id>/`, and `state.vscdb` trajectory summaries.
 - Context extraction:
+  - CLI: read-only SQLite step extraction from `antigravity-cli/conversations/<id>.db`.
   - Offline: `brain/<id>/task.md`, `implementation_plan.md`, `walkthrough.md`, and `.resolved*` variants.
   - Live: local Antigravity language-server RPC when the app is running.
 - Legacy fallback: chat-shaped JSON/JSONL under `code_tracker/`; snapshot-only files are ignored.
@@ -14,8 +16,15 @@
 ### Inspect current session IDs
 
 ```bash
+find ~/.gemini/antigravity-cli/conversations -maxdepth 1 -name '*.db' -print
 find ~/.gemini/antigravity/conversations -maxdepth 1 -name '*.pb' -print
 find ~/.gemini/antigravity/brain -maxdepth 1 -type d -print
+```
+
+### Resume a CLI conversation natively
+
+```bash
+agy --conversation <conversation-id>
 ```
 
 ### Inspect offline handoff artifacts
@@ -41,6 +50,7 @@ find ~/.gemini/antigravity/code_tracker -type f \( -name '*.json' -o -name '*.js
 ## Current Parser Comparison
 
 - The parser now indexes current Antigravity installs even when `code_tracker` contains only file snapshots.
+- Antigravity CLI conversations are indexed from `~/.gemini/antigravity-cli/conversations/*.db`.
 - Offline handoffs are artifact-backed and explicitly note that full raw transcript extraction requires live Antigravity.
 - Legacy JSONL remains supported only for files with real user/assistant chat entries.
 

--- a/docs/parser-documentation/storage-format/14-antigravity.md
+++ b/docs/parser-documentation/storage-format/14-antigravity.md
@@ -5,6 +5,8 @@ Accessed: 2026-04-28
 ## Observed Storage
 
 - Root: `~/.gemini/antigravity/`
+- CLI root: `~/.gemini/antigravity-cli/`
+- CLI conversations: `antigravity-cli/conversations/<conversation-id>.db`
 - Persisted conversation IDs: `conversations/*.pb`
 - Handoff artifacts: `brain/<conversation-id>/task.md`, `implementation_plan.md`, `walkthrough.md`, plus `.resolved*` variants.
 - UI/index metadata: Antigravity global storage SQLite at `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb` on macOS.
@@ -12,7 +14,8 @@ Accessed: 2026-04-28
 
 ## Parser Behavior
 
-- `src/parsers/antigravity.ts` now discovers sessions from the union of `conversations/*.pb`, `brain/<id>/`, `state.vscdb` trajectory summaries, and optional live language-server RPC.
+- `src/parsers/antigravity.ts` now discovers sessions from the union of CLI `conversations/*.db`, IDE `conversations/*.pb`, `brain/<id>/`, `state.vscdb` trajectory summaries, and optional live language-server RPC.
+- CLI `.db` extraction reads `steps` read-only through `node:sqlite` and decodes embedded protobuf/JSON strings best-effort for messages and tool activity.
 - `code_tracker/` is no longer treated as canonical. It is parsed only as a legacy fallback when a file actually contains chat-shaped `{type, content, timestamp}` records.
 - Offline extraction does not decrypt `.pb`; it builds a useful handoff from brain artifacts and state metadata.
 - When Antigravity is running, the parser attempts read-only RPC extraction for full steps, messages, tool activity, and modified files.
@@ -26,6 +29,7 @@ Accessed: 2026-04-28
 ## Direct Access Recipe
 
 ```bash
+find ~/.gemini/antigravity-cli/conversations -name '*.db'
 find ~/.gemini/antigravity/conversations -name '*.pb'
 find ~/.gemini/antigravity/brain -maxdepth 2 -type f | head -n 80
 sqlite3 "$HOME/Library/Application Support/Antigravity/User/globalStorage/state.vscdb" \

--- a/src/__tests__/antigravity-parser.test.ts
+++ b/src/__tests__/antigravity-parser.test.ts
@@ -54,6 +54,7 @@ function makeRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'continues-antigravity-'));
   tempRoots.push(root);
   vi.stubEnv('ANTIGRAVITY_HOME', root);
+  vi.stubEnv('ANTIGRAVITY_CLI_HOME', path.join(root, 'missing-antigravity-cli'));
   vi.stubEnv('ANTIGRAVITY_STATE_DB', path.join(root, 'missing-state.vscdb'));
   vi.stubEnv('ANTIGRAVITY_DISABLE_RPC', '1');
   return root;
@@ -115,6 +116,28 @@ function createStateDb(dbPath: string, key: string, value: string): void {
   try {
     db.exec('CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)');
     db.prepare('INSERT INTO ItemTable (key, value) VALUES (?, ?)').run(key, value);
+  } finally {
+    db.close();
+  }
+}
+
+function createCliConversationDb(
+  dbPath: string,
+  rows: Array<{ idx: number; stepType: number; payload: string }>,
+): void {
+  const sqliteModule = require('node:sqlite') as {
+    DatabaseSync: new (database: string) => SqliteDatabase;
+  };
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new sqliteModule.DatabaseSync(dbPath);
+  try {
+    db.exec(
+      'CREATE TABLE steps (idx integer PRIMARY KEY, step_type integer NOT NULL DEFAULT 0, metadata blob, task_details blob, render_info blob, step_payload blob)',
+    );
+    const insert = db.prepare('INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)');
+    for (const row of rows) {
+      insert.run(row.idx, row.stepType, Buffer.from(row.payload, 'utf8'));
+    }
   } finally {
     db.close();
   }
@@ -235,6 +258,64 @@ describe('Antigravity parser', () => {
     expect(sessions[0].lines).toBe(7);
     expect(sessions[0].createdAt.toISOString()).toBe(createdAt.toISOString());
     expect(sessions[0].updatedAt.toISOString()).toBe(updatedAt.toISOString());
+  });
+
+  it('discovers Antigravity CLI sqlite conversations under antigravity-cli', async () => {
+    const root = makeRoot();
+    const cliRoot = path.join(root, 'antigravity-cli');
+    const id = 'dddddddd-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    vi.stubEnv('ANTIGRAVITY_CLI_HOME', cliRoot);
+    writeFile(path.join(cliRoot, 'cache', 'last_conversations.json'), JSON.stringify({ '/home/user/project': id }));
+    createCliConversationDb(path.join(cliRoot, 'conversations', `${id}.db`), [
+      { idx: 0, stepType: 14, payload: 'Fix the CLI resume flow for Antigravity' },
+      {
+        idx: 1,
+        stepType: 15,
+        payload:
+          'I will inspect the resume adapter. run_command {"CommandLine":"git status --short","Cwd":"/home/user/project"}',
+      },
+    ]);
+
+    const sessions = await parseAntigravitySessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id,
+      source: 'antigravity',
+      cwd: '/home/user/project',
+      repo: 'user/project',
+      lines: 2,
+      summary: 'Fix the CLI resume flow for Antigravity',
+      originalPath: path.join(cliRoot, 'conversations', `${id}.db`),
+    });
+  });
+
+  it('extracts Antigravity CLI context from sqlite steps without launching the IDE', async () => {
+    const root = makeRoot();
+    const cliRoot = path.join(root, 'antigravity-cli');
+    const id = 'eeeeeeee-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    vi.stubEnv('ANTIGRAVITY_CLI_HOME', cliRoot);
+    createCliConversationDb(path.join(cliRoot, 'conversations', `${id}.db`), [
+      { idx: 0, stepType: 14, payload: 'Fix the Antigravity CLI parser' },
+      {
+        idx: 1,
+        stepType: 15,
+        payload:
+          'I will inspect the registry. run_command {"CommandLine":"rg antigravity src/parsers/registry.ts","Cwd":"/home/user/project"}',
+      },
+    ]);
+
+    const [session] = await parseAntigravitySessions();
+    const context = await extractAntigravityContext(session);
+
+    expect(context.recentMessages.map((message) => message.role)).toContain('user');
+    expect(context.recentMessages.map((message) => message.role)).toContain('assistant');
+    expect(
+      context.toolSummaries.some((summary) =>
+        summary.samples.some((sample) => sample.summary.includes('rg antigravity')),
+      ),
+    ).toBe(true);
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it('extracts an offline handoff from brain artifacts when live RPC is unavailable', async () => {

--- a/src/__tests__/forward-flags.test.ts
+++ b/src/__tests__/forward-flags.test.ts
@@ -126,6 +126,37 @@ describe('cross-tool forwarding', () => {
     expect(resolved.passthroughArgs).toEqual([]);
   });
 
+  it('maps antigravity cli forwarding and resume commands to agy', () => {
+    const session: UnifiedSession = {
+      id: 'abc123456789',
+      source: 'antigravity',
+      cwd: '/tmp/project',
+      lines: 10,
+      bytes: 120,
+      createdAt: new Date('2026-02-20T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-20T00:00:00.000Z'),
+      originalPath: '/tmp/session.db',
+    };
+
+    const resolved = resolveCrossToolForwarding('antigravity', {
+      rawArgs: ['--allow-all', '--sandbox', 'false', '--model', 'gemini-3-flash'],
+    });
+
+    expect(adapters.antigravity.binaryName).toBe('agy');
+    expect(adapters.antigravity.binaryFallbacks).toEqual(['antigravity']);
+    expect(adapters.antigravity.nativeResumeArgs(session)).toEqual(['--conversation', 'abc123456789']);
+    expect(getResumeCommand(session)).toBe(
+      'agy --conversation abc123456789 (or: antigravity --conversation abc123456789)',
+    );
+    expect(resolved.mappedArgs).toEqual([
+      '--dangerously-skip-permissions',
+      '--sandbox=false',
+      '--model',
+      'gemini-3-flash',
+    ]);
+    expect(resolved.passthroughArgs).toEqual([]);
+  });
+
   it('consumes unsupported approval and permission forwarding for opencode', () => {
     const resolved = resolveCrossToolForwarding('opencode', {
       rawArgs: ['--approval-mode', 'plan', '--permission-mode', 'plan'],
@@ -149,6 +180,7 @@ describe('cross-tool forwarding', () => {
     expect(getDefaultHandoffInitArgs('kiro')).toEqual([]);
     expect(getDefaultHandoffInitArgs('crush')).toEqual([]);
     expect(getDefaultHandoffInitArgs('qwen-code')).toEqual([]);
+    expect(getDefaultHandoffInitArgs('antigravity')).toEqual([]);
 
     expect(getDefaultHandoffInitArgs('codex')).toEqual([
       '-c',

--- a/src/parsers/antigravity.ts
+++ b/src/parsers/antigravity.ts
@@ -5,6 +5,7 @@ import * as https from 'node:https';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
+import { pathToFileURL } from 'node:url';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
@@ -24,6 +25,7 @@ const SOURCE_NAME: SessionSource = 'antigravity';
 const SUMMARY_STATE_KEYS = ['antigravityUnifiedStateSync.trajectorySummaries', 'unifiedStateSync.trajectorySummaries'];
 const BRAIN_ARTIFACT_BASE_FILES = ['task.md', 'implementation_plan.md', 'walkthrough.md'];
 const UUIDISH_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+const UUIDISH_ANYWHERE_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/iu;
 const RPC_TIMEOUT_MS = 1500;
 const LAUNCH_POLL_INTERVAL_MS_DEFAULT = 500;
 const LAUNCH_TIMEOUT_MS_DEFAULT = 25_000;
@@ -45,6 +47,7 @@ function getLaunchTimeoutMs(): number {
 
 interface SqlitePreparedStatement {
   get(...params: unknown[]): unknown | undefined;
+  all(...params: unknown[]): unknown[];
 }
 
 interface SqliteDatabase {
@@ -68,10 +71,20 @@ interface LiveSummary extends StateSummary {
 interface AntigravityRecord {
   id: string;
   conversationPath?: string;
+  cliConversationPath?: string;
   brainDir?: string;
   legacyPath?: string;
   state?: StateSummary;
   live?: LiveSummary;
+}
+
+interface CliDbStep {
+  idx: number;
+  stepType: number;
+  payload?: Uint8Array;
+  metadata?: Uint8Array;
+  taskDetails?: Uint8Array;
+  renderInfo?: Uint8Array;
 }
 
 interface AntigravityEntry {
@@ -131,12 +144,29 @@ function getAntigravityRoot(): string {
   return path.join(configuredHome, '.gemini', 'antigravity');
 }
 
+function getAntigravityCliRoot(): string {
+  const explicit = process.env.ANTIGRAVITY_CLI_HOME?.trim();
+  if (explicit) return expandHome(explicit);
+
+  const configuredHome = process.env.GEMINI_CLI_HOME || homeDir();
+  if (path.basename(configuredHome) === 'antigravity-cli') return configuredHome;
+  return path.join(configuredHome, '.gemini', 'antigravity-cli');
+}
+
 function getConversationsDir(): string {
   return path.join(getAntigravityRoot(), 'conversations');
 }
 
 function getBrainDir(): string {
   return path.join(getAntigravityRoot(), 'brain');
+}
+
+function getCliBrainDir(): string {
+  return path.join(getAntigravityCliRoot(), 'brain');
+}
+
+function getCliConversationsDir(): string {
+  return path.join(getAntigravityCliRoot(), 'conversations');
 }
 
 function getCodeTrackerDir(): string {
@@ -283,6 +313,16 @@ async function discoverConversationRecords(records: Map<string, AntigravityRecor
   }
 }
 
+async function discoverCliConversationRecords(records: Map<string, AntigravityRecord>): Promise<void> {
+  const conversationsDir = getCliConversationsDir();
+  for (const entry of await readDirSafe(conversationsDir)) {
+    if (!entry.isFile() || !entry.name.endsWith('.db')) continue;
+    const id = path.basename(entry.name, '.db');
+    if (!UUIDISH_RE.test(id)) continue;
+    addRecord(records, id, { cliConversationPath: path.join(conversationsDir, entry.name) });
+  }
+}
+
 async function findBrainArtifactPath(brainDir: string, baseName: string): Promise<string | undefined> {
   const entries = await readDirSafe(brainDir);
   const exact = entries.find((entry) => entry.isFile() && entry.name === baseName);
@@ -309,12 +349,13 @@ async function hasBrainArtifacts(dirPath: string): Promise<boolean> {
 }
 
 async function discoverBrainRecords(records: Map<string, AntigravityRecord>): Promise<void> {
-  const brainDir = getBrainDir();
-  for (const entry of await readDirSafe(brainDir)) {
-    if (!entry.isDirectory()) continue;
-    const dirPath = path.join(brainDir, entry.name);
-    if (!UUIDISH_RE.test(entry.name) && !(await hasBrainArtifacts(dirPath))) continue;
-    addRecord(records, entry.name, { brainDir: dirPath });
+  for (const brainDir of [getBrainDir(), getCliBrainDir()]) {
+    for (const entry of await readDirSafe(brainDir)) {
+      if (!entry.isDirectory()) continue;
+      const dirPath = path.join(brainDir, entry.name);
+      if (!UUIDISH_RE.test(entry.name) && !(await hasBrainArtifacts(dirPath))) continue;
+      addRecord(records, entry.name, { brainDir: dirPath });
+    }
   }
 }
 
@@ -394,9 +435,10 @@ async function discoverLegacyRecords(records: Map<string, AntigravityRecord>): P
     // sessions whose basenames collide across subdirectories don't merge in
     // addRecord. Falls back to basename for any file outside code_tracker/.
     const relative = path.relative(codeTrackerDir, filePath);
-    const idBase = relative && !relative.startsWith('..')
-      ? relative.slice(0, -ext.length).replace(/[\\/]/gu, ':')
-      : path.basename(filePath, ext);
+    const idBase =
+      relative && !relative.startsWith('..')
+        ? relative.slice(0, -ext.length).replace(/[\\/]/gu, ':')
+        : path.basename(filePath, ext);
     addRecord(records, `legacy:${idBase}`, { legacyPath: filePath });
   }
 }
@@ -411,6 +453,27 @@ function openDb(dbPath: string): { db: SqliteDatabase; close: () => void } | nul
     return { db, close: () => db.close() };
   } catch (err) {
     logger.debug('antigravity: failed to open state database', dbPath, err);
+    return null;
+  }
+}
+
+function immutableSqliteUri(dbPath: string): string {
+  const url = pathToFileURL(dbPath);
+  url.searchParams.set('mode', 'ro');
+  url.searchParams.set('immutable', '1');
+  return url.toString();
+}
+
+function openCliConversationDb(dbPath: string): { db: SqliteDatabase; close: () => void } | null {
+  try {
+    const require = createRequire(import.meta.url);
+    const sqliteModule = require('node:sqlite') as {
+      DatabaseSync: new (database: string, options?: { open?: boolean; readOnly?: boolean }) => SqliteDatabase;
+    };
+    const db = new sqliteModule.DatabaseSync(immutableSqliteUri(dbPath), { open: true, readOnly: true });
+    return { db, close: () => db.close() };
+  } catch (err) {
+    logger.debug('antigravity: failed to open cli conversation database', dbPath, err);
     return null;
   }
 }
@@ -756,6 +819,242 @@ function loadStateSummaries(): Map<string, StateSummary> {
   }
 
   return combined;
+}
+
+async function loadCliLastConversationCwds(): Promise<Map<string, string>> {
+  const filePath = path.join(getAntigravityCliRoot(), 'cache', 'last_conversations.json');
+  try {
+    const parsed: unknown = JSON.parse(await fsp.readFile(filePath, 'utf8'));
+    if (!isRecord(parsed)) return new Map();
+    const byId = new Map<string, string>();
+    for (const [cwd, id] of Object.entries(parsed)) {
+      if (isNonEmptyString(cwd) && isNonEmptyString(id)) byId.set(id, cwd);
+    }
+    return byId;
+  } catch (err) {
+    logger.debug('antigravity: failed to read cli last conversations cache', filePath, err);
+    return new Map();
+  }
+}
+
+function dbBlob(value: unknown): Uint8Array | undefined {
+  return value instanceof Uint8Array ? value : undefined;
+}
+
+function extractPrintableStrings(bytes: Uint8Array): string[] {
+  const raw = Buffer.from(bytes).toString('latin1');
+  return Array.from(raw.matchAll(/[ -~]{4,}/gu), (match) => match[0].trim()).filter(Boolean);
+}
+
+function textLooksUseful(value: string): boolean {
+  if (value.length < 8) return false;
+  if (UUIDISH_RE.test(value.replace(/^\$/u, ''))) return false;
+  if (UUIDISH_ANYWHERE_RE.test(value)) return false;
+  if (value.includes('sessionID')) return false;
+  if (/\b(command|execute_url|read_url|mcp)\(\*\)/u.test(value)) return false;
+  if (/^(sessionID|trajectory_id|model_enum|toolAction|toolSummary|CommandLine|Cwd|DirectoryPath)$/u.test(value)) {
+    return false;
+  }
+  if (/^[A-Za-z_]+\(.\)$/u.test(value)) return false;
+  if (/^[A-Za-z0-9_-]{8,}$/u.test(value) && !value.includes(' ')) return false;
+  return /[A-Za-z][A-Za-z]/u.test(value);
+}
+
+function stringsFromStep(step: CliDbStep): string[] {
+  const chunks = [step.payload, step.metadata, step.taskDetails, step.renderInfo].filter(
+    (value): value is Uint8Array => value !== undefined,
+  );
+  const strings: string[] = [];
+  for (const chunk of chunks) {
+    strings.push(...Array.from(iterUtf8StringsInProto(chunk, 4)));
+    strings.push(...extractPrintableStrings(chunk));
+  }
+  return Array.from(new Set(strings.map((value) => value.replace(/\s+/gu, ' ').trim()).filter(textLooksUseful)));
+}
+
+function parseJsonObjects(strings: string[]): Record<string, unknown>[] {
+  const objects: Record<string, unknown>[] = [];
+  for (const value of strings) {
+    const starts = [...value.matchAll(/\{/gu)].map((match) => match.index).filter((index) => index !== undefined);
+    for (const start of starts) {
+      const candidate = value.slice(start);
+      try {
+        const parsed: unknown = JSON.parse(candidate);
+        if (isRecord(parsed)) objects.push(parsed);
+      } catch {
+        // Ignore non-JSON protobuf strings.
+      }
+    }
+  }
+  return objects;
+}
+
+function cleanCliMessageText(value: string): string {
+  const botMarker = value.indexOf('2(bot-');
+  const trimmed = (botMarker >= 0 ? value.slice(0, botMarker) : value).trim();
+  const leadingSentence = trimmed.match(/[A-Z][\s\S]+/u)?.[0] ?? trimmed;
+  return leadingSentence.replace(/[`'"]?$/u, '').trim();
+}
+
+function chooseCliText(strings: string[], preferred?: (value: string) => boolean): string | undefined {
+  const candidates = strings
+    .map(cleanCliMessageText)
+    .filter((value) => textLooksUseful(value) && !value.startsWith('{') && !value.startsWith('file://'));
+  const preferredMatch = preferred ? candidates.find(preferred) : undefined;
+  return preferredMatch ?? candidates.sort((left, right) => right.length - left.length)[0];
+}
+
+function extractCliCwdFromStrings(strings: string[]): string | undefined {
+  for (const text of strings) {
+    const uriMatch = text.match(/file:\/\/[^\s"')]+/u)?.[0];
+    if (uriMatch) {
+      const cwd = decodeFileUri(uriMatch);
+      if (cwd) return path.dirname(cwd);
+    }
+    if (text.startsWith('/') && text.includes(path.sep)) return text.replace(/0$/u, '');
+  }
+  return undefined;
+}
+
+function readCliSteps(dbPath: string): CliDbStep[] {
+  const handle = openCliConversationDb(dbPath);
+  if (!handle) return [];
+
+  try {
+    const rows = handle.db
+      .prepare('SELECT idx, step_type, metadata, task_details, render_info, step_payload FROM steps ORDER BY idx ASC')
+      .all();
+    return rows.flatMap((row): CliDbStep[] => {
+      if (!isRecord(row) || typeof row.idx !== 'number' || typeof row.step_type !== 'number') return [];
+      return [
+        {
+          idx: row.idx,
+          stepType: row.step_type,
+          payload: dbBlob(row.step_payload),
+          metadata: dbBlob(row.metadata),
+          taskDetails: dbBlob(row.task_details),
+          renderInfo: dbBlob(row.render_info),
+        },
+      ];
+    });
+  } catch (err) {
+    logger.debug('antigravity: failed to read cli conversation steps', dbPath, err);
+    return [];
+  } finally {
+    handle.close();
+  }
+}
+
+function readCliStepCount(dbPath: string): number | undefined {
+  const handle = openCliConversationDb(dbPath);
+  if (!handle) return undefined;
+
+  try {
+    const row = handle.db.prepare('SELECT COUNT(*) AS count FROM steps').get();
+    return isRecord(row) && typeof row.count === 'number' ? row.count : undefined;
+  } catch (err) {
+    logger.debug('antigravity: failed to count cli conversation steps', dbPath, err);
+    return undefined;
+  } finally {
+    handle.close();
+  }
+}
+
+function titleFromCliSteps(steps: CliDbStep[]): string | undefined {
+  for (const stepType of [23, 14]) {
+    for (const step of steps) {
+      if (step.stepType !== stepType) continue;
+      const strings = stringsFromStep(step);
+      const title = chooseCliText(strings, (value) => value.length <= 120 && !value.includes('\n'));
+      if (title) return title;
+    }
+  }
+  for (const step of steps) {
+    const text = chooseCliText(stringsFromStep(step));
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function summarizeCliToolPayload(
+  toolName: string,
+  payload: Record<string, unknown>,
+  collector: SummaryCollector,
+): void {
+  if (toolName === 'run_command') {
+    const command = firstString(payload, ['CommandLine', 'commandLine', 'command', 'cmd']);
+    if (!command) return;
+    const output = firstString(payload, ['Output', 'output', 'stdout', 'stderr', 'result']);
+    const cwd = firstString(payload, ['Cwd', 'cwd']);
+    collector.add(toolName, shellSummary(command, output), {
+      data: {
+        category: 'shell',
+        command,
+        ...(cwd ? { cwd } : {}),
+        ...(output ? { stdoutTail: output.slice(-500) } : {}),
+      },
+    });
+    return;
+  }
+
+  const filePath = extractFilePath(payload);
+  if (filePath) {
+    const isWrite = /write|edit|patch|replace|create/iu.test(toolName);
+    collector.add(toolName, fileSummary(isWrite ? 'edit' : 'read', filePath), {
+      data: { category: isWrite ? 'edit' : 'read', filePath },
+      filePath,
+      isWrite,
+    });
+    return;
+  }
+
+  const directory = firstString(payload, ['DirectoryPath', 'directoryPath', 'path']);
+  if (directory) {
+    collector.add(toolName, mcpSummary(toolName, directory), {
+      data: { category: 'glob', pattern: directory },
+    });
+    return;
+  }
+
+  summarizeGenericTool(toolName, payload, undefined, collector);
+}
+
+function extractFromCliDbSteps(steps: CliDbStep[], config: VerbosityConfig, fallbackDate: Date): RpcStepExtraction {
+  const messages: ConversationMessage[] = [];
+  const collector = new SummaryCollector(config);
+
+  for (const step of steps) {
+    const strings = stringsFromStep(step);
+    const objects = parseJsonObjects(strings);
+    const timestamp = fallbackDate;
+
+    if (step.stepType === 14 || step.stepType === 23) {
+      const text = chooseCliText(strings);
+      if (text) messages.push({ role: 'user', content: text, timestamp });
+    } else if (step.stepType === 15) {
+      const text = chooseCliText(strings, (value) => /^(I|I'll|I will|Done|The|We)\b/u.test(value));
+      if (text) messages.push({ role: 'assistant', content: text, timestamp });
+    }
+
+    for (const payload of objects) {
+      const toolName =
+        firstString(payload, ['toolName', 'name']) ??
+        (firstString(payload, ['CommandLine', 'commandLine', 'command', 'cmd']) ? 'run_command' : undefined) ??
+        (extractFilePath(payload) ? 'view_file' : undefined) ??
+        strings.find((value) => /^[a-z_]+$/u.test(value));
+      if (toolName) summarizeCliToolPayload(toolName, payload, collector);
+    }
+  }
+
+  return {
+    messages,
+    filesModified: collector.getFilesModified(),
+    toolSummaries: collector.getSummaries(),
+    pendingTasks: [],
+    sessionNotes: {
+      compactSummary: 'Extracted from Antigravity CLI conversation SQLite using best-effort protobuf string decoding.',
+    },
+  };
 }
 
 async function discoverStateRecords(records: Map<string, AntigravityRecord>): Promise<void> {
@@ -1105,24 +1404,34 @@ async function buildSessionFromRecord(record: AntigravityRecord): Promise<Unifie
   // Skip metadata-only records that have no concrete backing path; downstream
   // inspect/extract paths fs.statSync the originalPath, which would crash if
   // we emit a fallback to the (directory-only) antigravity root.
-  if (!record.conversationPath && !record.brainDir) return null;
+  if (!record.conversationPath && !record.cliConversationPath && !record.brainDir) return null;
 
   const artifactPaths = await brainArtifactPaths(record.brainDir);
-  const stats = await pathStats([record.conversationPath, ...artifactPaths].filter(isNonEmptyString));
-  const title = recordPreferredTitle(record) ?? (await titleFromBrain(record.brainDir));
-  const cwd = record.live?.cwd ?? record.state?.cwd ?? (await inferCwdFromBrain(record.brainDir)) ?? '';
+  const stats = await pathStats(
+    [record.conversationPath, record.cliConversationPath, ...artifactPaths].filter(isNonEmptyString),
+  );
+  const cliSteps = record.cliConversationPath ? readCliSteps(record.cliConversationPath).slice(0, 40) : [];
+  const cliCwds = record.cliConversationPath ? await loadCliLastConversationCwds() : new Map<string, string>();
+  const cliStrings = cliSteps.flatMap(stringsFromStep);
+  const cliCwd = cliCwds.get(record.id) ?? extractCliCwdFromStrings(cliStrings);
+  const title = recordPreferredTitle(record) ?? (await titleFromBrain(record.brainDir)) ?? titleFromCliSteps(cliSteps);
+  const cwd = record.live?.cwd ?? record.state?.cwd ?? (await inferCwdFromBrain(record.brainDir)) ?? cliCwd ?? '';
   const createdAt =
     record.live?.createdAt ?? record.state?.createdAt ?? stats.createdAt ?? stats.updatedAt ?? new Date(0);
   const updatedAt = record.live?.updatedAt ?? record.state?.updatedAt ?? stats.updatedAt ?? createdAt;
   const summary = cleanSummary(title ?? `Antigravity conversation ${record.id.slice(0, 8)}`, 80);
-  const originalPath = record.conversationPath ?? record.brainDir ?? getAntigravityRoot();
+  const originalPath = record.cliConversationPath ?? record.conversationPath ?? record.brainDir ?? getAntigravityRoot();
 
   return {
     id: record.id,
     source: SOURCE_NAME,
     cwd,
     repo: extractRepoFromCwd(cwd),
-    lines: record.live?.stepCount ?? record.state?.stepCount ?? artifactPaths.length,
+    lines:
+      record.live?.stepCount ??
+      record.state?.stepCount ??
+      (record.cliConversationPath ? readCliStepCount(record.cliConversationPath) : undefined) ??
+      artifactPaths.length,
     bytes: stats.bytes,
     createdAt,
     updatedAt,
@@ -1162,6 +1471,7 @@ async function buildLegacySession(filePath: string, prefixedId?: string): Promis
 async function discoverRecords(): Promise<Map<string, AntigravityRecord>> {
   const records = new Map<string, AntigravityRecord>();
   await discoverConversationRecords(records);
+  await discoverCliConversationRecords(records);
   await discoverBrainRecords(records);
   await discoverStateRecords(records);
   await discoverLiveRecords(records);
@@ -1205,6 +1515,8 @@ async function resolveBrainDirForSession(session: UnifiedSession): Promise<strin
   const id = extractSessionId(session);
   const direct = path.join(getBrainDir(), id);
   if (await exists(direct)) return direct;
+  const cliDirect = path.join(getCliBrainDir(), id);
+  if (await exists(cliDirect)) return cliDirect;
   const maybeRecordDir = path.dirname(session.originalPath);
   if (path.basename(maybeRecordDir) === id && (await hasBrainArtifacts(maybeRecordDir))) return maybeRecordDir;
   return undefined;
@@ -1753,6 +2065,34 @@ async function extractOfflineContext(session: UnifiedSession, config: VerbosityC
   };
 }
 
+function extractCliDbContext(session: UnifiedSession, config: VerbosityConfig): SessionContext | null {
+  if (!session.originalPath.endsWith('.db')) return null;
+  const steps = readCliSteps(session.originalPath);
+  if (steps.length === 0) return null;
+
+  const extracted = extractFromCliDbSteps(steps, config, session.updatedAt);
+  const recentMessages = trimMessages(extracted.messages, config.recentMessages);
+  const markdown = generateHandoffMarkdown(
+    session,
+    recentMessages,
+    extracted.filesModified,
+    extracted.pendingTasks,
+    extracted.toolSummaries,
+    extracted.sessionNotes,
+    config,
+  );
+
+  return {
+    session,
+    recentMessages,
+    filesModified: extracted.filesModified,
+    pendingTasks: extracted.pendingTasks,
+    toolSummaries: extracted.toolSummaries,
+    sessionNotes: extracted.sessionNotes,
+    markdown,
+  };
+}
+
 export async function extractAntigravityContext(
   session: UnifiedSession,
   config?: VerbosityConfig,
@@ -1773,6 +2113,9 @@ export async function extractAntigravityContext(
       markdown,
     };
   }
+
+  const cliDbContext = extractCliDbContext(session, resolvedConfig);
+  if (cliDbContext) return cliDbContext;
 
   const live = await extractLiveContext(session, resolvedConfig);
   if (live && liveHasContent(live)) {

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -209,6 +209,63 @@ function mapGeminiFlags(context: ForwardFlagMapContext): ForwardMapResult {
   return { mappedArgs: args };
 }
 
+function mapAntigravityFlags(context: ForwardFlagMapContext): ForwardMapResult {
+  const args: string[] = [];
+  const warnings: string[] = [];
+
+  const autoOccurrences = collectAutoApproveOccurrences(context);
+  const fullAutoOccurrences = context.all('fullAuto');
+  const askOccurrences = context.all('askForApproval');
+  const approvalModeOccurrences = context.all('approvalMode');
+  const permissionModeOccurrences = context.all('permissionMode');
+  const approvalMode = context.latestString('approvalMode')?.toLowerCase();
+  const askForApproval = context.latestString('askForApproval')?.toLowerCase();
+
+  if (
+    autoOccurrences.length > 0 ||
+    fullAutoOccurrences.length > 0 ||
+    approvalMode === 'yolo' ||
+    askForApproval === 'never'
+  ) {
+    context.consume(
+      ...autoOccurrences,
+      ...fullAutoOccurrences,
+      ...askOccurrences,
+      ...approvalModeOccurrences,
+      ...permissionModeOccurrences,
+    );
+    args.push('--dangerously-skip-permissions');
+
+    if (approvalModeOccurrences.length > 0 && approvalMode && approvalMode !== 'yolo') {
+      warnings.push('Antigravity: mapped auto-approve behavior overrides unsupported approval-mode values.');
+    }
+  } else if (askOccurrences.length > 0 || approvalModeOccurrences.length > 0 || permissionModeOccurrences.length > 0) {
+    context.consume(...askOccurrences, ...approvalModeOccurrences, ...permissionModeOccurrences);
+    warnings.push('Antigravity: approval and permission mode forwarding flags are not supported and were ignored.');
+  }
+
+  const sandbox = context.latest('sandbox');
+  if (sandbox) {
+    context.consumeKeys('sandbox');
+    const normalized = String(sandbox.value).toLowerCase();
+    if (sandbox.value === true || ['true', '1', 'yes', 'on', 'enabled'].includes(normalized)) {
+      args.push('--sandbox=true');
+    } else if (['false', '0', 'no', 'off', 'disabled', 'none'].includes(normalized)) {
+      args.push('--sandbox=false');
+    } else {
+      args.push('--sandbox', String(sandbox.value));
+    }
+  }
+
+  const model = context.latestString('model');
+  if (model) {
+    context.consumeKeys('model');
+    args.push('--model', model);
+  }
+
+  return { mappedArgs: args, warnings };
+}
+
 function mapClaudeFlags(context: ForwardFlagMapContext): ForwardMapResult {
   const args: string[] = [];
   const warnings: string[] = [];
@@ -886,19 +943,21 @@ register({
 // ── Antigravity ──────────────────────────────────────────────────────
 register({
   name: 'antigravity',
-  label: 'Antigravity',
+  label: 'Antigravity CLI',
   color: chalk.hex('#A8DADC'),
-  storagePath: '~/.gemini/antigravity/',
+  storagePath: '~/.gemini/antigravity-cli/ (CLI), ~/.gemini/antigravity/ (IDE)',
   envVar: 'ANTIGRAVITY_HOME',
   // Antigravity's parser falls back to GEMINI_CLI_HOME when ANTIGRAVITY_HOME
   // is unset, so changes to that var must also invalidate the index cache.
-  extraEnvVars: ['GEMINI_CLI_HOME', 'ANTIGRAVITY_STATE_DB'],
-  binaryName: 'antigravity',
+  extraEnvVars: ['GEMINI_CLI_HOME', 'ANTIGRAVITY_CLI_HOME', 'ANTIGRAVITY_STATE_DB'],
+  binaryName: 'agy',
+  binaryFallbacks: ['antigravity'],
   parseSessions: parseAntigravitySessions,
   extractContext: extractAntigravityContext,
-  nativeResumeArgs: () => [],
+  nativeResumeArgs: (s) => ['--conversation', s.id],
   crossToolArgs: (prompt) => [prompt],
-  resumeCommandDisplay: () => `antigravity`,
+  resumeCommandDisplay: (s) => `agy --conversation ${s.id} (or: antigravity --conversation ${s.id})`,
+  mapHandoffFlags: mapAntigravityFlags,
 });
 
 // ── Kimi CLI ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add Antigravity CLI session discovery from ~/.gemini/antigravity-cli/conversations/*.db
- extract CLI context from SQLite steps with read-only immutable access and best-effort protobuf/JSON string decoding
- update the Antigravity adapter to prefer agy, support native --conversation resume, and map handoff flags
- document the Antigravity CLI storage format and access recipe

## Validation

- pnpm test
- pnpm run build
- pnpm exec biome check src/parsers/antigravity.ts src/parsers/registry.ts src/__tests__/antigravity-parser.test.ts src/__tests__/forward-flags.test.ts

Note: pnpm run check still reports pre-existing unrelated Biome diagnostics outside this change set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class support for Antigravity CLI conversations from SQLite, extracting messages and tool activity without launching the IDE. Also switches the adapter to prefer `agy` with native `--conversation` resume and clearer flag mapping.

- **New Features**
  - Discover CLI sessions from `~/.gemini/antigravity-cli/conversations/*.db` and the CLI brain dir; IDE `conversations/*.pb` and state summaries remain supported.
  - Extract context from SQLite steps in read-only immutable mode via `node:sqlite`; decode protobuf/JSON strings to messages and tool activity; infer CWD from `cache/last_conversations.json` or file:// URIs; derive titles and step counts.
  - Adapter updates: prefer `agy` (fallback `antigravity`), support `--conversation <id>`, map auto-approve → `--dangerously-skip-permissions`, normalize `--sandbox`, and forward `--model` with warnings for unsupported approval/permission modes; registry now accepts `ANTIGRAVITY_CLI_HOME`. Docs updated for CLI storage/access; tests added for CLI parser and flag forwarding.

- **Migration**
  - Ensure `agy` is on PATH; `antigravity` remains a fallback.
  - If using a custom CLI home, set `ANTIGRAVITY_CLI_HOME` (parser also respects `GEMINI_CLI_HOME`).
  - Resume a session with: `agy --conversation <conversation-id>` (or `antigravity --conversation <conversation-id>`).

<sup>Written for commit f4e050eebbe030ce199371a0d23d9976dc225a74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

