### PR TITLE
fix(cursor): bound slug path resolution

### DIFF
--- a/src/__tests__/cwd-from-slug.test.ts
+++ b/src/__tests__/cwd-from-slug.test.ts
@@ -1,8 +1,13 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { cwdFromSlug } from '../utils/slug.js';
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return { ...actual, existsSync: vi.fn(actual.existsSync) };
+});
 
 describe('cwdFromSlug', () => {
   const itWindows = process.platform === 'win32' ? it : it.skip;
@@ -32,5 +37,21 @@ describe('cwdFromSlug', () => {
 
   it('keeps Unix fallback behavior for non-drive slugs', () => {
     expect(cwdFromSlug('Users-alice-my-project')).toBe('/Users/alice/my/project');
+  });
+
+  it('caps filesystem probes for unresolved dash-heavy slugs', () => {
+    const existsSync = vi.mocked(fs.existsSync);
+    const originalImplementation = existsSync.getMockImplementation();
+    existsSync.mockClear();
+    existsSync.mockReturnValue(false);
+
+    try {
+      const resolved = cwdFromSlug('private-tmp-claude-501-Users-alice-project-session-scratchpad-hooktest-extra-one');
+
+      expect(resolved).toBe('/private/tmp/claude/501/Users/alice/project/session/scratchpad/hooktest/extra/one');
+      expect(existsSync.mock.calls.length).toBeLessThanOrEqual(10_000);
+    } finally {
+      existsSync.mockImplementation(originalImplementation!);
+    }
   });
 });

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs';
 import { IS_WINDOWS } from './platform.js';
 
+// Missing dash-heavy paths otherwise expand into 3^(dash count) filesystem probes.
+const MAX_CANDIDATE_CHECKS = 10_000;
+
 /**
  * Derive cwd from a slug directory name using recursive backtracking.
  * Slugs replace `/` and `.` with `-` in the directory name, e.g.:
@@ -12,6 +15,7 @@ import { IS_WINDOWS } from './platform.js';
 export function cwdFromSlug(slug: string): string {
   const parts = slug.split('-');
   let best: string | null = null;
+  let candidateChecks = 0;
   const isDriveSlug = parts.length > 0 && /^[A-Za-z]$/.test(parts[0] || '');
 
   function candidatePaths(segments: string[]): string[] {
@@ -27,10 +31,12 @@ export function cwdFromSlug(slug: string): string {
   }
 
   function resolve(idx: number, segments: string[]): void {
-    if (best) return; // already found a match
+    if (best || candidateChecks >= MAX_CANDIDATE_CHECKS) return;
 
     if (idx >= parts.length) {
       for (const p of candidatePaths(segments)) {
+        if (candidateChecks >= MAX_CANDIDATE_CHECKS) break;
+        candidateChecks++;
         if (fs.existsSync(p)) {
           best = p;
           break;


### PR DESCRIPTION
## Summary

- cap filesystem probes while resolving ambiguous Cursor project slugs
- preserve existing candidate precedence and fallback behavior
- add a regression test for dash-heavy missing paths

## Problem

`cwdFromSlug()` tries `/`, `.`, and literal `-` for every dash. When a Cursor project points to a deleted temporary path, the exhaustive search grows as `3^n`; a 21-dash scratchpad slug can peg a CPU core and leave the session picker on “Loading sessions.”

## Verification

- `pnpm test` — 918 passed, 2 platform skips
- `pnpm exec biome check src/utils/slug.ts src/__tests__/cwd-from-slug.test.ts`
- `pnpm run build`

The repository-wide `pnpm run check` currently reports pre-existing formatter drift in `src/parsers/antigravity.ts`, `src/parsers/copilot.ts`, and `src/parsers/droid.ts`; this branch does not touch those files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound path resolution for Cursor project slugs to prevent exponential filesystem checks and session picker hangs. Adds a 10,000-check cap in `cwdFromSlug` while keeping existing precedence and fallbacks.

- **Bug Fixes**
  - Cap candidate filesystem probes at 10,000 to stop 3^n blowups on dash-heavy, missing paths.
  - Preserve existing resolution order and OS-specific fallbacks.
  - Add regression test that mocks `fs.existsSync` and verifies the cap and Unix fallback path.

<sup>Written for commit 83673be06e2c6fa24a60ca8dcef1fdf2158915ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/cli-continues/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

