### PR TITLE
feat: add Oh My Pi support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Added
+
+- **Oh My Pi support** — added OMP JSONL session discovery, parsing, handoff extraction, native resume targeting, README coverage, and parser regression tests.
+
 ## [4.1.0] - 2026-03-02
 
 ### Session Origin Tracking

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ https://github.com/user-attachments/assets/6945f3a5-bd19-45ab-9702-6df8e165a734
 
 ## Supported tools
 
-16 AI coding agents, any-to-any handoff:
+17 AI coding agents, any-to-any handoff:
 
-**Claude Code** · **Codex** · **GitHub Copilot CLI** · **Gemini CLI** · **Cursor** · **Amp** · **Cline** · **Roo Code** · **Kilo Code** · **Kiro** · **Crush** · **OpenCode** · **Factory Droid** · **Antigravity** · **Kimi CLI** · **Qwen Code**
+**Claude Code** · **Codex** · **GitHub Copilot CLI** · **Gemini CLI** · **Cursor** · **Amp** · **Cline** · **Roo Code** · **Kilo Code** · **Kiro** · **Crush** · **OpenCode** · **Oh My Pi** · **Factory Droid** · **Antigravity** · **Kimi CLI** · **Qwen Code**
 
-That's 240 cross-tool handoff paths. Pick any source, pick any destination — it works.
+That's 272 cross-tool handoff paths. Pick any source, pick any destination — it works.
 
 ## Install
 
@@ -194,6 +194,7 @@ Every tool stores sessions differently — different formats, different schemas,
 | Antigravity | PB + brain artifacts + optional live RPC | `~/.gemini/antigravity/` |
 | Kimi CLI | JSONL + JSON | `~/.kimi/sessions/` |
 | Qwen Code | JSONL | `~/.qwen/projects/*/chats/` |
+| Oh My Pi | JSONL | `$PI_CODING_AGENT_DIR/sessions/` (default: `~/.omp/agent/sessions/`) |
 
 All reads are **read-only** — `continues` never modifies your session files. Index cached at `~/.continues/sessions.jsonl` (5-min TTL, auto-refresh).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continues",
   "version": "4.1.1",
-  "description": "Never lose context. Resume any AI coding session across Claude Code, Codex, Copilot, Gemini CLI, Cursor, Amp, Cline, Roo Code, Kilo Code, Kiro, Crush, OpenCode, Droid & Antigravity.",
+  "description": "Never lose context. Resume any AI coding session across Claude Code, Codex, Copilot, Gemini CLI, Cursor, Amp, Cline, Roo Code, Kilo Code, Kiro, Crush, OpenCode, Oh My Pi, Droid & Antigravity.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/src/__tests__/e2e-conversions.test.ts
+++ b/src/__tests__/e2e-conversions.test.ts
@@ -29,6 +29,7 @@ import {
   extractKiloCodeContext,
   extractKimiContext,
   extractKiroContext,
+  extractOmpContext,
   extractOpenCodeContext,
   extractQwenCodeContext,
   extractRooCodeContext,
@@ -45,6 +46,7 @@ import {
   parseKiloCodeSessions,
   parseKimiSessions,
   parseKiroSessions,
+  parseOmpSessions,
   parseOpenCodeSessions,
   parseQwenCodeSessions,
   parseRooCodeSessions,
@@ -69,6 +71,7 @@ const ALL_SOURCES: SessionSource[] = [
   'antigravity',
   'kimi',
   'qwen-code',
+  'omp',
 ];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
@@ -88,6 +91,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   antigravity: parseAntigravitySessions,
   kimi: parseKimiSessions,
   'qwen-code': parseQwenCodeSessions,
+  omp: parseOmpSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -107,6 +111,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   antigravity: extractAntigravityContext,
   kimi: extractKimiContext,
   'qwen-code': extractQwenCodeContext,
+  omp: extractOmpContext,
 };
 
 // Results directory
@@ -298,6 +303,7 @@ describe('E2E: 20 Cross-Tool Conversion Paths', () => {
           antigravity: 'Antigravity',
           kimi: 'Kimi CLI',
           'qwen-code': 'Qwen Code',
+          omp: 'Oh My Pi',
         };
         const sourceLabel = sourceLabels[source];
 

--- a/src/__tests__/extract-handoffs.ts
+++ b/src/__tests__/extract-handoffs.ts
@@ -19,6 +19,7 @@ import {
   extractKiloCodeContext,
   extractKimiContext,
   extractKiroContext,
+  extractOmpContext,
   extractOpenCodeContext,
   extractQwenCodeContext,
   extractRooCodeContext,
@@ -35,6 +36,7 @@ import {
   parseKiloCodeSessions,
   parseKimiSessions,
   parseKiroSessions,
+  parseOmpSessions,
   parseOpenCodeSessions,
   parseQwenCodeSessions,
   parseRooCodeSessions,
@@ -61,6 +63,7 @@ const ALL_SOURCES: SessionSource[] = [
   'antigravity',
   'kimi',
   'qwen-code',
+  'omp',
 ];
 
 const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
@@ -80,6 +83,7 @@ const parsers: Record<SessionSource, () => Promise<UnifiedSession[]>> = {
   antigravity: parseAntigravitySessions,
   kimi: parseKimiSessions,
   'qwen-code': parseQwenCodeSessions,
+  omp: parseOmpSessions,
 };
 
 const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionContext>> = {
@@ -99,6 +103,7 @@ const extractors: Record<SessionSource, (s: UnifiedSession) => Promise<SessionCo
   antigravity: extractAntigravityContext,
   kimi: extractKimiContext,
   'qwen-code': extractQwenCodeContext,
+  omp: extractOmpContext,
 };
 
 async function main() {

--- a/src/__tests__/fixtures/index.ts
+++ b/src/__tests__/fixtures/index.ts
@@ -1202,6 +1202,84 @@ export function createQwenCodeFixture(): FixtureDir {
 }
 
 /**
+ * Create a temporary directory with Oh My Pi session fixtures
+ */
+export function createOmpFixture(): FixtureDir {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'test-omp-'));
+  const projectDir = path.join(root, 'sessions', '-home-user-project');
+  fs.mkdirSync(projectDir, { recursive: true });
+
+  const sessionFile = path.join(projectDir, '2026-01-15T10-00-00-000Z_test-omp-session-1.jsonl');
+  const lines = [
+    JSON.stringify({
+      type: 'session',
+      version: 3,
+      id: 'test-omp-session-1',
+      timestamp: '2026-01-15T10:00:00.000Z',
+      cwd: '/home/user/project',
+      title: 'Fix auth bug',
+    }),
+    JSON.stringify({
+      type: 'model_change',
+      id: 'model-1',
+      timestamp: '2026-01-15T10:00:00.500Z',
+      model: 'openai-codex/gpt-5.5',
+    }),
+    JSON.stringify({
+      type: 'message',
+      id: 'user-1',
+      parentId: 'model-1',
+      timestamp: '2026-01-15T10:00:01.000Z',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Fix the authentication bug in login.ts' }],
+      },
+    }),
+    JSON.stringify({
+      type: 'message',
+      id: 'assistant-1',
+      parentId: 'user-1',
+      timestamp: '2026-01-15T10:00:05.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I found the issue in login.ts. The token validation was missing.' }],
+        provider: 'openai-codex',
+        model: 'gpt-5.5',
+      },
+    }),
+    JSON.stringify({
+      type: 'message',
+      id: 'user-2',
+      parentId: 'assistant-1',
+      timestamp: '2026-01-15T10:00:10.000Z',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Great, please also add error handling' }],
+      },
+    }),
+    JSON.stringify({
+      type: 'message',
+      id: 'assistant-2',
+      parentId: 'user-2',
+      timestamp: '2026-01-15T10:00:15.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Done. I added try-catch blocks and proper error messages.' }],
+        provider: 'openai-codex',
+        model: 'gpt-5.5',
+      },
+    }),
+  ];
+
+  fs.writeFileSync(sessionFile, lines.join('\n') + '\n');
+
+  return {
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+/**
  * Create OpenCode JSON-only fixture (legacy format)
  */
 export function createOpenCodeJsonFixture(): FixtureDir {

--- a/src/__tests__/omp-parser.test.ts
+++ b/src/__tests__/omp-parser.test.ts
@@ -1,0 +1,295 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type * as OmpParser from '../parsers/omp.js';
+import type { UnifiedSession } from '../types/index.js';
+
+const tempDirs: string[] = [];
+
+function makeOmpAgentDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'omp-parser-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeOmpSession(agentDir: string, projectSlug: string, filename: string, rows: unknown[]): string {
+  const targetDir = path.join(agentDir, 'sessions', projectSlug);
+  fs.mkdirSync(targetDir, { recursive: true });
+  const fullPath = path.join(targetDir, filename);
+  fs.writeFileSync(fullPath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+  return fullPath;
+}
+
+async function loadOmpParser(agentDir: string): Promise<typeof OmpParser> {
+  vi.resetModules();
+  vi.stubEnv('PI_CODING_AGENT_DIR', agentDir);
+  return import('../parsers/omp.js');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe('omp parser', () => {
+  it('discovers Oh My Pi sessions from PI_CODING_AGENT_DIR project folders', async () => {
+    const agentDir = makeOmpAgentDir();
+    writeOmpSession(agentDir, '-tmp-project', '2026-07-16T10-38-55-184Z_019f6a82-test-session.jsonl', [
+      {
+        type: 'title',
+        v: 1,
+        title: 'Fix parser edge cases',
+        source: 'auto',
+        updatedAt: '2026-07-16T10:39:34.876Z',
+      },
+      {
+        type: 'session',
+        version: 3,
+        id: '019f6a82-test-session',
+        timestamp: '2026-07-16T10:38:55.184Z',
+        cwd: '/tmp/project',
+        title: 'Fix parser edge cases',
+      },
+      {
+        type: 'model_change',
+        id: 'model-1',
+        parentId: null,
+        timestamp: '2026-07-16T10:38:56.000Z',
+        model: 'openai-codex/gpt-5.5',
+      },
+      {
+        type: 'message',
+        id: 'user-1',
+        parentId: 'model-1',
+        timestamp: '2026-07-16T10:39:08.530Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Please fix the parser.' }],
+        },
+      },
+    ]);
+
+    const { parseOmpSessions } = await loadOmpParser(agentDir);
+    const sessions = await parseOmpSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: '019f6a82-test-session',
+      source: 'omp',
+      cwd: '/tmp/project',
+      summary: 'Fix parser edge cases',
+      model: 'openai-codex/gpt-5.5',
+      originalPath: expect.stringContaining('2026-07-16T10-38-55-184Z_019f6a82-test-session.jsonl'),
+    });
+    expect(sessions[0]?.createdAt.toISOString()).toBe('2026-07-16T10:38:55.184Z');
+    expect(sessions[0]?.updatedAt.toISOString()).toBe('2026-07-16T10:39:34.876Z');
+  });
+
+  it('keeps lightweight session ordering based on latest header metadata timestamp', async () => {
+    const agentDir = makeOmpAgentDir();
+    writeOmpSession(agentDir, '-tmp-project', '2026-07-16T10-00-00-000Z_older-created-active.jsonl', [
+      {
+        type: 'title',
+        v: 1,
+        title: 'Active OMP session',
+        updatedAt: '2026-07-16T10:59:00.000Z',
+      },
+      {
+        type: 'session',
+        version: 3,
+        id: 'older-created-active',
+        timestamp: '2026-07-16T10:00:00.000Z',
+        cwd: '/tmp/project',
+        title: 'Active OMP session',
+      },
+    ]);
+    writeOmpSession(agentDir, '-tmp-project', '2026-07-16T10-30-00-000Z_newer-created-stale.jsonl', [
+      {
+        type: 'title',
+        v: 1,
+        title: 'Stale OMP session',
+        updatedAt: '2026-07-16T10:30:00.000Z',
+      },
+      {
+        type: 'session',
+        version: 3,
+        id: 'newer-created-stale',
+        timestamp: '2026-07-16T10:30:00.000Z',
+        cwd: '/tmp/project',
+        title: 'Stale OMP session',
+      },
+    ]);
+
+    const { parseOmpSessions } = await loadOmpParser(agentDir);
+    const sessions = await parseOmpSessions({ lightweight: true });
+
+    expect(sessions.map((session) => session.id)).toEqual(['older-created-active', 'newer-created-stale']);
+    expect(sessions[0]?.updatedAt.toISOString()).toBe('2026-07-16T10:59:00.000Z');
+  });
+
+  it('extracts OMP messages, tool activity, model notes, token usage, and lifecycle', async () => {
+    const agentDir = makeOmpAgentDir();
+    const originalPath = writeOmpSession(
+      agentDir,
+      '-tmp-project',
+      '2026-07-16T10-38-55-184Z_019f6a82-context-session.jsonl',
+      [
+        {
+          type: 'session',
+          version: 3,
+          id: '019f6a82-context-session',
+          timestamp: '2026-07-16T10:38:55.184Z',
+          cwd: '/tmp/project',
+          title: 'Add OMP support',
+        },
+        {
+          type: 'model_change',
+          id: 'model-1',
+          timestamp: '2026-07-16T10:38:55.255Z',
+          model: 'openai-codex/gpt-5.5',
+        },
+        {
+          type: 'thinking_level_change',
+          id: 'thinking-1',
+          parentId: 'model-1',
+          timestamp: '2026-07-16T10:39:08.526Z',
+          thinkingLevel: 'high',
+          configured: 'auto',
+        },
+        {
+          type: 'message',
+          id: 'user-1',
+          parentId: 'thinking-1',
+          timestamp: '2026-07-16T10:39:08.530Z',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'Add support for OMP sessions.' }],
+          },
+        },
+        {
+          type: 'message',
+          id: 'assistant-1',
+          parentId: 'user-1',
+          timestamp: '2026-07-16T10:39:12.871Z',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: '**Planning parser changes**' },
+              {
+                type: 'toolCall',
+                id: 'call-read',
+                name: 'read',
+                arguments: { i: 'Reading package', path: 'package.json' },
+              },
+            ],
+            provider: 'openai-codex',
+            model: 'gpt-5.5',
+            usage: {
+              input: 100,
+              output: 40,
+              cacheRead: 12,
+              cacheWrite: 3,
+              reasoningTokens: 7,
+            },
+          },
+        },
+        {
+          type: 'custom',
+          customType: 'tool_execution_start',
+          data: {
+            toolCallId: 'call-read',
+            toolName: 'read',
+            startedAt: '2026-07-16T10:39:12.872Z',
+            args: { path: 'package.json' },
+            intent: 'Reading package',
+          },
+          id: 'tool-start-1',
+          parentId: 'assistant-1',
+          timestamp: '2026-07-16T10:39:12.872Z',
+        },
+        {
+          type: 'message',
+          id: 'tool-result-1',
+          parentId: 'tool-start-1',
+          timestamp: '2026-07-16T10:39:12.876Z',
+          message: {
+            role: 'toolResult',
+            toolCallId: 'call-read',
+            toolName: 'read',
+            content: [{ type: 'text', text: '[package.json#ABCD]\n1:{"name":"demo"}' }],
+            isError: false,
+          },
+        },
+        {
+          type: 'message',
+          id: 'assistant-2',
+          parentId: 'tool-result-1',
+          timestamp: '2026-07-16T10:39:47.170Z',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Implemented the parser.' }],
+            provider: 'openai-codex',
+            model: 'gpt-5.5',
+          },
+        },
+        {
+          type: 'custom',
+          customType: 'session_exit',
+          data: { reason: 'dispose', kind: 'normal', recordedAt: '2026-07-16T10:39:52.772Z' },
+          id: 'exit-1',
+          parentId: 'assistant-2',
+          timestamp: '2026-07-16T10:39:52.772Z',
+        },
+      ],
+    );
+
+    const { extractOmpContext } = await loadOmpParser(agentDir);
+    const session: UnifiedSession = {
+      id: '019f6a82-context-session',
+      source: 'omp',
+      cwd: '/tmp/project',
+      lines: 9,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-07-16T10:38:55.184Z'),
+      updatedAt: new Date('2026-07-16T10:39:52.772Z'),
+      originalPath,
+      summary: 'Add OMP support',
+      model: 'openai-codex/gpt-5.5',
+    };
+
+    const context = await extractOmpContext(session);
+
+    expect(context.recentMessages.map((message) => [message.role, message.content])).toEqual([
+      ['user', 'Add support for OMP sessions.'],
+      ['assistant', 'Implemented the parser.'],
+    ]);
+    expect(context.toolSummaries).toEqual([
+      expect.objectContaining({
+        name: 'Read',
+        count: 1,
+        samples: [expect.objectContaining({ summary: 'read package.json' })],
+      }),
+    ]);
+    expect(context.sessionNotes?.model).toBe('openai-codex/gpt-5.5');
+    expect(context.sessionNotes?.sourceMetadata).toMatchObject({
+      sessionId: '019f6a82-context-session',
+      cliVersion: 'v3',
+      provider: 'openai-codex',
+      thinkingLevel: 'high',
+    });
+    expect(context.sessionNotes?.tokenUsage).toEqual({ input: 100, output: 40 });
+    expect(context.sessionNotes?.cacheTokens).toEqual({ creation: 3, read: 12 });
+    expect(context.sessionNotes?.thinkingTokens).toBe(7);
+    expect(context.sessionNotes?.lifecycle).toEqual([
+      expect.objectContaining({ type: 'session_exit', timestamp: '2026-07-16T10:39:52.772Z' }),
+    ]);
+    expect(context.timeline?.map((event) => event.kind)).toContain('tool_call');
+    expect(context.markdown).toContain('| **Source** | Oh My Pi |');
+    expect(context.markdown).toContain('Add support for OMP sessions.');
+  });
+});

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -42,8 +42,8 @@ import { EDIT_TOOLS, READ_TOOLS, SHELL_TOOLS, TOOL_NAMES, WRITE_TOOLS } from '..
 // ── tool-names.ts ────────────────────────────────────────────────────────────
 
 describe('TOOL_NAMES', () => {
-  it('contains exactly 16 tools', () => {
-    expect(TOOL_NAMES).toHaveLength(16);
+  it('contains exactly 17 tools', () => {
+    expect(TOOL_NAMES).toHaveLength(17);
   });
 
   it('includes all known tools', () => {
@@ -64,6 +64,7 @@ describe('TOOL_NAMES', () => {
       'antigravity',
       'kimi',
       'qwen-code',
+      'omp',
     ];
     expect([...TOOL_NAMES]).toEqual(expected);
   });

--- a/src/__tests__/unit-conversions.test.ts
+++ b/src/__tests__/unit-conversions.test.ts
@@ -23,6 +23,7 @@ import {
   createKiloCodeFixture,
   createKimiFixture,
   createKiroFixture,
+  createOmpFixture,
   createOpenCodeSqliteFixture,
   createQwenCodeFixture,
   createRooCodeFixture,
@@ -432,6 +433,34 @@ function parseQwenCodeFixtureMessages(filePath: string): ConversationMessage[] {
   return messages;
 }
 
+function parseOmpFixtureMessages(filePath: string): ConversationMessage[] {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.trim().split('\n');
+  const messages: ConversationMessage[] = [];
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as {
+        type?: string;
+        timestamp?: string;
+        message?: { role?: string; content?: Array<{ type?: string; text?: string }> };
+      };
+      if (parsed.type !== 'message') continue;
+      const role = parsed.message?.role;
+      if (role !== 'user' && role !== 'assistant') continue;
+      const text = (parsed.message?.content ?? [])
+        .filter((block) => block.type === 'text' && block.text)
+        .map((block) => block.text)
+        .join('\n');
+      if (text) messages.push({ role, content: text, timestamp: new Date(parsed.timestamp ?? 0) });
+    } catch {
+      /* skip */
+    }
+  }
+
+  return messages;
+}
+
 // ─── Fixture Data ────────────────────────────────────────────────────────────
 
 // Derive from registry — automatically picks up new tools
@@ -459,6 +488,7 @@ beforeAll(() => {
   fixtures['kilo-code'] = createKiloCodeFixture();
   fixtures.antigravity = createAntigravityFixture();
   fixtures['qwen-code'] = createQwenCodeFixture();
+  fixtures.omp = createOmpFixture();
   fixtures.crush = createCrushFixture();
 
   // Build contexts from fixtures
@@ -905,6 +935,34 @@ beforeAll(() => {
     pendingTasks: [],
     toolSummaries: [],
     markdown: generateHandoffMarkdown(qwenCodeSession, qwenCodeMsgs, [], [], []),
+  };
+
+  // OMP
+  const ompFile = fs
+    .readdirSync(fixtures.omp.root, { recursive: true })
+    .map((f) => path.join(fixtures.omp.root, f as string))
+    .find((f) => f.endsWith('.jsonl'))!;
+  const ompSession: UnifiedSession = {
+    id: 'test-omp-session-1',
+    source: 'omp',
+    cwd: '/home/user/project',
+    repo: 'user/project',
+    lines: 6,
+    bytes: fs.statSync(ompFile).size,
+    createdAt: now,
+    updatedAt: now,
+    originalPath: ompFile,
+    summary: 'Fix auth bug',
+    model: 'openai-codex/gpt-5.5',
+  };
+  const ompMsgs = parseOmpFixtureMessages(ompFile);
+  contexts.omp = {
+    session: ompSession,
+    recentMessages: ompMsgs,
+    filesModified: [],
+    pendingTasks: [],
+    toolSummaries: [],
+    markdown: generateHandoffMarkdown(ompSession, ompMsgs, [], [], []),
   };
 });
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -17,6 +17,7 @@ export { extractDroidContext, parseDroidSessions } from './droid.js';
 export { extractGeminiContext, parseGeminiSessions } from './gemini.js';
 export { extractKimiContext, parseKimiSessions } from './kimi.js';
 export { extractKiroContext, parseKiroSessions } from './kiro.js';
+export { extractOmpContext, parseOmpSessions } from './omp.js';
 export { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
 export { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
 export type { ToolAdapter } from './registry.js';

--- a/src/parsers/omp.ts
+++ b/src/parsers/omp.ts
@@ -1,0 +1,579 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { VerbosityConfig } from '../config/index.js';
+import { getPreset } from '../config/index.js';
+import { logger } from '../logger.js';
+import type {
+  ConversationMessage,
+  SessionContext,
+  SessionEvent,
+  SessionNotes,
+  SessionParseOptions,
+  ToolUsageSummary,
+  UnifiedSession,
+} from '../types/index.js';
+import { classifyToolName } from '../types/tool-names.js';
+import { countDiffStats, extractStdoutTail } from '../utils/diff.js';
+import { findFiles, mapConcurrent } from '../utils/fs-helpers.js';
+import { getFileStats, readJsonlFile, scanJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
+import { generateHandoffMarkdown } from '../utils/markdown.js';
+import { cleanSummary, extractRepo, homeDir } from '../utils/parser-helpers.js';
+import { matchesCwd } from '../utils/slug.js';
+import {
+  extractExitCode,
+  fileSummary,
+  globSummary,
+  grepSummary,
+  mcpSummary,
+  SummaryCollector,
+  searchSummary,
+  shellSummary,
+  truncate,
+} from '../utils/tool-summarizer.js';
+
+const OMP_AGENT_DIR = process.env.PI_CODING_AGENT_DIR || path.join(homeDir(), '.omp', 'agent');
+const OMP_SESSIONS_DIR = path.join(OMP_AGENT_DIR, 'sessions');
+const MAX_EXACT_LINE_COUNT_BYTES = 1024 * 1024;
+const MAX_METADATA_SCAN_BYTES = 1024 * 1024;
+
+type OmpContentBlock = {
+  type?: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+};
+
+type OmpMessagePayload = {
+  role?: string;
+  content?: string | OmpContentBlock[];
+  toolCallId?: string;
+  toolName?: string;
+  isError?: boolean;
+  provider?: string;
+  model?: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    reasoningTokens?: number;
+  };
+};
+
+type OmpRecord = {
+  type?: string;
+  customType?: string;
+  id?: string;
+  parentId?: string | null;
+  timestamp?: string;
+  title?: string;
+  updatedAt?: string;
+  version?: number;
+  cwd?: string;
+  model?: string;
+  thinkingLevel?: string;
+  configured?: string;
+  message?: OmpMessagePayload;
+  data?: {
+    toolCallId?: string;
+    toolName?: string;
+    startedAt?: string;
+    args?: Record<string, unknown>;
+    intent?: string;
+    reason?: string;
+    kind?: string;
+    recordedAt?: string;
+    pendingToolCalls?: unknown[];
+  };
+};
+
+type OmpSessionInfo = {
+  id: string;
+  cwd: string;
+  title: string;
+  model?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+async function findSessionFiles(): Promise<string[]> {
+  return findFiles(OMP_SESSIONS_DIR, {
+    match: (entry) => entry.name.endsWith('.jsonl'),
+  });
+}
+
+function parseValidDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function parseFilename(filePath: string): { timestamp?: Date; id?: string } {
+  const match = path.basename(filePath).match(/^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z)_(.+)\.jsonl$/);
+  if (!match) return {};
+  const [, rawTimestamp, id] = match;
+  return {
+    timestamp: parseValidDate(rawTimestamp.replace(/T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/, 'T$1:$2:$3.$4Z')),
+    id,
+  };
+}
+
+function extractTextContent(content: OmpMessagePayload['content']): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((block) => block.type === 'text' && typeof block.text === 'string')
+    .map((block) => block.text)
+    .join('\n');
+}
+
+function firstUserMessage(records: OmpRecord[]): string {
+  for (const record of records) {
+    if (record.type !== 'message' || record.message?.role !== 'user') continue;
+    const content = extractTextContent(record.message.content).trim();
+    if (content) return content;
+  }
+  return '';
+}
+
+async function parseSessionInfo(filePath: string): Promise<OmpSessionInfo | null> {
+  const filename = parseFilename(filePath);
+  const info: Partial<OmpSessionInfo> = {
+    ...(filename.id ? { id: filename.id } : {}),
+    ...(filename.timestamp ? { createdAt: filename.timestamp } : {}),
+  };
+  const headRecords: OmpRecord[] = [];
+
+  await scanJsonlHead(
+    filePath,
+    200,
+    (parsed) => {
+      const record = parsed as OmpRecord;
+      headRecords.push(record);
+
+      if (record.type === 'title' && typeof record.title === 'string' && !info.title) {
+        info.title = record.title;
+      }
+
+      if (record.type === 'session') {
+        if (typeof record.id === 'string') info.id = record.id;
+        if (typeof record.cwd === 'string') info.cwd = record.cwd;
+        if (typeof record.title === 'string') info.title = record.title;
+        info.createdAt = parseValidDate(record.timestamp) ?? info.createdAt;
+      }
+
+      if (record.type === 'model_change' && typeof record.model === 'string' && !info.model) {
+        info.model = record.model;
+      }
+
+      const timestamp = parseValidDate(record.updatedAt ?? record.timestamp);
+      if (timestamp && (!info.updatedAt || timestamp.getTime() > info.updatedAt.getTime())) info.updatedAt = timestamp;
+
+      return info.id && info.cwd && info.title && info.model ? 'stop' : 'continue';
+    },
+    { maxBytes: MAX_METADATA_SCAN_BYTES },
+  );
+
+  if (!info.title) info.title = cleanSummary(firstUserMessage(headRecords));
+  if (!info.id) return null;
+
+  return {
+    id: info.id,
+    cwd: info.cwd ?? '',
+    title: info.title ?? '',
+    ...(info.model ? { model: info.model } : {}),
+    ...(info.createdAt ? { createdAt: info.createdAt } : {}),
+    ...(info.updatedAt ? { updatedAt: info.updatedAt } : {}),
+  };
+}
+
+async function extractLastTimestamp(filePath: string): Promise<Date | undefined> {
+  let lastTimestamp: Date | undefined;
+  await scanJsonlFile(
+    filePath,
+    (parsed) => {
+      const record = parsed as OmpRecord;
+      const timestamp = parseValidDate(record.updatedAt ?? record.timestamp ?? record.data?.recordedAt);
+      if (timestamp && (!lastTimestamp || timestamp.getTime() > lastTimestamp.getTime())) lastTimestamp = timestamp;
+      return 'continue';
+    },
+    { maxBytes: MAX_METADATA_SCAN_BYTES },
+  );
+  return lastTimestamp;
+}
+
+export async function parseOmpSessions(options: SessionParseOptions = {}): Promise<UnifiedSession[]> {
+  const files = await findSessionFiles();
+  const parsedSessions = await mapConcurrent(files, 16, async (filePath): Promise<UnifiedSession | null> => {
+    try {
+      const info = await parseSessionInfo(filePath);
+      if (!info) return null;
+      if (options.cwd && info.cwd && !matchesCwd(info.cwd, options.cwd)) return null;
+
+      const fileStats = fs.statSync(filePath);
+      const stats =
+        options.lightweight || fileStats.size > MAX_EXACT_LINE_COUNT_BYTES
+          ? { lines: 0, bytes: fileStats.size }
+          : await getFileStats(filePath);
+      const lastTimestamp =
+        !options.lightweight && fileStats.size <= MAX_METADATA_SCAN_BYTES
+          ? await extractLastTimestamp(filePath)
+          : undefined;
+      const updatedAt = lastTimestamp ?? (fileStats.size > MAX_METADATA_SCAN_BYTES ? fileStats.mtime : info.updatedAt);
+
+      return {
+        id: info.id,
+        source: 'omp',
+        cwd: info.cwd,
+        repo: extractRepo({ cwd: info.cwd }),
+        lines: stats.lines,
+        bytes: stats.bytes,
+        createdAt: info.createdAt ?? fileStats.birthtime,
+        updatedAt: updatedAt ?? fileStats.mtime,
+        originalPath: filePath,
+        summary: cleanSummary(info.title) || undefined,
+        ...(info.model ? { model: info.model } : {}),
+      };
+    } catch (err) {
+      logger.debug('omp: skipping unparseable session', filePath, err);
+      return null;
+    }
+  });
+
+  const sessionsById = new Map<string, UnifiedSession>();
+  for (const session of parsedSessions) {
+    if (!session) continue;
+    const existing = sessionsById.get(session.id);
+    if (!existing || existing.updatedAt.getTime() < session.updatedAt.getTime()) {
+      sessionsById.set(session.id, session);
+    }
+  }
+
+  const sorted = Array.from(sessionsById.values()).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  return options.limit ? sorted.slice(0, options.limit) : sorted;
+}
+
+function toolResultText(record: OmpRecord): string {
+  if (record.type !== 'message' || record.message?.role !== 'toolResult') return '';
+  return extractTextContent(record.message.content);
+}
+
+function pathArg(args: Record<string, unknown> | undefined): string | undefined {
+  for (const key of ['path', 'filePath', 'file_path', 'targetPath', 'cwd']) {
+    const value = args?.[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function commandArg(args: Record<string, unknown> | undefined): string | undefined {
+  const value = args?.command;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function addToolSummary(record: OmpRecord, resultByCallId: Map<string, OmpRecord>, collector: SummaryCollector): void {
+  if (record.customType !== 'tool_execution_start') return;
+  const toolName = record.data?.toolName;
+  if (!toolName) return;
+
+  const args = record.data?.args ?? {};
+  const result = record.data?.toolCallId ? resultByCallId.get(record.data.toolCallId) : undefined;
+  const resultText = result ? toolResultText(result) : '';
+  const isError = result?.message?.isError === true;
+  const category = classifyToolName(toolName) ?? 'mcp';
+  const filePath = pathArg(args);
+
+  switch (category) {
+    case 'shell': {
+      const command = commandArg(args) ?? record.data?.intent ?? toolName;
+      collector.add('Bash', shellSummary(command, resultText), {
+        data: {
+          category: 'shell',
+          command,
+          ...(extractExitCode(resultText) !== undefined ? { exitCode: extractExitCode(resultText) } : {}),
+          ...(extractStdoutTail(resultText, 20) ? { stdoutTail: extractStdoutTail(resultText, 20) } : {}),
+          ...(isError ? { errored: true, errorMessage: truncate(resultText, 200) } : {}),
+        },
+        isError,
+      });
+      return;
+    }
+    case 'read': {
+      const target = filePath ?? String(args.url ?? args.i ?? '(unknown)');
+      collector.add('Read', fileSummary('read', target), {
+        data: { category: 'read', filePath: target },
+        isError,
+      });
+      return;
+    }
+    case 'write': {
+      const target = filePath ?? '(unknown)';
+      collector.add('Write', fileSummary('write', target), {
+        data: { category: 'write', filePath: target },
+        filePath: target,
+        isWrite: true,
+        isError,
+      });
+      return;
+    }
+    case 'edit': {
+      const target = filePath ?? '(unknown)';
+      const diffStats = countDiffStats(resultText);
+      collector.add('Edit', fileSummary('edit', target, diffStats), {
+        data: { category: 'edit', filePath: target, diff: resultText, diffStats },
+        filePath: target,
+        isWrite: true,
+        isError,
+      });
+      return;
+    }
+    case 'grep': {
+      const pattern = typeof args.pattern === 'string' ? args.pattern : String(args.i ?? '(pattern)');
+      collector.add('Grep', grepSummary(pattern, filePath), {
+        data: { category: 'grep', pattern, ...(filePath ? { targetPath: filePath } : {}) },
+        isError,
+      });
+      return;
+    }
+    case 'glob': {
+      const pattern = typeof args.path === 'string' ? args.path : String(args.i ?? '(pattern)');
+      collector.add('Glob', globSummary(pattern), {
+        data: { category: 'glob', pattern },
+        isError,
+      });
+      return;
+    }
+    case 'search': {
+      const query = typeof args.query === 'string' ? args.query : String(args.i ?? '');
+      collector.add('WebSearch', searchSummary(query), {
+        data: { category: 'search', query },
+        isError,
+      });
+      return;
+    }
+    default: {
+      const argsText = JSON.stringify(args).slice(0, 200);
+      collector.add(toolName, mcpSummary(toolName, argsText, resultText), {
+        data: {
+          category: 'mcp',
+          toolName,
+          params: argsText,
+          ...(resultText ? { result: truncate(resultText, 100) } : {}),
+        },
+        isError,
+      });
+    }
+  }
+}
+
+function extractToolData(
+  records: OmpRecord[],
+  config: VerbosityConfig,
+): { summaries: ToolUsageSummary[]; filesModified: string[] } {
+  const collector = new SummaryCollector(config);
+  const resultByCallId = new Map<string, OmpRecord>();
+
+  for (const record of records) {
+    if (record.type === 'message' && record.message?.role === 'toolResult' && record.message.toolCallId) {
+      resultByCallId.set(record.message.toolCallId, record);
+    }
+  }
+
+  for (const record of records) {
+    addToolSummary(record, resultByCallId, collector);
+  }
+
+  return { summaries: collector.getSummaries(), filesModified: collector.getFilesModified() };
+}
+
+function extractSessionNotes(records: OmpRecord[], session: UnifiedSession): SessionNotes {
+  const notes: SessionNotes = {
+    ...(session.model ? { model: session.model } : {}),
+    rawAccess: { kind: 'file', path: session.originalPath, redacted: true },
+  };
+  const reasoning: string[] = [];
+  const sourceMetadata: Record<string, unknown> = {};
+
+  for (const record of records) {
+    if (record.type === 'session') {
+      if (typeof record.id === 'string') sourceMetadata.sessionId = record.id;
+      if (typeof record.version === 'number') sourceMetadata.cliVersion = `v${record.version}`;
+      if (typeof record.timestamp === 'string') sourceMetadata.sessionTimestamp = record.timestamp;
+      continue;
+    }
+
+    if (record.type === 'model_change' && typeof record.model === 'string') {
+      notes.model = record.model;
+      sourceMetadata.model = record.model;
+      continue;
+    }
+
+    if (record.type === 'thinking_level_change') {
+      if (typeof record.thinkingLevel === 'string') sourceMetadata.thinkingLevel = record.thinkingLevel;
+      if (typeof record.configured === 'string') sourceMetadata.thinkingConfigured = record.configured;
+      continue;
+    }
+
+    if (record.customType === 'session_exit') {
+      notes.lifecycle ??= [];
+      notes.lifecycle.push({
+        type: 'session_exit',
+        timestamp: record.timestamp,
+        metadata: {
+          ...(record.data?.reason ? { reason: record.data.reason } : {}),
+          ...(record.data?.kind ? { kind: record.data.kind } : {}),
+          ...(record.data?.recordedAt ? { recordedAt: record.data.recordedAt } : {}),
+        },
+      });
+      continue;
+    }
+
+    if (record.type !== 'message' || !record.message) continue;
+
+    if (record.message.provider) sourceMetadata.provider = record.message.provider;
+    if (record.message.model && !notes.model) notes.model = record.message.model;
+
+    const usage = record.message.usage;
+    if (usage) {
+      const input = usage.input ?? notes.tokenUsage?.input ?? 0;
+      const output = usage.output ?? notes.tokenUsage?.output ?? 0;
+      notes.tokenUsage = { input, output };
+      const cacheRead = usage.cacheRead ?? notes.cacheTokens?.read ?? 0;
+      const cacheWrite = usage.cacheWrite ?? notes.cacheTokens?.creation ?? 0;
+      if (cacheRead > 0 || cacheWrite > 0) notes.cacheTokens = { creation: cacheWrite, read: cacheRead };
+      if (typeof usage.reasoningTokens === 'number' && usage.reasoningTokens > 0) {
+        notes.thinkingTokens = usage.reasoningTokens;
+      }
+    }
+
+    if (record.message.role === 'assistant' && Array.isArray(record.message.content)) {
+      for (const block of record.message.content) {
+        if (block.type !== 'thinking' || typeof block.thinking !== 'string' || reasoning.length >= 5) continue;
+        const firstLine = block.thinking
+          .replace(/^\*\*|\*\*$/g, '')
+          .split(/[.\n]/)[0]
+          ?.trim();
+        if (firstLine) reasoning.push(truncate(firstLine, 200));
+      }
+    }
+  }
+
+  if (reasoning.length > 0) notes.reasoning = reasoning;
+  if (Object.keys(sourceMetadata).length > 0) notes.sourceMetadata = sourceMetadata;
+  return notes;
+}
+
+function extractConversation(records: OmpRecord[]): ConversationMessage[] {
+  const messages: ConversationMessage[] = [];
+  for (const record of records) {
+    if (record.type !== 'message' || !record.message) continue;
+    const role = record.message.role;
+    if (role !== 'user' && role !== 'assistant' && role !== 'system') continue;
+    const content = extractTextContent(record.message.content).trim();
+    if (!content) continue;
+    messages.push({
+      role,
+      content,
+      timestamp: parseValidDate(record.timestamp),
+      sourceId: record.id,
+      sourceParentId: record.parentId ?? undefined,
+    });
+  }
+  return messages;
+}
+
+function buildTimeline(messages: ConversationMessage[], records: OmpRecord[]): SessionEvent[] {
+  const events: SessionEvent[] = [];
+
+  for (const message of messages) {
+    events.push({
+      kind: 'message',
+      sequence: 0,
+      role: message.role,
+      content: message.content,
+      timestamp: message.timestamp,
+      sourceId: message.sourceId,
+      sourceParentId: message.sourceParentId,
+    });
+  }
+
+  for (const record of records) {
+    if (record.customType === 'tool_execution_start' && record.data?.toolName) {
+      events.push({
+        kind: 'tool_call',
+        sequence: 0,
+        timestamp: parseValidDate(record.timestamp ?? record.data.startedAt),
+        id: record.id,
+        sourceId: record.id,
+        sourceParentId: record.parentId ?? undefined,
+        toolName: record.data.toolName,
+        toolCallId: record.data.toolCallId,
+        arguments: record.data.args,
+        content: record.data.intent,
+      });
+    } else if (record.type === 'message' && record.message?.role === 'toolResult') {
+      events.push({
+        kind: 'tool_result',
+        sequence: 0,
+        timestamp: parseValidDate(record.timestamp),
+        id: record.id,
+        sourceId: record.id,
+        sourceParentId: record.parentId ?? undefined,
+        toolName: record.message.toolName,
+        toolCallId: record.message.toolCallId,
+        status: record.message.isError ? 'error' : 'ok',
+        result: truncate(toolResultText(record), 1000),
+      });
+    } else if (record.customType === 'session_exit') {
+      events.push({
+        kind: 'lifecycle',
+        sequence: 0,
+        timestamp: parseValidDate(record.timestamp),
+        id: record.id,
+        sourceId: record.id,
+        sourceParentId: record.parentId ?? undefined,
+        status: 'session_exit',
+        metadata: record.data,
+      });
+    }
+  }
+
+  events.sort((a, b) => (a.timestamp?.getTime() ?? 0) - (b.timestamp?.getTime() ?? 0));
+  return events.map((event, sequence) => ({ ...event, sequence }));
+}
+
+export async function extractOmpContext(session: UnifiedSession, config?: VerbosityConfig): Promise<SessionContext> {
+  const resolvedConfig = config ?? getPreset('standard');
+  const records = await readJsonlFile<OmpRecord>(session.originalPath);
+  const { summaries: toolSummaries, filesModified } = extractToolData(records, resolvedConfig);
+  const sessionNotes = extractSessionNotes(records, session);
+  const pendingTasks: string[] = [];
+  const allMessages = extractConversation(records);
+  const trimmed = allMessages.slice(-resolvedConfig.recentMessages);
+  const timeline = buildTimeline(trimmed, records);
+
+  const markdown = generateHandoffMarkdown(
+    session,
+    trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    sessionNotes,
+    resolvedConfig,
+    'inline',
+    timeline,
+  );
+
+  return {
+    session,
+    recentMessages: trimmed,
+    filesModified,
+    pendingTasks,
+    toolSummaries,
+    sessionNotes,
+    timeline,
+    markdown,
+  };
+}

--- a/src/parsers/registry.ts
+++ b/src/parsers/registry.ts
@@ -28,6 +28,7 @@ import { extractDroidContext, parseDroidSessions } from './droid.js';
 import { extractGeminiContext, parseGeminiSessions } from './gemini.js';
 import { extractKimiContext, parseKimiSessions } from './kimi.js';
 import { extractKiroContext, parseKiroSessions } from './kiro.js';
+import { extractOmpContext, parseOmpSessions } from './omp.js';
 import { extractOpenCodeContext, parseOpenCodeSessions } from './opencode.js';
 import { extractQwenCodeContext, parseQwenCodeSessions } from './qwen-code.js';
 
@@ -937,6 +938,21 @@ register({
   crossToolArgs: (prompt) => [prompt],
   resumeCommandDisplay: (s) => `qwen --resume ${s.id}`,
   mapHandoffFlags: mapGeminiFlags,
+});
+
+// ── Oh My Pi ─────────────────────────────────────────────────────────
+register({
+  name: 'omp',
+  label: 'Oh My Pi',
+  color: chalk.hex('#FFB000'),
+  storagePath: '$PI_CODING_AGENT_DIR/sessions/ (default: ~/.omp/agent/sessions/)',
+  envVar: 'PI_CODING_AGENT_DIR',
+  binaryName: 'omp',
+  parseSessions: parseOmpSessions,
+  extractContext: extractOmpContext,
+  nativeResumeArgs: (s) => ['--resume', s.id],
+  crossToolArgs: (prompt) => [prompt],
+  resumeCommandDisplay: (s) => `omp --resume ${s.id}`,
 });
 
 // ── Completeness assertion ──────────────────────────────────────────

--- a/src/types/tool-names.ts
+++ b/src/types/tool-names.ts
@@ -21,6 +21,7 @@ export const TOOL_NAMES = Object.freeze([
   'antigravity',
   'kimi',
   'qwen-code',
+  'omp',
 ] as const);
 
 /** Source CLI tool — derived from TOOL_NAMES, never defined manually */
@@ -48,13 +49,14 @@ export const SHELL_TOOLS: ReadonlySet<string> = new Set([
 ]);
 
 /** File read tools */
-export const READ_TOOLS: ReadonlySet<string> = new Set(['Read', 'ReadFile', 'read_file']);
+export const READ_TOOLS: ReadonlySet<string> = new Set(['Read', 'ReadFile', 'read_file', 'read']);
 
 /** File write/create tools */
 export const WRITE_TOOLS: ReadonlySet<string> = new Set([
   'Write',
   'WriteFile',
   'write_file',
+  'write',
   'Create',
   'create',
   'create_file',
@@ -97,7 +99,7 @@ export const GLOB_TOOLS: ReadonlySet<string> = new Set([
 ]);
 
 /** Web search tools */
-export const SEARCH_TOOLS: ReadonlySet<string> = new Set(['WebSearch', 'web_search', 'web_search_call']);
+export const SEARCH_TOOLS: ReadonlySet<string> = new Set(['WebSearch', 'web_search', 'web_search_call', 'web_search']);
 
 /** Web fetch tools */
 export const FETCH_TOOLS: ReadonlySet<string> = new Set(['WebFetch', 'web_fetch']);
@@ -109,7 +111,7 @@ export const TASK_TOOLS: ReadonlySet<string> = new Set(['Task', 'task', 'Agent']
 export const TASK_OUTPUT_TOOLS: ReadonlySet<string> = new Set(['TaskOutput']);
 
 /** User interaction tools */
-export const ASK_TOOLS: ReadonlySet<string> = new Set(['AskUserQuestion', 'request_user_input']);
+export const ASK_TOOLS: ReadonlySet<string> = new Set(['AskUserQuestion', 'request_user_input', 'ask']);
 
 /** Tools to skip — internal bookkeeping, no useful handoff context */
 export const SKIP_TOOLS: ReadonlySet<string> = new Set([


### PR DESCRIPTION
## Problem

Oh My Pi sessions were invisible to `continues`. OMP stores session transcripts as JSONL under `$PI_CODING_AGENT_DIR/sessions/` (default `~/.omp/agent/sessions/`), but there was no parser, registry entry, fixture, or cross-tool handoff path for it.

That meant starting work in OMP and handing it off to Codex, Claude, Gemini, OpenCode, etc. lost the entire session.

**Before**
```bash
$ continues list --source omp
# omp was not a supported source
```

**After**
```bash
$ continues list --source omp --json -n 1
[
  {
    "source": "omp",
    "cwd": "/Users/kd-m2air/Local",
    "summary": "Add OMP support",
    "model": "openai-codex/gpt-5.5",
    "originalPath": "/Users/kd-m2air/.omp/agent/sessions/...jsonl"
  }
]
```

And OMP sessions can now generate normal handoff markdown:
```markdown
# Session Handoff Context

## Session Overview
| Source | Oh My Pi |
| Session ID | `019f6a82-...` |
| Working Directory | `~/Local` |
| Session File | `~/.omp/agent/sessions/...jsonl` |

## Recent Conversation
...

## Tool Activity
...

## Session Origin
This session was extracted from **Oh My Pi** session data.
```

## What changed

Added OMP as the 17th supported tool.

**New parser support:**
- Discovers OMP `.jsonl` sessions from `$PI_CODING_AGENT_DIR/sessions/*/*.jsonl`
- Defaults to `~/.omp/agent/sessions/`
- Extracts session id, cwd, repo, title/summary, model, created/updated timestamps
- Keeps lightweight session ordering based on the latest OMP metadata `updatedAt`
- De-dupes duplicate session ids by newest `updatedAt`

**New handoff data extracted:**
- User/assistant/system conversation messages
- Tool execution start/result pairs by `toolCallId`
- Shell/read/write/edit/grep/glob/search/MCP tool summaries via `SummaryCollector`
- Modified files from write/edit activity
- Model/provider metadata
- Token usage, cache tokens, thinking tokens
- Thinking level configuration
- Session lifecycle events
- Timeline events for messages, tool calls, tool results, and exits

**CLI integration:**
- Adds `omp` to `TOOL_NAMES`
- Registers OMP in `src/parsers/registry.ts`
- Exports `parseOmpSessions` / `extractOmpContext`
- Adds native resume display/args: `omp --resume <id>`
- Adds cross-tool handoff support with positional prompt argument

**Docs and metadata:**
- README supported-tool table now includes Oh My Pi
- README storage table documents `$PI_CODING_AGENT_DIR/sessions/`
- Package description mentions Oh My Pi
- CHANGELOG has an Unreleased OMP entry

## Technical approach

- Follows the existing parser contract: `parseOmpSessions()` and `extractOmpContext()`.
- Uses shared JSONL helpers instead of loading session files wholesale.
- Uses `scanJsonlHead` for cheap metadata discovery and `readJsonlFile` only during full context extraction.
- Uses `SummaryCollector` and existing summarizer helpers instead of OMP-specific markdown formatting.
- Treats unknown/malformed records conservatively: skip what cannot be parsed, keep the session usable.
- Adds a regression test for lightweight recency because `continues list/pick/quick-resume` can use source indexes built without full transcript scans.

## Files changed

| File / area | Purpose |
|---|---|
| `src/parsers/omp.ts` | New OMP parser and handoff extractor. |
| `src/parsers/registry.ts` | Register OMP source, storage path, native resume, and cross-tool args. |
| `src/types/tool-names.ts` | Add `omp` to supported tool names and source union. |
| `src/parsers/index.ts` | Export OMP parser functions. |
| `src/__tests__/omp-parser.test.ts` | OMP discovery, extraction, and lightweight recency regression tests. |
| `src/__tests__/fixtures/index.ts` | Sanitized OMP fixture factory. |
| `src/__tests__/unit-conversions.test.ts` | Add OMP to source/target conversion matrix. |
| `src/__tests__/schemas.test.ts` | Update supported-tool schema expectations. |
| `README.md`, `CHANGELOG.md`, `package.json` | User-facing OMP support docs/metadata. |

## Testing

Automated checks:
- `corepack pnpm@10 run build`
- `corepack pnpm@10 test`
  - 29 test files passed
  - 984 tests passed
  - 2 skipped
- `npx -y node@22 node_modules/vitest/vitest.mjs run`
  - verifies the suite under the CI Node 22 runtime
  - 29 test files passed
  - 984 tests passed
  - 2 skipped

E2E smoke against real local OMP data:
- `npm run dev -- scan --rebuild`
  - found OMP sessions
- `npm run dev -- list --source omp --json -n 1`
  - returned a real OMP session from `~/.omp/agent/sessions/...jsonl`
- `npm run dev -- resume 019f6a82 -i codex --debug-prompt --no-tui`
  - generated a Codex handoff from an OMP session

Review pass:
- Ran an internal reviewer pass before opening the PR.
- Reviewer found one correctness issue: lightweight OMP indexing could order sessions by stale timestamps.
- Added a failing regression test first, then fixed timestamp handling to keep `updatedAt` monotonic.

## Risks / reviewer focus

1. **OMP schema drift** — parser is tolerant, but new record shapes may need follow-up coverage.
2. **Tool result pairing** — tool summaries depend on `tool_execution_start` and later `toolResult` messages sharing `toolCallId`; missing results still produce conservative summaries.
3. **Native resume contract** — assumes `omp --resume <id>` is the right CLI shape.
4. **Cross-tool prompt contract** — assumes OMP accepts the handoff prompt as a positional message argument.

## Follow-ups

- Add parser-documentation pages for OMP storage/message/tool-call formats if this repo wants docs parity with older tools.
- Add live sanitized OMP fixture samples if the project prefers fixtures copied from real sessions over synthetic records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Oh My Pi (OMP) as a first-class source: we discover, parse, and extract handoffs from OMP JSONL sessions and support native resume. This brings supported tools to 17 and updates docs accordingly.

- **New Features**
  - OMP session discovery and parsing from `$PI_CODING_AGENT_DIR/sessions/` (default `~/.omp/agent/sessions/`), with lightweight recency ordering.
  - Context extraction: recent messages, tool calls/results, model notes, token/cache usage, thinking level, and lifecycle; handoff markdown and timeline included.
  - Registry/CLI integration: new `omp` source with list/inspect/dump; native resume via `omp --resume <id>` and cross-tool handoff.
  - Tests and fixtures: new `omp` fixtures and parser tests; e2e/unit paths updated across sources.
  - Docs and metadata updated (`README.md`, `CHANGELOG.md`, `package.json`); minor lint and import path cleanups.

- **Migration**
  - No changes required. Optionally set `PI_CODING_AGENT_DIR`; otherwise the default `~/.omp/agent/sessions/` is used.
  - Try it: `continues list --source omp -n 1` and `continues resume <id> -i codex`

<sup>Written for commit 80db52a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
