### PR TITLE
chore: satisfy current Biome checks

### DIFF
--- a/src/__tests__/claude-task-reconciliation.test.ts
+++ b/src/__tests__/claude-task-reconciliation.test.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getPreset } from '../config/index.js';
 import { extractClaudeContext } from '../parsers/claude.js';
@@ -22,7 +22,7 @@ function makeSession(originalPath: string): UnifiedSession {
 
 function writeJsonl(filePath: string, records: Array<Record<string, unknown>>): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, records.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf8');
+  fs.writeFileSync(filePath, `${records.map((r) => JSON.stringify(r)).join('\n')}\n`, 'utf8');
 }
 
 describe('Claude task reconciliation', () => {

--- a/src/__tests__/cwd-from-slug.test.ts
+++ b/src/__tests__/cwd-from-slug.test.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { cwdFromSlug } from '../utils/slug.js';
 

--- a/src/__tests__/e2e-conversions.test.ts
+++ b/src/__tests__/e2e-conversions.test.ts
@@ -11,9 +11,9 @@
  *   copilot -i "prompt" (falls back to stdin)
  */
 
-import { execSync } from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   extractAmpContext,
@@ -185,8 +185,9 @@ function runTool(tool: SessionSource, prompt: string, cwd: string): string {
     });
 
     return output.trim();
-  } catch (err: any) {
-    return `ERROR: ${err.message?.slice(0, 500) || 'unknown error'}`;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `ERROR: ${message.slice(0, 500) || 'unknown error'}`;
   } finally {
     try {
       fs.unlinkSync(tmpFile);

--- a/src/__tests__/extract-handoffs.ts
+++ b/src/__tests__/extract-handoffs.ts
@@ -3,8 +3,8 @@
  * Saves to ~/.continues/e2e-test-results/handoff-from-{source}.md
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   extractAmpContext,
   extractAntigravityContext,

--- a/src/__tests__/fixtures/index.ts
+++ b/src/__tests__/fixtures/index.ts
@@ -1,10 +1,10 @@
 /**
  * Test fixtures - sanitized session data for supported parsers
  */
-import { createHash } from 'crypto';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 export interface FixtureDir {
   root: string;
@@ -68,7 +68,7 @@ export function createClaudeFixture(): FixtureDir {
     }),
   ];
 
-  fs.writeFileSync(sessionFile, lines.join('\n') + '\n');
+  fs.writeFileSync(sessionFile, `${lines.join('\n')}\n`);
 
   return {
     root,
@@ -153,7 +153,7 @@ updated_at: 2026-01-15T10:05:00.000Z
     }),
   ];
 
-  fs.writeFileSync(path.join(sessionDir, 'events.jsonl'), events.join('\n') + '\n');
+  fs.writeFileSync(path.join(sessionDir, 'events.jsonl'), `${events.join('\n')}\n`);
 
   return {
     root,
@@ -284,7 +284,7 @@ export function createCodexFixture(): FixtureDir {
   ];
 
   const filename = 'rollout-2026-01-15T10-00-00-test-codex-uuid-1234.jsonl';
-  fs.writeFileSync(path.join(dateDir, filename), lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(dateDir, filename), `${lines.join('\n')}\n`);
 
   return {
     root,
@@ -723,7 +723,7 @@ export function createDroidFixture(): FixtureDir {
     }),
   ];
 
-  fs.writeFileSync(path.join(workspaceDir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(workspaceDir, `${sessionId}.jsonl`), `${lines.join('\n')}\n`);
 
   return {
     root,
@@ -808,7 +808,7 @@ export function createCursorFixture(): FixtureDir {
     }),
   ];
 
-  fs.writeFileSync(path.join(sessionDir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(sessionDir, `${sessionId}.jsonl`), `${lines.join('\n')}\n`);
 
   return {
     root,
@@ -1060,7 +1060,7 @@ export function createKimiFixture(): FixtureDir {
       content: 'Done. I added try-catch blocks and proper error messages.',
     }),
   ];
-  fs.writeFileSync(path.join(sessionDir, 'context.jsonl'), contextLines.join('\n') + '\n');
+  fs.writeFileSync(path.join(sessionDir, 'context.jsonl'), `${contextLines.join('\n')}\n`);
 
   // metadata.json — optional in Kimi, but included here for schema/compat coverage
   fs.writeFileSync(
@@ -1193,7 +1193,7 @@ export function createQwenCodeFixture(): FixtureDir {
     }),
   ];
 
-  fs.writeFileSync(path.join(chatsDir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
+  fs.writeFileSync(path.join(chatsDir, `${sessionId}.jsonl`), `${lines.join('\n')}\n`);
 
   return {
     root,

--- a/src/__tests__/injection-test.ts
+++ b/src/__tests__/injection-test.ts
@@ -10,9 +10,9 @@
  *  5. Verify the key phrase survives the round-trip
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { extractClaudeContext } from '../parsers/claude.js';
 import { extractCodexContext } from '../parsers/codex.js';
 import { extractCopilotContext } from '../parsers/copilot.js';
@@ -106,7 +106,7 @@ function createClaudeSource(): string {
     }),
   ];
 
-  fs.writeFileSync(filePath, lines.join('\n') + '\n');
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`);
   return filePath;
 }
 
@@ -140,7 +140,7 @@ function createCopilotSource(): string {
     }),
   ];
 
-  fs.writeFileSync(path.join(dirPath, 'events.jsonl'), events.join('\n') + '\n');
+  fs.writeFileSync(path.join(dirPath, 'events.jsonl'), `${events.join('\n')}\n`);
   return dirPath;
 }
 
@@ -195,7 +195,7 @@ function createCodexSource(): string {
     }),
   ];
 
-  fs.writeFileSync(filePath, lines.join('\n') + '\n');
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`);
   return filePath;
 }
 
@@ -270,7 +270,7 @@ function writeClaudeTarget(markdown: string, label: string): string {
     }),
   ];
 
-  fs.writeFileSync(filePath, lines.join('\n') + '\n');
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`);
   return filePath;
 }
 
@@ -304,7 +304,7 @@ function writeCopilotTarget(markdown: string, label: string): string {
     }),
   ];
 
-  fs.writeFileSync(path.join(dirPath, 'events.jsonl'), events.join('\n') + '\n');
+  fs.writeFileSync(path.join(dirPath, 'events.jsonl'), `${events.join('\n')}\n`);
   return dirPath;
 }
 
@@ -349,7 +349,7 @@ function writeCodexTarget(markdown: string, label: string): string {
     }),
   ];
 
-  fs.writeFileSync(filePath, lines.join('\n') + '\n');
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`);
   return filePath;
 }
 
@@ -453,8 +453,8 @@ async function main() {
         const ctx = await extractSourceContext(source);
         sourceContexts.set(source, ctx);
         console.log(`✅  ${ctx.recentMessages.length} msgs, ${ctx.markdown.length} chars markdown`);
-      } catch (err: any) {
-        console.log(`❌  ${err.message ?? err}`);
+      } catch (err: unknown) {
+        console.log(`❌  ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 
@@ -533,12 +533,12 @@ async function main() {
             results.push(r);
             console.log(r.passed ? `✅ ${r.details}` : `❌ ${r.details}`);
           }
-        } catch (err: any) {
+        } catch (err: unknown) {
           const r: TestResult = {
             source,
             target,
             passed: false,
-            details: `Error: ${err.message ?? err}`,
+            details: `Error: ${err instanceof Error ? err.message : String(err)}`,
           };
           results.push(r);
           console.log(`❌ ${r.details}`);
@@ -554,7 +554,7 @@ async function main() {
     console.log('\n╔══════════════════════════════════════════════════╗');
     console.log('║                  RESULTS TABLE                   ║');
     console.log('╚══════════════════════════════════════════════════╝\n');
-    console.log('Source'.padEnd(10) + '  Target'.padEnd(12) + '  Status'.padEnd(8) + '  Details');
+    console.log(`${'Source'.padEnd(10) + '  Target'.padEnd(12) + '  Status'.padEnd(8)}  Details`);
     console.log('─'.repeat(72));
 
     for (const r of results) {

--- a/src/__tests__/real-e2e-full.ts
+++ b/src/__tests__/real-e2e-full.ts
@@ -8,9 +8,9 @@
  * 4. Semantic verification: target must reference specific facts from the source
  */
 
-import { execSync } from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 import { extractContext, getAllSessions } from '../utils/index.js';
 
@@ -197,8 +197,19 @@ Based ONLY on the handoff context above, describe in 2-3 sentences:
       default:
         throw new Error(`Unknown target: ${target}`);
     }
-  } catch (e: any) {
-    if (e.stdout && e.stdout.length > 20) return e.stdout.toString().trim();
+  } catch (e: unknown) {
+    if (typeof e === 'object' && e !== null && 'stdout' in e) {
+      const stdout = e.stdout;
+      if (
+        typeof stdout === 'object' &&
+        stdout !== null &&
+        'length' in stdout &&
+        typeof stdout.length === 'number' &&
+        stdout.length > 20
+      ) {
+        return String(stdout).trim();
+      }
+    }
     throw e;
   }
 }
@@ -278,8 +289,9 @@ async function main() {
 
         // Save response
         fs.writeFileSync(path.join(RESULTS_DIR, `response-${source}-to-${target}.txt`), response);
-      } catch (e: any) {
-        console.log(`     ⚠️  Error: ${e.message?.slice(0, 80)}`);
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        console.log(`     ⚠️  Error: ${message.slice(0, 80)}`);
         results.push({
           id: testId,
           source,
@@ -289,7 +301,7 @@ async function main() {
           factsTotal: sourceData.keyFacts.length,
           factDetails: [],
           responsePreview: '',
-          error: e.message?.slice(0, 200),
+          error: message.slice(0, 200),
         });
       }
     }

--- a/src/__tests__/stress-test.ts
+++ b/src/__tests__/stress-test.ts
@@ -11,10 +11,10 @@
  * Run with: npx tsx src/__tests__/stress-test.ts
  */
 
-import * as fs from 'fs';
-import { createRequire } from 'module';
-import * as path from 'path';
-import { performance } from 'perf_hooks';
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
 import { extractClaudeContext } from '../parsers/claude.js';
 import { extractCodexContext } from '../parsers/codex.js';
 import { extractCopilotContext } from '../parsers/copilot.js';
@@ -175,6 +175,7 @@ function createSessionFromPath(testSession: TestSession): UnifiedSession | null 
 
   // Extract session ID from path
   let sessionId: string;
+  let opencodeDir: string | undefined;
   if (source === 'claude' || source === 'codex') {
     sessionId = path.basename(filePath, '.jsonl').split('-').slice(-5).join('-');
   } else if (source === 'copilot') {
@@ -203,8 +204,7 @@ function createSessionFromPath(testSession: TestSession): UnifiedSession | null 
           | undefined;
 
         if (sessionRow?.directory) {
-          // Store directory for later use in the return statement
-          (testSession as any)._opencodeDir = sessionRow.directory;
+          opencodeDir = sessionRow.directory;
         }
       } else {
         sessionId = 'latest';
@@ -222,12 +222,7 @@ function createSessionFromPath(testSession: TestSession): UnifiedSession | null 
   return {
     id: sessionId,
     source,
-    cwd:
-      source === 'copilot'
-        ? filePath
-        : source === 'opencode' && (testSession as any)._opencodeDir
-          ? (testSession as any)._opencodeDir
-          : path.dirname(filePath),
+    cwd: source === 'copilot' ? filePath : source === 'opencode' && opencodeDir ? opencodeDir : path.dirname(filePath),
     repo: 'test-repo',
     lines: 0,
     bytes: size,
@@ -239,7 +234,7 @@ function createSessionFromPath(testSession: TestSession): UnifiedSession | null 
 }
 
 /** Validate SessionContext structure */
-function validateContext(context: SessionContext, sourceName: string): { valid: boolean; errors: string[] } {
+function validateContext(context: SessionContext, _sourceName: string): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
   // Check required fields
@@ -516,7 +511,7 @@ async function runStressTest() {
   // Take one successful extraction from each source
   const sourceContexts = new Map<string, SessionContext>();
   for (const source of sources) {
-    const context = Array.from(extractedContexts.entries()).find(([name, ctx]) => ctx.session.source === source)?.[1];
+    const context = Array.from(extractedContexts.entries()).find(([_name, ctx]) => ctx.session.source === source)?.[1];
     if (context) {
       sourceContexts.set(source, context);
     }

--- a/src/__tests__/unit-conversions.test.ts
+++ b/src/__tests__/unit-conversions.test.ts
@@ -4,8 +4,8 @@
  * independent of real session files on the machine.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ConversationMessage, SessionContext, SessionSource, UnifiedSession } from '../types/index.js';
 import { generateHandoffMarkdown, getSourceLabels } from '../utils/markdown.js';
@@ -52,8 +52,8 @@ function parseClaudeFixtureMessages(filePath: string): ConversationMessage[] {
           typeof parsed.message.content === 'string'
             ? parsed.message.content
             : parsed.message.content
-                .filter((c: any) => c.type === 'text' && c.text)
-                .map((c: any) => c.text)
+                .filter((c: { type?: unknown; text?: unknown }) => c.type === 'text' && typeof c.text === 'string')
+                .map((c: { text: string }) => c.text)
                 .join('\n');
         if (text && !text.startsWith('<') && !text.startsWith('/') && !text.includes('Session Handoff')) {
           messages.push({ role: 'user', content: text, timestamp: new Date(parsed.timestamp) });
@@ -63,8 +63,8 @@ function parseClaudeFixtureMessages(filePath: string): ConversationMessage[] {
           typeof parsed.message.content === 'string'
             ? parsed.message.content
             : parsed.message.content
-                .filter((c: any) => c.type === 'text' && c.text)
-                .map((c: any) => c.text)
+                .filter((c: { type?: unknown; text?: unknown }) => c.type === 'text' && typeof c.text === 'string')
+                .map((c: { text: string }) => c.text)
                 .join('\n');
         if (text) {
           messages.push({ role: 'assistant', content: text, timestamp: new Date(parsed.timestamp) });
@@ -110,12 +110,12 @@ function parseGeminiFixtureMessages(filePath: string): ConversationMessage[] {
       if (msg.content) {
         messages.push({ role: 'assistant', content: msg.content, timestamp: new Date(msg.timestamp) });
       } else if (msg.toolCalls?.length > 0) {
-        const toolNames = msg.toolCalls.map((t: any) => t.name).join(', ');
+        const toolNames = msg.toolCalls.map((t: { name: string }) => t.name).join(', ');
         messages.push({
           role: 'assistant',
           content: `[Used tools: ${toolNames}]`,
           timestamp: new Date(msg.timestamp),
-          toolCalls: msg.toolCalls.map((t: any) => ({ name: t.name, arguments: t.args })),
+          toolCalls: msg.toolCalls.map((t: { name: string; args: unknown }) => ({ name: t.name, arguments: t.args })),
         });
       }
     }
@@ -199,7 +199,7 @@ function parseOpenCodeFixtureMessages(dbPath: string, sessionId: string): Conver
   try {
     const msgRows = db
       .prepare('SELECT id, session_id, time_created, data FROM message WHERE session_id = ? ORDER BY time_created ASC')
-      .all(sessionId) as any[];
+      .all(sessionId) as { id: string; time_created: number; data: string }[];
 
     for (const msgRow of msgRows) {
       const msgData = JSON.parse(msgRow.data);
@@ -207,12 +207,12 @@ function parseOpenCodeFixtureMessages(dbPath: string, sessionId: string): Conver
 
       const partRows = db
         .prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC')
-        .all(msgRow.id) as any[];
+        .all(msgRow.id) as { data: string }[];
 
       let text = '';
       for (const partRow of partRows) {
         const partData = JSON.parse(partRow.data);
-        if (partData.type === 'text' && partData.text) text += partData.text + '\n';
+        if (partData.type === 'text' && partData.text) text += `${partData.text}\n`;
       }
 
       if (text.trim()) {
@@ -384,8 +384,8 @@ function parseKimiFixtureMessages(filePath: string): ConversationMessage[] {
         typeof parsed.content === 'string'
           ? parsed.content
           : (parsed.content || [])
-              .filter((b: any) => b?.type === 'text' && typeof b.text === 'string')
-              .map((b: any) => b.text)
+              .filter((b: { type?: unknown; text?: unknown }) => b?.type === 'text' && typeof b.text === 'string')
+              .map((b: { text: string }) => b.text)
               .join('\n');
 
       if (!text) continue;
@@ -413,8 +413,8 @@ function parseQwenCodeFixtureMessages(filePath: string): ConversationMessage[] {
       if (parsed.type !== 'user' && parsed.type !== 'assistant') continue;
 
       const text = (parsed.message?.parts || [])
-        .filter((p: any) => p?.text)
-        .map((p: any) => p.text)
+        .filter((p: { text?: unknown }) => p?.text)
+        .map((p: { text: string }) => p.text)
         .join('\n');
 
       if (!text) continue;
@@ -1112,7 +1112,7 @@ describe('Shared generateHandoffMarkdown', () => {
       originalPath: '/tmp',
     };
     const md = generateHandoffMarkdown(session, [longMsg], [], [], []);
-    expect(md).toContain('A'.repeat(500) + '…');
+    expect(md).toContain(`${'A'.repeat(500)}…`);
     expect(md).not.toContain('A'.repeat(501));
   });
 

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -2,10 +2,10 @@
  * `continues dump <source|all> <directory>` — bulk export sessions to files.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import chalk from 'chalk';
-import * as fs from 'fs';
 import ora from 'ora';
-import * as path from 'path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset, loadConfig } from '../config/index.js';
 import { ALL_TOOLS, adapters } from '../parsers/registry.js';
@@ -144,7 +144,7 @@ export async function dumpCommand(
 
     // Clear progress line and print summary
     if (context.isTTY) {
-      process.stdout.write('\r' + ' '.repeat(80) + '\r');
+      process.stdout.write(`\r${' '.repeat(80)}\r`);
     }
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -6,9 +6,9 @@
  * Designed for verifying that nothing is silently dropped during extraction.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import chalk from 'chalk';
-import * as fs from 'fs';
-import * as path from 'path';
 import type { VerbosityConfig } from '../config/index.js';
 import { getPreset, loadConfig } from '../config/index.js';
 import { adapters } from '../parsers/registry.js';
@@ -34,7 +34,7 @@ function getSessionFormat(source: string, session?: UnifiedSession): SessionForm
       // (id prefixed `legacy:`). Detect from the file extension so `inspect`
       // can read raw events for those sessions instead of always reporting
       // raw analysis as unavailable.
-      if (session && session.id.startsWith('legacy:')) {
+      if (session?.id.startsWith('legacy:')) {
         if (session.originalPath.endsWith('.jsonl')) return 'jsonl';
         if (session.originalPath.endsWith('.json')) return 'json';
       }
@@ -363,7 +363,7 @@ function renderEventDistribution(events: RawEventCounts, source: string): string
   for (const [type, count] of sorted) {
     const frac = count / events.total;
     const pct = (frac * 100).toFixed(1);
-    lines.push(`  ${bar(frac)}  ${pad(type + ':', maxLabel + 1)} ${rpad(count, 6)}  (${rpad(pct, 5)}%)`);
+    lines.push(`  ${bar(frac)}  ${pad(`${type}:`, maxLabel + 1)} ${rpad(count, 6)}  (${rpad(pct, 5)}%)`);
   }
 
   lines.push(`  ${' '.repeat(30)}  ${pad('TOTAL:', maxLabel + 1)} ${rpad(events.total, 6)}`);
@@ -383,7 +383,7 @@ function renderContentBlocks(blocks: ContentBlockCounts): string {
   const maxLabel = Math.max(...sorted.map(([k]) => k.length));
 
   for (const [type, count] of sorted) {
-    lines.push(`  ${pad(type + ':', maxLabel + 1)} ${rpad(count, 6)}`);
+    lines.push(`  ${pad(`${type}:`, maxLabel + 1)} ${rpad(count, 6)}`);
   }
 
   lines.push(`  ${pad('TOTAL:', maxLabel + 1)} ${rpad(blocks.total, 6)}`);
@@ -400,7 +400,7 @@ function renderToolCategories(tools: ToolCategoryCounts): string {
 
   for (const [category, count] of sorted) {
     const barWidth = Math.max(1, Math.round((count / maxCount) * 20));
-    lines.push(`  ${pad(category + ':', maxLabel + 1)} ${rpad(count, 5)}  ${'█'.repeat(barWidth)}`);
+    lines.push(`  ${pad(`${category}:`, maxLabel + 1)} ${rpad(count, 5)}  ${'█'.repeat(barWidth)}`);
   }
 
   lines.push(`  ${pad('TOTAL:', maxLabel + 1)} ${rpad(tools.total, 5)}`);
@@ -430,10 +430,10 @@ function renderReasoningChain(steps: ReasoningStep[]): string {
   const lines: string[] = [chalk.cyan.bold(`🧠 Reasoning Chain (${steps.length} steps extracted)`)];
 
   for (const step of steps) {
-    const thought = step.thought.length > 60 ? step.thought.slice(0, 57) + '...' : step.thought;
+    const thought = step.thought.length > 60 ? `${step.thought.slice(0, 57)}...` : step.thought;
     const next = step.nextAction
       ? step.nextAction.length > 30
-        ? step.nextAction.slice(0, 27) + '...'
+        ? `${step.nextAction.slice(0, 27)}...`
         : step.nextAction
       : '';
     lines.push(
@@ -513,7 +513,7 @@ function renderConversionSummary(
 
 function truncateLine(s: string, maxLen: number): string {
   if (s.length <= maxLen) return s;
-  return s.slice(0, maxLen - 3) + '...';
+  return `${s.slice(0, maxLen - 3)}...`;
 }
 
 function renderTruncated(

--- a/src/display/star-prompt.ts
+++ b/src/display/star-prompt.ts
@@ -4,13 +4,13 @@
  * State persisted in ~/.continues/star-prompt.json.
  */
 
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
-import { spawnSync } from 'child_process';
-import { existsSync } from 'fs';
-import { mkdir, readFile, writeFile } from 'fs/promises';
-import { homedir } from 'os';
-import { join } from 'path';
 import { SHELL_OPTION } from '../utils/platform.js';
 
 const REPO = 'yigitkonur/cli-continues';
@@ -66,7 +66,7 @@ export async function maybePromptGithubStar(): Promise<void> {
   await markPrompted();
 
   const shouldStar = await clack.confirm({
-    message: chalk.hex('#FFD93D')('⭐') + ' ' + chalk.gray('Enjoying continues? Star it on GitHub?'),
+    message: `${chalk.hex('#FFD93D')('⭐')} ${chalk.gray('Enjoying continues? Star it on GitHub?')}`,
     initialValue: true,
   });
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,9 +11,6 @@ import { TOOL_NAMES } from './types/tool-names.js';
  */
 export class ContinuesError extends Error {
   override readonly name: string = 'ContinuesError';
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-  }
 }
 
 /** Thrown when a parser fails to read or interpret session data. */
@@ -56,9 +53,6 @@ export class UnknownSourceError extends ContinuesError {
 /** Thrown when the session index cannot be read or written. */
 export class IndexError extends ContinuesError {
   override readonly name = 'IndexError';
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-  }
 }
 
 /** Thrown when file storage operations fail (read/write handoff, cache). */

--- a/src/parsers/antigravity.ts
+++ b/src/parsers/antigravity.ts
@@ -394,9 +394,10 @@ async function discoverLegacyRecords(records: Map<string, AntigravityRecord>): P
     // sessions whose basenames collide across subdirectories don't merge in
     // addRecord. Falls back to basename for any file outside code_tracker/.
     const relative = path.relative(codeTrackerDir, filePath);
-    const idBase = relative && !relative.startsWith('..')
-      ? relative.slice(0, -ext.length).replace(/[\\/]/gu, ':')
-      : path.basename(filePath, ext);
+    const idBase =
+      relative && !relative.startsWith('..')
+        ? relative.slice(0, -ext.length).replace(/[\\/]/gu, ':')
+        : path.basename(filePath, ext);
     addRecord(records, `legacy:${idBase}`, { legacyPath: filePath });
   }
 }

--- a/src/parsers/copilot.ts
+++ b/src/parsers/copilot.ts
@@ -677,10 +677,7 @@ function stableStringify(value: unknown): string {
 // session that exceeds the cap.
 const MAX_TIMESTAMP_SCAN_BYTES = 1024 * 1024;
 
-async function extractLastEventTimestamp(
-  eventsPath: string,
-  eventsFileSizeBytes?: number,
-): Promise<Date | undefined> {
+async function extractLastEventTimestamp(eventsPath: string, eventsFileSizeBytes?: number): Promise<Date | undefined> {
   // If the file exceeds the scan cap, scanJsonlFile would truncate mid-file and leave us
   // with some early timestamp instead of the actual last event. That would make active
   // large sessions appear oldest in lists. Skip the scan entirely so the caller's

--- a/src/parsers/droid.ts
+++ b/src/parsers/droid.ts
@@ -115,7 +115,12 @@ async function parseSessionInfo(
             if (block.text.includes('<system-reminder>') && block.text.includes('fatal: not a git repository')) {
               cwdIsNotGitRepo = true;
             }
-            if (cleaned && !cleaned.startsWith('<') && !cleaned.startsWith('/') && !cleaned.includes('Session Handoff')) {
+            if (
+              cleaned &&
+              !cleaned.startsWith('<') &&
+              !cleaned.startsWith('/') &&
+              !cleaned.includes('Session Handoff')
+            ) {
               firstUserMessage = cleaned;
               break;
             }

--- a/src/utils/fs-helpers.ts
+++ b/src/utils/fs-helpers.ts
@@ -1,8 +1,8 @@
 /**
  * Shared filesystem helpers used by multiple parsers.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { logger } from '../logger.js';
 
 export interface FindFilesOptions {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { VerbosityConfig } from '../config/index.js';
 import { UnknownSourceError } from '../errors.js';
 import { logger } from '../logger.js';
@@ -77,7 +77,7 @@ function serializeSessions(sessions: UnifiedSession[]): string[] {
 
 function writeIndexFile(indexFile: string, sessions: UnifiedSession[], source?: SessionSource): void {
   const fingerprint = `${ENV_FINGERPRINT_PREFIX}${computeEnvFingerprint(source)}`;
-  fs.writeFileSync(indexFile, fingerprint + '\n' + serializeSessions(sessions).join('\n') + '\n');
+  fs.writeFileSync(indexFile, `${fingerprint}\n${serializeSessions(sessions).join('\n')}\n`);
 }
 
 /**

--- a/src/utils/parser-helpers.ts
+++ b/src/utils/parser-helpers.ts
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import * as os from 'node:os';
 import type { ConversationMessage } from '../types/index.js';
 import { extractRepoFromGitUrl } from './content.js';
 

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { IS_WINDOWS } from './platform.js';
 
 /**
@@ -15,7 +15,7 @@ export function cwdFromSlug(slug: string): string {
   const isDriveSlug = parts.length > 0 && /^[A-Za-z]$/.test(parts[0] || '');
 
   function candidatePaths(segments: string[]): string[] {
-    const unixPath = '/' + segments.join('/');
+    const unixPath = `/${segments.join('/')}`;
     if (segments.length > 0 && /^[A-Za-z]$/.test(segments[0] || '')) {
       const drive = segments[0].toUpperCase();
       const rest = segments.slice(1).join('/');
@@ -50,11 +50,11 @@ export function cwdFromSlug(slug: string): string {
       const rest = segments.slice(0, -1);
 
       // Option 2: treat dash as dot (e.g. dzcm-test → dzcm.test)
-      resolve(idx + 1, [...rest, last + '.' + part]);
+      resolve(idx + 1, [...rest, `${last}.${part}`]);
       if (best) return;
 
       // Option 3: keep as literal dash (e.g. laravel-contentai)
-      resolve(idx + 1, [...rest, last + '-' + part]);
+      resolve(idx + 1, [...rest, `${last}-${part}`]);
     }
   }
 
@@ -67,7 +67,7 @@ export function cwdFromSlug(slug: string): string {
     return rest ? `${drive}:/${rest}` : `${drive}:/`;
   }
 
-  return '/' + slug.replace(/-/g, '/');
+  return `/${slug.replace(/-/g, '/')}`;
 }
 
 /**
@@ -79,5 +79,5 @@ export function matchesCwd(sessionCwd: string, targetDir: string): boolean {
   const normTarget = targetDir.replace(/\/+$/, '');
   if (normTarget === '') return false; // guard against root '/'
   const normSession = sessionCwd.replace(/\/+$/, '');
-  return normSession === normTarget || normSession.startsWith(normTarget + '/');
+  return normSession === normTarget || normSession.startsWith(`${normTarget}/`);
 }

--- a/src/utils/tool-summarizer.ts
+++ b/src/utils/tool-summarizer.ts
@@ -13,14 +13,14 @@ import type { StructuredToolSample, ToolSample, ToolUsageSummary } from '../type
 /** Truncate a string, adding '...' if it exceeds max length */
 export function truncate(s: string, max: number): string {
   if (s.length <= max) return s;
-  return s.slice(0, max - 3) + '...';
+  return `${s.slice(0, max - 3)}...`;
 }
 
 /** Extract exit code from tool result text */
 export function extractExitCode(text?: string): number | undefined {
   if (!text) return undefined;
   const m = text.match(/exit(?:ed with)? code[:\s]+(\d+)/i);
-  return m ? parseInt(m[1]) : undefined;
+  return m ? parseInt(m[1], 10) : undefined;
 }
 
 /** Append ` → "result"` to a summary if result is non-empty */


### PR DESCRIPTION
## Context

While preparing the OMP integration, I noticed the current Biome config flags a small set of existing source/test files. This PR keeps that cleanup separate from the OMP parser work so either PR can be reviewed and merged independently.

## What changed

- Applies current Biome autofixes for Node builtin imports, template literals, parseInt radix, import ordering, and formatting.
- Replaces the remaining explicit `any` annotations in test/e2e utilities with `unknown` or narrow local types.
- Does not change parser behavior, runtime behavior, package metadata, docs, or fixtures.

## Verification

- `npm run lint`
- `corepack pnpm@10 run build`
- `corepack pnpm@10 test`
- `corepack pnpm@10 run check`

## Review notes

This is intentionally separate from #78. It can be merged before or after the OMP support PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up to satisfy current Biome rules across sources and tests. No behavior changes; lint, build, and tests all pass.

- **Refactors**
  - Applied Biome autofixes: `node:` built-in imports, template literals, `parseInt` radix, import order, and formatting.
  - Tightened typings and error handling in tests/e2e and utils (use `unknown` guards, narrower types); simplified custom error classes.
  - Normalized string construction and console output; no parser or runtime changes.

<sup>Written for commit 74fb017eeb19ae345a701b64c6b4f42090002b51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

