### PR TITLE
fix(Antigravity): Add binaryFallbacks for antigravity parser

### DIFF
--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -894,6 +894,7 @@ register({
   // is unset, so changes to that var must also invalidate the index cache.
   extraEnvVars: ['GEMINI_CLI_HOME', 'ANTIGRAVITY_STATE_DB'],
   binaryName: 'antigravity',
+  binaryFallbacks: ['agy'],
   parseSessions: parseAntigravitySessions,
   extractContext: extractAntigravityContext,
   nativeResumeArgs: () => [],


### PR DESCRIPTION
# Summary
 - Updated registery.ts to include `agy` as a binary fallback for antigravity.
 - Fixes `Error: Tool not available: Antigravity. Is it installed and on your PATH?` error.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yigitkonur/cli-continues/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `agy` as a binary fallback for the Antigravity parser so the CLI can detect the tool when installed under that name, fixing "Tool not available: Antigravity" PATH errors.

<sup>Written for commit a9cf242f9043f85a559ca63f8a739d75b866028a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

