### PR TITLE
fix(cursor): preserve path-prefixed user queries

### DIFF
--- a/src/__tests__/cursor-parser.test.ts
+++ b/src/__tests__/cursor-parser.test.ts
@@ -40,6 +40,15 @@ function writeCursorRepoJson(home: string, slug: string, data: unknown): void {
   fs.writeFileSync(path.join(dir, 'repo.json'), JSON.stringify(data), 'utf8');
 }
 
+function copyCursorFixture(home: string, slug: string, sessionId: string, fixtureName: string): string {
+  const dir = path.join(home, '.cursor', 'projects', slug, 'agent-transcripts', sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  const fixturePath = path.join(import.meta.dirname, 'fixtures', fixtureName);
+  const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
+  fs.copyFileSync(fixturePath, transcriptPath);
+  return transcriptPath;
+}
+
 function cursorTextRow(role: 'user' | 'assistant', text: string, timestamp: string): unknown {
   return {
     role,
@@ -128,6 +137,36 @@ describe('cursor parser confidence warnings', () => {
 });
 
 describe('cursor parser hardening', () => {
+  it('keeps a user_query whose text starts with an absolute path while filtering Cursor system reminders', async () => {
+    const home = makeCursorHome();
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const originalPath = copyCursorFixture(home, 'Users-test-project', sessionId, 'cursor-user-query-path.jsonl');
+    const { extractCursorContext } = await loadCursorParser(home);
+
+    const context = await extractCursorContext({
+      id: sessionId,
+      source: 'cursor',
+      cwd: '/tmp/cursor-project',
+      repo: 'test/project',
+      lines: 4,
+      bytes: fs.statSync(originalPath).size,
+      createdAt: new Date('2026-07-20T07:03:00.000Z'),
+      updatedAt: new Date('2026-07-20T07:03:00.000Z'),
+      originalPath,
+    });
+
+    expect(context.recentMessages).toEqual([
+      expect.objectContaining({ role: 'user', content: '/Users/example/project/scripts/check.ts\n\nPlease inspect this file.' }),
+      expect.objectContaining({ role: 'assistant', content: 'I will inspect the file.' }),
+    ]);
+    expect(context.markdown).toContain('### User');
+    expect(context.markdown).toContain('/Users/example/project/scripts/check.ts');
+    expect(context.markdown).toContain('### Assistant');
+    expect(context.markdown.indexOf('### User')).toBeLessThan(context.markdown.indexOf('### Assistant'));
+    expect(context.markdown).not.toContain('internal Cursor state');
+    expect(context.markdown).not.toContain('[REDACTED]');
+  });
+
   it('discovers nested transcript.jsonl and flat Cursor CLI transcript layouts', async () => {
     const home = makeCursorHome();
     const nestedId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';

--- a/src/__tests__/fixtures/cursor-user-query-path.jsonl
+++ b/src/__tests__/fixtures/cursor-user-query-path.jsonl
@@ -1,0 +1,4 @@
+{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Monday, Jul 20, 2026, 3:03 PM (UTC+8)</timestamp>\n<user_query>\n/Users/example/project/scripts/check.ts\n\nPlease inspect this file.\n</user_query>"}]}}
+{"role":"user","message":{"content":[{"type":"text","text":"<system_reminder>internal Cursor state</system_reminder>"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"[REDACTED]"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"I will inspect the file."}]}}

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -5,7 +5,7 @@ import { getPreset } from '../config/index.js';
 import { logger } from '../logger.js';
 import type { ConversationMessage, SessionContext, SessionNotes, UnifiedSession } from '../types/index.js';
 import { CursorTranscriptLineSchema } from '../types/schemas.js';
-import { cleanUserQueryText, isRealUserMessage, isSystemContent } from '../utils/content.js';
+import { cleanUserQueryText, isSystemContent } from '../utils/content.js';
 import { findFiles } from '../utils/fs-helpers.js';
 import { getFileStats, readJsonlFile, scanJsonlHead } from '../utils/jsonl.js';
 import { generateHandoffMarkdown } from '../utils/markdown.js';
@@ -122,13 +122,14 @@ function cleanCursorUserText(text: string): string {
   return stripCursorMetadataTags(cleanUserQueryText(text)).trim();
 }
 
-function isCursorNoiseText(rawText: string, cleanedText: string, role: NormalizedCursorLine['role']): boolean {
+function isCursorNoiseText(rawText: string, cleanedText: string): boolean {
   const raw = rawText.trim();
   const cleaned = cleanedText.trim();
   if (!cleaned) return true;
+  if (cleaned === '[REDACTED]') return true;
   if (isSystemContent(raw) || isSystemContent(cleaned)) return true;
   if (raw.startsWith('<system_reminder>') || cleaned.startsWith('<system_reminder>')) return true;
-  if (role === 'user' && !isRealUserMessage(cleaned)) return true;
+  if (cleaned.includes('Session Handoff')) return true;
   return false;
 }
 
@@ -370,7 +371,7 @@ async function parseSessionInfo(filePath: string): Promise<{
       for (const block of line.content) {
         if (block.type !== 'text' || !block.text) continue;
         const cleaned = cleanCursorUserText(block.text);
-        if (!isCursorNoiseText(block.text, cleaned, line.role)) {
+        if (!isCursorNoiseText(block.text, cleaned)) {
           firstUserMessage = cleaned;
           break;
         }
@@ -502,7 +503,7 @@ export async function extractCursorContext(session: UnifiedSession, config?: Ver
     for (const block of line.content) {
       if (block.type === 'text' && block.text) {
         const cleaned = line.role === 'user' ? cleanCursorUserText(block.text) : stripCursorMetadataTags(block.text);
-        if (isCursorNoiseText(block.text, cleaned, line.role)) continue;
+        if (isCursorNoiseText(block.text, cleaned)) continue;
         if (cleaned) textParts.push(cleaned);
       }
     }


### PR DESCRIPTION
## Summary
- preserve Cursor `<user_query>` text that begins with an absolute filesystem path
- keep explicit system, system reminder, handoff, and redacted-placeholder filtering
- add a sanitized Cursor transcript fixture and regression coverage

## Root cause
The Cursor parser reused a generic user-message heuristic that rejected all text beginning with `/`. After unwrapping `<user_query>`, legitimate Cursor prompts can begin with an absolute path and were therefore omitted from the handoff.

## Validation
- `npm test -- --run src/__tests__/cursor-parser.test.ts`
- `npm test`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Cursor parser to preserve `<user_query>` messages that start with an absolute path (e.g., `/Users/...`) so they appear in recent messages and the handoff markdown. System reminders and `[REDACTED]` content remain filtered, and a sanitized transcript fixture with regression coverage is added.

<sup>Written for commit f3215371e87c3b7f7b46a6b930ea563f2e249f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

