### PR TITLE
feat(parsers): add Command Code CLI session support

### DIFF
--- a/src/__tests__/e2e-conversions.test.ts
+++ b/src/__tests__/e2e-conversions.test.ts
@@ -32,6 +32,7 @@ import {
   extractOpenCodeContext,
   extractQwenCodeContext,
   extractRooCodeContext,
+  extractCommandCodeContext,
   parseAmpSessions,
   parseAntigravitySessions,
   parseClaudeSessions,
@@ -48,6 +49,7 @@ import {
   parseOpenCodeSessions,
   parseQwenCodeSessions,
   parseRooCodeSessions,
+  parseCommandCodeSessions,
 } from '../parsers/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 import { WHICH_CMD } from '../utils/platform.js';
@@ -69,6 +71,7 @@ const ALL_SOURCES: SessionSource[] = [
   'antigravity',
   'kimi',
   'qwen-code',
+  'command-code',
 ];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
@@ -88,6 +91,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   antigravity: parseAntigravitySessions,
   kimi: parseKimiSessions,
   'qwen-code': parseQwenCodeSessions,
+  'command-code': parseCommandCodeSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -107,6 +111,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   antigravity: extractAntigravityContext,
   kimi: extractKimiContext,
   'qwen-code': extractQwenCodeContext,
+  'command-code': extractCommandCodeContext,
 };
 
 // Results directory
@@ -298,6 +303,7 @@ describe('E2E: 20 Cross-Tool Conversion Paths', () => {
           antigravity: 'Antigravity',
           kimi: 'Kimi CLI',
           'qwen-code': 'Qwen Code',
+          'command-code': 'Command Code',
         };
         const sourceLabel = sourceLabels[source];
 

--- a/src/__tests__/extract-handoffs.ts
+++ b/src/__tests__/extract-handoffs.ts
@@ -22,6 +22,7 @@ import {
   extractOpenCodeContext,
   extractQwenCodeContext,
   extractRooCodeContext,
+  extractCommandCodeContext,
   parseAmpSessions,
   parseAntigravitySessions,
   parseClaudeSessions,
@@ -38,6 +39,7 @@ import {
   parseOpenCodeSessions,
   parseQwenCodeSessions,
   parseRooCodeSessions,
+  parseCommandCodeSessions,
 } from '../parsers/index.js';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 
@@ -61,6 +63,7 @@ const ALL_SOURCES: SessionSource[] = [
   'antigravity',
   'kimi',
   'qwen-code',
+  'command-code',
 ];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
@@ -80,6 +83,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   antigravity: parseAntigravitySessions,
   kimi: parseKimiSessions,
   'qwen-code': parseQwenCodeSessions,
+  'command-code': parseCommandCodeSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -99,6 +103,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   antigravity: extractAntigravityContext,
   kimi: extractKimiContext,
   'qwen-code': extractQwenCodeContext,
+  'command-code': extractCommandCodeContext,
 };
 
 async function main() {

--- a/src/__tests__/fixtures/index.ts
+++ b/src/__tests__/fixtures/index.ts
@@ -1289,3 +1289,85 @@ export function createOpenCodeJsonFixture(): FixtureDir {
     cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
   };
 }
+
+export function createCommandCodeFixture(): FixtureDir {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'test-command-code-'));
+  const projectSlug = 'home-user-project';
+  const projectDir = path.join(root, projectSlug);
+  fs.mkdirSync(projectDir, { recursive: true });
+
+  const sessionId = 'aaaabbbb-cccc-4ddd-eeee-ffffffffffff';
+
+  fs.writeFileSync(
+    path.join(projectDir, `${sessionId}.meta.json`),
+    JSON.stringify({ title: 'Fix auth bug', model: 'claude-sonnet-4-5' }),
+  );
+
+  const lines = [
+    JSON.stringify({
+      id: '11111111-0000-0000-0000-000000000001',
+      timestamp: '2026-01-15T10:00:01.000Z',
+      sessionId,
+      parentId: null,
+      role: 'user',
+      content: [{ type: 'text', text: 'Fix the authentication bug in login.ts' }],
+      gitBranch: 'main',
+      metadata: { source: 'cli', version: 2 },
+    }),
+    JSON.stringify({
+      id: '11111111-0000-0000-0000-000000000002',
+      timestamp: '2026-01-15T10:00:05.000Z',
+      sessionId,
+      parentId: '11111111-0000-0000-0000-000000000001',
+      role: 'assistant',
+      content: [
+        { type: 'reasoning', text: 'I need to inspect login.ts first.' },
+        { type: 'text', text: 'I found the issue in login.ts. The token validation was missing.' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_001',
+          toolName: 'read_file',
+          input: { path: '/home/user/project/src/login.ts' },
+        },
+      ],
+      gitBranch: 'main',
+      metadata: { source: 'cli', version: 2 },
+    }),
+    JSON.stringify({
+      id: '11111111-0000-0000-0000-000000000003',
+      timestamp: '2026-01-15T10:00:10.000Z',
+      sessionId,
+      parentId: '11111111-0000-0000-0000-000000000002',
+      role: 'user',
+      content: [{ type: 'text', text: 'Great, please also add error handling' }],
+      gitBranch: 'main',
+      metadata: { source: 'cli', version: 2 },
+    }),
+    JSON.stringify({
+      id: '11111111-0000-0000-0000-000000000004',
+      timestamp: '2026-01-15T10:00:15.000Z',
+      sessionId,
+      parentId: '11111111-0000-0000-0000-000000000003',
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'Done. I added try-catch blocks and proper error messages.' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_002',
+          toolName: 'shell_command',
+          input: { command: 'npm test -- login' },
+        },
+      ],
+      gitBranch: 'main',
+      metadata: { source: 'cli', version: 2 },
+    }),
+  ];
+
+  fs.writeFileSync(path.join(projectDir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(projectDir, `${sessionId}.checkpoints.jsonl`), '');
+
+  return {
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -42,8 +42,8 @@ import { EDIT_TOOLS, READ_TOOLS, SHELL_TOOLS, TOOL_NAMES, WRITE_TOOLS } from '..
 // ── tool-names.ts ────────────────────────────────────────────────────────────
 
 describe('TOOL_NAMES', () => {
-  it('contains exactly 16 tools', () => {
-    expect(TOOL_NAMES).toHaveLength(16);
+  it('contains exactly 17 tools', () => {
+    expect(TOOL_NAMES).toHaveLength(17);
   });
 
   it('includes all known tools', () => {
@@ -64,6 +64,7 @@ describe('TOOL_NAMES', () => {
       'antigravity',
       'kimi',
       'qwen-code',
+      'command-code',
     ];
     expect([...TOOL_NAMES]).toEqual(expected);
   });

--- a/src/__tests__/unit-conversions.test.ts
+++ b/src/__tests__/unit-conversions.test.ts
@@ -24,6 +24,7 @@ import {
   createKimiFixture,
   createKiroFixture,
   createOpenCodeSqliteFixture,
+  createCommandCodeFixture,
   createQwenCodeFixture,
   createRooCodeFixture,
   type FixtureDir,
@@ -402,6 +403,36 @@ function parseKimiFixtureMessages(filePath: string): ConversationMessage[] {
   return messages;
 }
 
+function parseCommandCodeFixtureMessages(filePath: string): ConversationMessage[] {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.trim().split('\n');
+  const messages: ConversationMessage[] = [];
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed.role !== 'user' && parsed.role !== 'assistant') continue;
+
+      const text = (parsed.content || [])
+        .filter((c: any) => c?.type === 'text' && c?.text)
+        .map((c: any) => c.text)
+        .join('\n');
+
+      if (!text) continue;
+
+      messages.push({
+        role: parsed.role as 'user' | 'assistant',
+        content: text,
+        timestamp: parsed.timestamp ? new Date(parsed.timestamp) : undefined,
+      });
+    } catch {
+      /* skip */
+    }
+  }
+
+  return messages;
+}
+
 function parseQwenCodeFixtureMessages(filePath: string): ConversationMessage[] {
   const content = fs.readFileSync(filePath, 'utf8');
   const lines = content.trim().split('\n');
@@ -460,6 +491,7 @@ beforeAll(() => {
   fixtures.antigravity = createAntigravityFixture();
   fixtures['qwen-code'] = createQwenCodeFixture();
   fixtures.crush = createCrushFixture();
+  fixtures['command-code'] = createCommandCodeFixture();
 
   // Build contexts from fixtures
   const now = new Date();
@@ -906,6 +938,35 @@ beforeAll(() => {
     toolSummaries: [],
     markdown: generateHandoffMarkdown(qwenCodeSession, qwenCodeMsgs, [], [], []),
   };
+
+  // CommandCode
+  const commandCodeJsonl = fs
+    .readdirSync(fixtures['command-code'].root, { recursive: true })
+    .map((f) => path.join(fixtures['command-code'].root, f as string))
+    .find((f) => f.endsWith('.jsonl') && !f.endsWith('.checkpoints.jsonl'))!;
+  const commandCodeSession: UnifiedSession = {
+    id: 'aaaabbbb-cccc-4ddd-eeee-ffffffffffff',
+    source: 'command-code',
+    cwd: '/home/user/project',
+    repo: 'user/project',
+    branch: 'main',
+    lines: 4,
+    bytes: fs.statSync(commandCodeJsonl).size,
+    createdAt: now,
+    updatedAt: now,
+    originalPath: commandCodeJsonl,
+    summary: 'Fix auth bug',
+    model: 'claude-sonnet-4-5',
+  };
+  const commandCodeMsgs = parseCommandCodeFixtureMessages(commandCodeJsonl);
+  contexts['command-code'] = {
+    session: commandCodeSession,
+    recentMessages: commandCodeMsgs,
+    filesModified: [],
+    pendingTasks: [],
+    toolSummaries: [],
+    markdown: generateHandoffMarkdown(commandCodeSession, commandCodeMsgs, [], [], []),
+  };
 });
 
 afterAll(() => {
@@ -1049,6 +1110,35 @@ describe('Low-Level Fixture Parsing', () => {
     for (const msg of msgs) {
       expect(msg.content).not.toContain('tool_use');
       expect(msg.content).not.toContain('tool_result');
+    }
+  });
+
+  it('CommandCode: extracts user and assistant text messages from JSONL', () => {
+    const msgs = contexts['command-code'].recentMessages;
+    expect(msgs.length).toBe(4);
+    expect(msgs[0].role).toBe('user');
+    expect(msgs[0].content).toContain('Fix the authentication bug');
+    expect(msgs[1].role).toBe('assistant');
+    expect(msgs[1].content).toContain('token validation was missing');
+  });
+
+  it('CommandCode: joins multiple text blocks into single message content', () => {
+    // The fixture assistant message has reasoning + text blocks; only text blocks should be joined
+    const msgs = contexts['command-code'].recentMessages;
+    const assistantMsgs = msgs.filter((m) => m.role === 'assistant');
+    expect(assistantMsgs.length).toBe(2);
+    // reasoning block should NOT appear in content
+    for (const msg of assistantMsgs) {
+      expect(msg.content).not.toContain('I need to inspect login.ts first');
+    }
+  });
+
+  it('CommandCode: skips tool-call and tool-result blocks from message content', () => {
+    const msgs = contexts['command-code'].recentMessages;
+    for (const msg of msgs) {
+      expect(msg.content).not.toContain('tool-call');
+      expect(msg.content).not.toContain('tool-result');
+      expect(msg.content).not.toContain('toolCallId');
     }
   });
 });

--- a/src/parsers/command-code.ts
+++ b/src/parsers/command-code.ts
@@ -1,0 +1,190 @@
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
+import { logger } from '../logger.js';
+import type { ConversationMessage, SessionContext, UnifiedSession } from '../types/index.js';
+import { listSubdirectories } from '../utils/fs-helpers.js';
+import { getFileStats, scanJsonlFile } from '../utils/jsonl.js';
+import { generateHandoffMarkdown } from '../utils/markdown.js';
+import { cleanSummary, extractRepo, homeDir } from '../utils/parser-helpers.js';
+import { cwdFromSlug } from '../utils/slug.js';
+import { fileSummary, SummaryCollector, shellSummary } from '../utils/tool-summarizer.js';
+
+const COMMAND_CODE_HOME =
+  process.env.COMMAND_CODE_HOME ?? path.join(homeDir(), '.commandcode');
+const PROJECTS_DIR = path.join(COMMAND_CODE_HOME, 'projects');
+
+interface CommandCodeMeta {
+  title?: string;
+  model?: string;
+}
+
+interface CommandCodeContentBlock {
+  type: string;
+  text?: string;
+  toolName?: string;
+  toolCallId?: string;
+  input?: Record<string, unknown>;
+}
+
+interface CommandCodeRecord {
+  id?: string;
+  sessionId?: string;
+  timestamp?: string;
+  role?: string;
+  content?: CommandCodeContentBlock[];
+  gitBranch?: string;
+}
+
+async function readMeta(metaPath: string): Promise<CommandCodeMeta> {
+  try {
+    const raw = await fsp.readFile(metaPath, 'utf8');
+    return JSON.parse(raw) as CommandCodeMeta;
+  } catch {
+    return {};
+  }
+}
+
+function joinTextBlocks(content: CommandCodeContentBlock[]): string {
+  return content
+    .filter((b) => b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text as string)
+    .join('\n')
+    .trim();
+}
+
+export async function parseCommandCodeSessions(): Promise<UnifiedSession[]> {
+  const sessions: UnifiedSession[] = [];
+
+  let projectDirs: string[];
+  try {
+    projectDirs = listSubdirectories(PROJECTS_DIR);
+  } catch {
+    return sessions;
+  }
+
+  for (const projectDir of projectDirs) {
+    const slug = path.basename(projectDir);
+    const cwd = cwdFromSlug(slug);
+
+    let entries: string[];
+    try {
+      const all = await fsp.readdir(projectDir);
+      entries = all.filter((f) => f.endsWith('.jsonl') && !f.endsWith('.checkpoints.jsonl'));
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const sessionId = path.basename(entry, '.jsonl');
+      const jsonlPath = path.join(projectDir, entry);
+      const metaPath = path.join(projectDir, `${sessionId}.meta.json`);
+
+      try {
+        const [stats, meta] = await Promise.all([getFileStats(jsonlPath), readMeta(metaPath)]);
+
+        let branch: string | undefined;
+        let firstTimestamp: Date | undefined;
+        let lastTimestamp: Date | undefined;
+
+        await scanJsonlFile(jsonlPath, (parsed) => {
+          const rec = parsed as CommandCodeRecord;
+          if (rec.gitBranch && !branch) branch = rec.gitBranch;
+          if (rec.timestamp) {
+            const ts = new Date(rec.timestamp);
+            if (!firstTimestamp) firstTimestamp = ts;
+            lastTimestamp = ts;
+          }
+          return 'continue';
+        });
+
+        const createdAt = firstTimestamp ?? new Date(0);
+        const updatedAt = lastTimestamp ?? createdAt;
+        const summary = cleanSummary(meta.title ?? `CommandCode session ${sessionId.slice(0, 8)}`, 80);
+
+        sessions.push({
+          id: sessionId,
+          source: 'command-code',
+          cwd,
+          repo: extractRepo({ cwd }),
+          branch,
+          lines: stats.lines,
+          bytes: stats.bytes,
+          createdAt,
+          updatedAt,
+          originalPath: jsonlPath,
+          summary,
+          model: meta.model,
+        });
+      } catch (err) {
+        logger.debug('command-code: failed to parse session', jsonlPath, err);
+      }
+    }
+  }
+
+  return sessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}
+
+export async function extractCommandCodeContext(
+  session: UnifiedSession,
+  config?: VerbosityConfig,
+): Promise<SessionContext> {
+  const resolvedConfig = config ?? getPreset('default');
+  const messages: ConversationMessage[] = [];
+  const collector = new SummaryCollector(resolvedConfig);
+
+  await scanJsonlFile(session.originalPath, (parsed) => {
+    const rec = parsed as CommandCodeRecord;
+    if (!rec.role || !Array.isArray(rec.content)) return 'continue';
+
+    const timestamp = rec.timestamp ? new Date(rec.timestamp) : undefined;
+
+    if (rec.role === 'user' || rec.role === 'assistant') {
+      const text = joinTextBlocks(rec.content);
+      if (text) {
+        messages.push({ role: rec.role as 'user' | 'assistant', content: text, timestamp });
+      }
+    }
+
+    for (const block of rec.content) {
+      if (block.type !== 'tool-call' || !block.toolName) continue;
+      const input = block.input ?? {};
+      const toolName = block.toolName;
+
+      if (toolName === 'shell_command' || toolName === 'execute_command' || toolName === 'run_command') {
+        const command = (input.command ?? input.cmd ?? '') as string;
+        if (command) {
+          collector.add(toolName, shellSummary(command), { data: { category: 'shell', command } });
+        }
+      } else {
+        const filePath = (input.path ?? input.file_path ?? input.filePath ?? '') as string;
+        if (filePath) {
+          const isWrite = /write|edit|patch|create/i.test(toolName);
+          collector.add(toolName, fileSummary(isWrite ? 'edit' : 'read', filePath), {
+            data: { category: isWrite ? 'edit' : 'read', filePath },
+            filePath,
+            isWrite,
+          });
+        }
+      }
+    }
+    return 'continue';
+  });
+
+  const maxMessages = resolvedConfig.recentMessages ?? 10;
+  const recentMessages = messages.slice(-maxMessages);
+  const filesModified = collector.getFilesModified();
+  const toolSummaries = collector.getSummaries();
+
+  const markdown = generateHandoffMarkdown(session, recentMessages, filesModified, [], toolSummaries);
+
+  return {
+    session,
+    recentMessages,
+    filesModified,
+    pendingTasks: [],
+    toolSummaries,
+    markdown,
+  };
+}

--- a/src/parsers/command-code.ts
+++ b/src/parsers/command-code.ts
@@ -130,7 +130,7 @@ export async function extractCommandCodeContext(
   session: UnifiedSession,
   config?: VerbosityConfig,
 ): Promise<SessionContext> {
-  const resolvedConfig = config ?? getPreset('default');
+  const resolvedConfig = config ?? getPreset('standard');
   const messages: ConversationMessage[] = [];
   const collector = new SummaryCollector(resolvedConfig);
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -19,5 +19,6 @@ export { extractKimiContext, parseKimiSessions } from './kimi.js';
 export { extractKiroContext, parseKiroSessions } from './kiro.js';
 export { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
 export { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
+export { extractCommandCodeContext, parseCommandCodeSessions } from './command-code.js';
 export type { ToolAdapter } from './registry.js';
 export { ALL_TOOLS, adapters, SOURCE_HELP } from './registry.js';

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -30,6 +30,7 @@ import { extractKimiContext, parseKimiSessions } from './kimi.js';
 import { extractKiroContext, parseKiroSessions } from './kiro.js';
 import { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
 import { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
+import { extractCommandCodeContext, parseCommandCodeSessions } from './command-code.js';
 
 /**
  * Adapter interface — single contract for all supported CLI tools.
@@ -937,6 +938,22 @@ register({
   crossToolArgs: (prompt) => [prompt],
   resumeCommandDisplay: (s) => `qwen --resume ${s.id}`,
   mapHandoffFlags: mapGeminiFlags,
+});
+
+// ── Command Code ──────────────────────────────────────────────────────
+register({
+  name: 'command-code',
+  label: 'Command Code',
+  color: chalk.hex('#F97316'),
+  storagePath: '~/.commandcode/projects/*/',
+  envVar: 'COMMAND_CODE_HOME',
+  binaryName: 'cmdc',
+  binaryFallbacks: ['cmd', 'command-code', 'commandcode'],
+  parseSessions: parseCommandCodeSessions,
+  extractContext: extractCommandCodeContext,
+  nativeResumeArgs: (s) => ['--resume', s.id],
+  crossToolArgs: (prompt) => [prompt],
+  resumeCommandDisplay: (s) => `cmdc --resume ${s.id}`,
 });
 
 // ── Completeness assertion ──────────────────────────────────────────

--- a/src/types/tool-names.ts
+++ b/src/types/tool-names.ts
@@ -21,6 +21,7 @@ export const TOOL_NAMES = Object.freeze([
   'antigravity',
   'kimi',
   'qwen-code',
+  'command-code',
 ] as const);
 
 /** Source CLI tool — derived from TOOL_NAMES, never defined manually */


### PR DESCRIPTION
## Summary

- Add `command-code` (installable via `npm i -g command-code`) as the 17th supported tool
- Discover sessions from `~/.commandcode/projects/<cwd-slug>/<uuid>.jsonl` + `<uuid>.meta.json`
- Extract user/assistant messages by joining `text` content blocks (skip `reasoning`, `tool-call`, `tool-result`)
- Summarize `shell_command` and file tool calls via `SummaryCollector`
- Registry: `binaryName=cmdc`, fallbacks `[cmd, command-code, commandcode]`, native resume via `--resume <session-id>`
- CWD derived from project directory slug via existing `cwdFromSlug` utility

## Storage format (verified against real session data)

- Root: `~/.commandcode/projects/<cwd-slug>/`
- Per session: `<uuid>.jsonl`, `<uuid>.meta.json`, `<uuid>.checkpoints.jsonl`
- JSONL record: `{id, sessionId, timestamp, role, content: [{type, text}], gitBranch, metadata}`
- Content types: `text`, `reasoning`, `tool-call`, `tool-result`
- Tool-call block: `{type: "tool-call", toolCallId, toolName, input}`
- Meta: `{title?, model?}`

## Test plan

- [x] `pnpm test` — 984 tests pass, 0 failures
- [x] `pnpm run build` — TypeScript compiles clean
- [x] Fixture covers: session discovery, message extraction, text block joining, reasoning skip, tool-call skip
- [x] `schemas.test.ts` updated (count 16→17, list includes `command-code`)
- [x] All cross-tool conversion paths covered via `ALL_TOOLS` auto-derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `command-code` CLI session support as the 17th tool. Parses local JSONL sessions into clean chat history, summarizes tool usage, and uses the standard verbosity preset for consistent handoffs.

- **New Features**
  - Discover sessions in `~/.commandcode/projects/<cwd-slug>/<uuid>.jsonl` with `<uuid>.meta.json`.
  - Extract only user/assistant text; skip `reasoning`, `tool-call`, and `tool-result`.
  - Summarize `shell_command` and file ops via `SummaryCollector`.
  - Derive `cwd` from slug, repo from `cwd`, branch/timestamps from records; read model/title from meta.
  - Register adapter: binary `cmdc` (fallbacks: `cmd`, `command-code`, `commandcode`), resume with `--resume <session-id>`.
  - Add fixtures and tests; update tool count to 17 and include `command-code` in cross-tool conversions.

- **Bug Fixes**
  - Use the `standard` verbosity preset for context extraction to align with other parsers.

<sup>Written for commit 4bb532833a40eb0b40d3ef9cc1f1df85f83c43bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

